### PR TITLE
chore: remove awaitResponse in handleMessagingHistorySet method

### DIFF
--- a/src/baileys/connection.ts
+++ b/src/baileys/connection.ts
@@ -348,13 +348,7 @@ export class BaileysConnection {
     // FIXME: Downloads are failing heavily right now. Under investigation.
     // await downloadMediaFromMessages(data.messages);
 
-    this.sendToWebhook(
-      {
-        event: "messaging-history.set",
-        data,
-      },
-      { awaitResponse: true },
-    );
+    this.sendToWebhook({ event: "messaging-history.set", data });
   }
 
   private handleWrongPhoneNumber() {


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/baileys-api/62)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated webhook messaging behavior to no longer await a response when sending messaging history events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->