### PR TITLE
feat: add sendReceipts method to send received messages receipt

### DIFF
--- a/src/baileys/connection.ts
+++ b/src/baileys/connection.ts
@@ -22,6 +22,7 @@ import makeWASocket, {
   type proto,
   Browsers,
   DisconnectReason,
+  type MessageReceiptType,
   makeCacheableSignalKeyStore,
 } from "@whiskeysockets/baileys";
 import { toDataURL } from "qrcode";
@@ -223,6 +224,10 @@ export class BaileysConnection {
       oldestMsgKey,
       oldestMsgTimestamp,
     );
+  }
+
+  sendReceipts(keys: proto.IMessageKey[], type: MessageReceiptType) {
+    return this.safeSocket().sendReceipts(keys, type);
   }
 
   private safeSocket() {

--- a/src/baileys/connectionsHandler.ts
+++ b/src/baileys/connectionsHandler.ts
@@ -6,6 +6,7 @@ import { getRedisSavedAuthStateIds } from "@/baileys/redisAuthState";
 import type {
   BaileysConnectionOptions,
   FetchMessageHistoryOptions,
+  SendReceiptsOptions,
 } from "@/baileys/types";
 import logger from "@/lib/logger";
 import type {
@@ -109,6 +110,10 @@ export class BaileysConnectionsHandler {
       oldestMsgKey,
       oldestMsgTimestamp,
     );
+  }
+
+  sendReceipts(phoneNumber: string, { keys, type }: SendReceiptsOptions) {
+    return this.getConnection(phoneNumber).sendReceipts(keys, type);
   }
 
   async logout(phoneNumber: string) {

--- a/src/baileys/types.ts
+++ b/src/baileys/types.ts
@@ -1,4 +1,8 @@
-import type { BaileysEventMap, proto } from "@whiskeysockets/baileys";
+import type {
+  BaileysEventMap,
+  MessageReceiptType,
+  proto,
+} from "@whiskeysockets/baileys";
 
 export interface BaileysConnectionOptions {
   clientName?: string;
@@ -20,4 +24,9 @@ export interface FetchMessageHistoryOptions {
   count: number;
   oldestMsgKey: proto.IMessageKey;
   oldestMsgTimestamp: number;
+}
+
+export interface SendReceiptsOptions {
+  keys: proto.IMessageKey[];
+  type: MessageReceiptType;
 }

--- a/src/baileys/types.ts
+++ b/src/baileys/types.ts
@@ -28,5 +28,5 @@ export interface FetchMessageHistoryOptions {
 
 export interface SendReceiptsOptions {
   keys: proto.IMessageKey[];
-  type: MessageReceiptType;
+  type?: MessageReceiptType;
 }

--- a/src/controllers/connections/index.ts
+++ b/src/controllers/connections/index.ts
@@ -229,6 +229,31 @@ const connectionsController = new Elysia({
       },
     },
   )
+  .post(
+    "/:phoneNumber/send-receipts",
+    async ({ params, body }) => {
+      const { phoneNumber } = params;
+      await baileys.sendReceipts(phoneNumber, body);
+    },
+    {
+      params: phoneNumberParams,
+      body: t.Object({
+        keys: t.Array(iMessageKey),
+        type: t.Undefined({
+          description:
+            "Type of receipt to send. Send undefined for receipt received messages",
+          example: "",
+        }),
+      }),
+      detail: {
+        responses: {
+          200: {
+            description: "Receipts sent successfully",
+          },
+        },
+      },
+    },
+  )
   .delete(
     "/:phoneNumber",
     async ({ params }) => {

--- a/src/controllers/connections/index.ts
+++ b/src/controllers/connections/index.ts
@@ -233,19 +233,17 @@ const connectionsController = new Elysia({
     "/:phoneNumber/send-receipts",
     async ({ params, body }) => {
       const { phoneNumber } = params;
-      await baileys.sendReceipts(phoneNumber, body);
+      const { keys } = body;
+      await baileys.sendReceipts(phoneNumber, { keys, type: undefined });
     },
     {
       params: phoneNumberParams,
       body: t.Object({
         keys: t.Array(iMessageKey),
-        type: t.Undefined({
-          description:
-            "Type of receipt to send. Send undefined for receipt received messages",
-          example: "",
-        }),
       }),
       detail: {
+        description:
+          "Sends read receipts for the provided message keys. Currently only supports sending `received` event. For `read` receipts, use `read-messages` endpoint.",
         responses: {
           200: {
             description: "Receipts sent successfully",

--- a/src/controllers/connections/index.ts
+++ b/src/controllers/connections/index.ts
@@ -233,8 +233,7 @@ const connectionsController = new Elysia({
     "/:phoneNumber/send-receipts",
     async ({ params, body }) => {
       const { phoneNumber } = params;
-      const { keys } = body;
-      await baileys.sendReceipts(phoneNumber, { keys, type: undefined });
+      await baileys.sendReceipts(phoneNumber, body);
     },
     {
       params: phoneNumberParams,

--- a/swagger.json
+++ b/swagger.json
@@ -1490,6 +1490,7 @@
             "xApiKey": []
           }
         ],
+        "description": "Sends read receipts for the provided message keys. Currently only supports sending `received` event. For `read` receipts, use `read-messages` endpoint.",
         "responses": {
           "200": {
             "description": "Receipts sent successfully"
@@ -1521,16 +1522,10 @@
                         }
                       }
                     }
-                  },
-                  "type": {
-                    "description": "Type of receipt to send. Send undefined for receipt received messages",
-                    "example": "",
-                    "type": "undefined"
                   }
                 },
                 "required": [
-                  "keys",
-                  "type"
+                  "keys"
                 ]
               }
             },
@@ -1557,16 +1552,10 @@
                         }
                       }
                     }
-                  },
-                  "type": {
-                    "description": "Type of receipt to send. Send undefined for receipt received messages",
-                    "example": "",
-                    "type": "undefined"
                   }
                 },
                 "required": [
-                  "keys",
-                  "type"
+                  "keys"
                 ]
               }
             },
@@ -1593,16 +1582,10 @@
                         }
                       }
                     }
-                  },
-                  "type": {
-                    "description": "Type of receipt to send. Send undefined for receipt received messages",
-                    "example": "",
-                    "type": "undefined"
                   }
                 },
                 "required": [
-                  "keys",
-                  "type"
+                  "keys"
                 ]
               }
             }

--- a/swagger.json
+++ b/swagger.json
@@ -1464,6 +1464,152 @@
         }
       }
     },
+    "/connections/{phoneNumber}/send-receipts": {
+      "post": {
+        "parameters": [
+          {
+            "description": "Phone number for connection. Must have + prefix.",
+            "schema": {
+              "type": "string",
+              "minLength": 6,
+              "maxLength": 16,
+              "pattern": "^\\+\\d{5,15}$",
+              "example": "+551234567890"
+            },
+            "in": "path",
+            "name": "phoneNumber",
+            "required": true
+          }
+        ],
+        "operationId": "postConnectionsByPhoneNumberSend-receipts",
+        "tags": [
+          "Connections"
+        ],
+        "security": [
+          {
+            "xApiKey": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Receipts sent successfully"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "keys": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "remoteJid": {
+                          "type": "string"
+                        },
+                        "fromMe": {
+                          "type": "boolean"
+                        },
+                        "participant": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  },
+                  "type": {
+                    "description": "Type of receipt to send. Send undefined for receipt received messages",
+                    "example": "",
+                    "type": "undefined"
+                  }
+                },
+                "required": [
+                  "keys",
+                  "type"
+                ]
+              }
+            },
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "keys": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "remoteJid": {
+                          "type": "string"
+                        },
+                        "fromMe": {
+                          "type": "boolean"
+                        },
+                        "participant": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  },
+                  "type": {
+                    "description": "Type of receipt to send. Send undefined for receipt received messages",
+                    "example": "",
+                    "type": "undefined"
+                  }
+                },
+                "required": [
+                  "keys",
+                  "type"
+                ]
+              }
+            },
+            "text/plain": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "keys": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "remoteJid": {
+                          "type": "string"
+                        },
+                        "fromMe": {
+                          "type": "boolean"
+                        },
+                        "participant": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  },
+                  "type": {
+                    "description": "Type of receipt to send. Send undefined for receipt received messages",
+                    "example": "",
+                    "type": "undefined"
+                  }
+                },
+                "required": [
+                  "keys",
+                  "type"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
     "/media/{messageId}": {
       "get": {
         "parameters": [


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/baileys-api/51)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new API endpoint to send message receipts for a specific phone number.
	- Added support for sending receipts by providing message keys and receipt type.
- **Documentation**
	- Updated API documentation to include the new endpoint and its request/response details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->