### PR TITLE
fix: handle closed socket in sendToWebhook method

### DIFF
--- a/src/baileys/connection.ts
+++ b/src/baileys/connection.ts
@@ -348,7 +348,7 @@ export class BaileysConnection {
     while (attempt <= maxRetries) {
       if (!this.socket) {
         logger.warn(
-          "[%s] [sendToWebhook] [WARN] Socket closed, skipping webhook with payload=%o",
+          "[%s] [sendToWebhook] Socket closed, skipping webhook with payload=%o",
           this.phoneNumber,
           sanitizedPayload,
         );


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/baileys-api/47)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability by preventing webhook payloads from being sent when the connection is no longer active. Users may notice fewer errors related to closed connections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->