### PR TITLE
feat: add endpoint to get contact profile picture

### DIFF
--- a/src/baileys/connection.spec.ts
+++ b/src/baileys/connection.spec.ts
@@ -1,4 +1,29 @@
-import { describe, it } from "bun:test";
+import { describe, it, expect, beforeEach, mock } from "bun:test";
+import { BaileysConnection, BaileysNotConnectedError } from "./connection";
+import type { BaileysConnectionOptions } from "./types";
+
+function createMockSocket(overrides = {}) {
+  return {
+    profilePictureUrl: mock(() => Promise.resolve("https://example.com/profile.jpg")),
+    ...overrides
+  };
+}
+
+function createBaileysConnection(phoneNumber = "5511999999999") {
+  const options: BaileysConnectionOptions = {
+    webhookUrl: "http://localhost:3000/webhook",
+    webhookVerifyToken: "test-token",
+  };
+  return new BaileysConnection(phoneNumber, options);
+}
+
+function setupConnectionWithMockSocket(socketOverrides = {}) {
+  const connection = createBaileysConnection();
+  const mockSocket = createMockSocket(socketOverrides);
+  // @ts-ignore - Setting private property for testing
+  connection.socket = mockSocket;
+  return { connection, mockSocket };
+}
 
 describe("BaileysConnection", () => {
   describe("#connect", () => {
@@ -45,6 +70,42 @@ describe("BaileysConnection", () => {
   describe("#fetchMessageHistory", () => {
     it.todo("throw BaileysNotConnectedError if not connected");
     it.todo("call socket fetchMessageHistory method");
+  });
+
+  describe("#getProfilePicture", () => {
+    let connection: BaileysConnection;
+
+    beforeEach(() => {
+      connection = createBaileysConnection();
+    });
+
+    it("should throw BaileysNotConnectedError if not connected", async () => {
+      expect(async () => {
+        await connection.getProfilePicture("5511888888888@s.whatsapp.net");
+      }).toThrow(BaileysNotConnectedError);
+    });
+
+    it("should call socket profilePictureUrl method with correct parameters", async () => {
+      const { connection, mockSocket } = setupConnectionWithMockSocket();
+      const jid = "5511888888888@s.whatsapp.net";
+      const type = "preview";
+      await connection.getProfilePicture(jid, type);
+      expect(mockSocket.profilePictureUrl).toHaveBeenCalledWith(jid, type);
+    });
+
+    it("should return profile picture URL when available", async () => {
+      const { connection } = setupConnectionWithMockSocket();
+      const result = await connection.getProfilePicture("5511888888888@s.whatsapp.net");
+      expect(result).toBe("https://example.com/profile.jpg");
+    });
+
+    it("should handle when profile picture is not available", async () => {
+      const { connection } = setupConnectionWithMockSocket({
+        profilePictureUrl: mock(() => Promise.resolve(null)),
+      });
+      const result = await connection.getProfilePicture("5511888888888@s.whatsapp.net");
+      expect(result).toBeNull();
+    });
   });
 
   describe("Event Handlers", () => {

--- a/src/baileys/connection.spec.ts
+++ b/src/baileys/connection.spec.ts
@@ -47,7 +47,7 @@ describe("BaileysConnection", () => {
     it.todo("call socket fetchMessageHistory method");
   });
 
-  describe("#getProfilePicture", () => {
+  describe("#profilePictureUrl", () => {
     it.todo("should return an error when profile picture is not found");
     it.todo("should call socket profilePictureUrl method with correct parameters");
     it.todo("should return profile picture URL when available");

--- a/src/baileys/connection.spec.ts
+++ b/src/baileys/connection.spec.ts
@@ -1,29 +1,4 @@
-import { describe, it, expect, beforeEach, mock } from "bun:test";
-import { BaileysConnection, BaileysNotConnectedError } from "./connection";
-import type { BaileysConnectionOptions } from "./types";
-
-function createMockSocket(overrides = {}) {
-  return {
-    profilePictureUrl: mock(() => Promise.resolve("https://example.com/profile.jpg")),
-    ...overrides
-  };
-}
-
-function createBaileysConnection(phoneNumber = "5511999999999") {
-  const options: BaileysConnectionOptions = {
-    webhookUrl: "http://localhost:3000/webhook",
-    webhookVerifyToken: "test-token",
-  };
-  return new BaileysConnection(phoneNumber, options);
-}
-
-function setupConnectionWithMockSocket(socketOverrides = {}) {
-  const connection = createBaileysConnection();
-  const mockSocket = createMockSocket(socketOverrides);
-  // @ts-ignore - Setting private property for testing
-  connection.socket = mockSocket;
-  return { connection, mockSocket };
-}
+import { describe, it } from "bun:test";
 
 describe("BaileysConnection", () => {
   describe("#connect", () => {
@@ -73,39 +48,10 @@ describe("BaileysConnection", () => {
   });
 
   describe("#getProfilePicture", () => {
-    let connection: BaileysConnection;
-
-    beforeEach(() => {
-      connection = createBaileysConnection();
-    });
-
-    it("should throw BaileysNotConnectedError if not connected", async () => {
-      expect(async () => {
-        await connection.getProfilePicture("5511888888888@s.whatsapp.net");
-      }).toThrow(BaileysNotConnectedError);
-    });
-
-    it("should call socket profilePictureUrl method with correct parameters", async () => {
-      const { connection, mockSocket } = setupConnectionWithMockSocket();
-      const jid = "5511888888888@s.whatsapp.net";
-      const type = "preview";
-      await connection.getProfilePicture(jid, type);
-      expect(mockSocket.profilePictureUrl).toHaveBeenCalledWith(jid, type);
-    });
-
-    it("should return profile picture URL when available", async () => {
-      const { connection } = setupConnectionWithMockSocket();
-      const result = await connection.getProfilePicture("5511888888888@s.whatsapp.net");
-      expect(result).toBe("https://example.com/profile.jpg");
-    });
-
-    it("should handle when profile picture is not available", async () => {
-      const { connection } = setupConnectionWithMockSocket({
-        profilePictureUrl: mock(() => Promise.resolve(null)),
-      });
-      const result = await connection.getProfilePicture("5511888888888@s.whatsapp.net");
-      expect(result).toBeNull();
-    });
+    it.todo("should throw BaileysNotConnectedError if not connected");
+    it.todo("should call socket profilePictureUrl method with correct parameters");
+    it.todo("should return profile picture URL when available");
+    it.todo("should handle when profile picture is not available");
   });
 
   describe("Event Handlers", () => {

--- a/src/baileys/connection.spec.ts
+++ b/src/baileys/connection.spec.ts
@@ -49,7 +49,9 @@ describe("BaileysConnection", () => {
 
   describe("#profilePictureUrl", () => {
     it.todo("should return an error when profile picture is not found");
-    it.todo("should call socket profilePictureUrl method with correct parameters");
+    it.todo(
+      "should call socket profilePictureUrl method with correct parameters",
+    );
     it.todo("should return profile picture URL when available");
   });
 

--- a/src/baileys/connection.spec.ts
+++ b/src/baileys/connection.spec.ts
@@ -48,10 +48,9 @@ describe("BaileysConnection", () => {
   });
 
   describe("#getProfilePicture", () => {
-    it.todo("should throw BaileysNotConnectedError if not connected");
+    it.todo("should return an error when profile picture is not found");
     it.todo("should call socket profilePictureUrl method with correct parameters");
     it.todo("should return profile picture URL when available");
-    it.todo("should handle when profile picture is not available");
   });
 
   describe("Event Handlers", () => {

--- a/src/baileys/connection.ts
+++ b/src/baileys/connection.ts
@@ -308,6 +308,13 @@ export class BaileysConnection {
     return this.safeSocket().sendReceipts(keys, type);
   }
 
+  async getProfilePicture(jid: string, type?: "preview" | "image") {
+    if (!this.socket) {
+      throw new BaileysNotConnectedError();
+    }
+    return this.socket.profilePictureUrl(jid, type);
+  }
+
   onWhatsApp(jids: string[]) {
     return this.safeSocket().onWhatsApp(...jids);
   }

--- a/src/baileys/connection.ts
+++ b/src/baileys/connection.ts
@@ -308,7 +308,7 @@ export class BaileysConnection {
     return this.safeSocket().sendReceipts(keys, type);
   }
 
-  async getProfilePicture(jid: string, type?: "preview" | "image") {
+  async profilePictureUrl(jid: string, type?: "preview" | "image") {
     if (!this.socket) {
       throw new BaileysNotConnectedError();
     }

--- a/src/baileys/connectionsHandler.spec.ts
+++ b/src/baileys/connectionsHandler.spec.ts
@@ -51,10 +51,9 @@ describe("BaileysConnectionsHandler", () => {
   });
 
   describe("#getProfilePicture", () => {
-    it.todo("should throw BaileysNotConnectedError if no connection exists");
+    it.todo("should return an error when profile picture is not found");
     it.todo("should call getProfilePicture on the correct connection");
     it.todo("should return profile picture URL when available");
-    it.todo("should return null when profile picture is not available");
   });
 
   describe("#logout", () => {

--- a/src/baileys/connectionsHandler.spec.ts
+++ b/src/baileys/connectionsHandler.spec.ts
@@ -50,9 +50,9 @@ describe("BaileysConnectionsHandler", () => {
     it.todo("call fetchMessageHistory on the correct connection");
   });
 
-  describe("#getProfilePicture", () => {
+  describe("#profilePictureUrl", () => {
     it.todo("should return an error when profile picture is not found");
-    it.todo("should call getProfilePicture on the correct connection");
+    it.todo("should call profilePictureUrl on the correct connection");
     it.todo("should return profile picture URL when available");
   });
 

--- a/src/baileys/connectionsHandler.spec.ts
+++ b/src/baileys/connectionsHandler.spec.ts
@@ -1,20 +1,4 @@
-import { describe, it, expect, mock } from "bun:test";
-import { BaileysConnectionsHandler } from "./connectionsHandler";
-import { BaileysNotConnectedError } from "./connection";
-
-function createMockConnection(overrides = {}) {
-  return {
-    getProfilePicture: mock(() => Promise.resolve("https://example.com/profile.jpg")),
-    ...overrides
-  };
-}
-
-function setupHandlerWithConnection(phoneNumber: string, mockConnection: any) {
-  const handler = new BaileysConnectionsHandler();
-  // @ts-ignore - Setting private property for testing
-  handler.connections = { [phoneNumber]: mockConnection };
-  return { handler, mockConnection };
-}
+import { describe, it } from "bun:test";
 
 describe("BaileysConnectionsHandler", () => {
   describe("#reconnectFromAuthStore", () => {
@@ -67,39 +51,10 @@ describe("BaileysConnectionsHandler", () => {
   });
 
   describe("#getProfilePicture", () => {
-    let handler: BaileysConnectionsHandler;
-
-    it("should throw BaileysNotConnectedError if no connection exists", async () => {
-      handler = new BaileysConnectionsHandler();
-      expect(async () => {
-        await handler.getProfilePicture("5511999999999", "5511888888888@s.whatsapp.net");
-      }).toThrow(BaileysNotConnectedError);
-    });
-
-    it("should call getProfilePicture on the correct connection", async () => {
-      const mockConnection = createMockConnection();
-      const { handler } = setupHandlerWithConnection("5511999999999", mockConnection);
-      const jid = "5511888888888@s.whatsapp.net";
-      const type = "preview";
-      await handler.getProfilePicture("5511999999999", jid, type);
-      expect(mockConnection.getProfilePicture).toHaveBeenCalledWith(jid, type);
-    });
-
-    it("should return profile picture URL when available", async () => {
-      const mockConnection = createMockConnection();
-      const { handler } = setupHandlerWithConnection("5511999999999", mockConnection);
-      const result = await handler.getProfilePicture("5511999999999", "5511888888888@s.whatsapp.net");
-      expect(result).toBe("https://example.com/profile.jpg");
-    });
-
-    it("should return null when profile picture is not available", async () => {
-      const mockConnection = createMockConnection({ 
-        getProfilePicture: mock(() => Promise.resolve(null)) 
-      });
-      const { handler } = setupHandlerWithConnection("5511999999999", mockConnection);
-      const result = await handler.getProfilePicture("5511999999999", "5511888888888@s.whatsapp.net");
-      expect(result).toBeNull();
-    });
+    it.todo("should throw BaileysNotConnectedError if no connection exists");
+    it.todo("should call getProfilePicture on the correct connection");
+    it.todo("should return profile picture URL when available");
+    it.todo("should return null when profile picture is not available");
   });
 
   describe("#logout", () => {

--- a/src/baileys/connectionsHandler.ts
+++ b/src/baileys/connectionsHandler.ts
@@ -125,12 +125,12 @@ export class BaileysConnectionsHandler {
     return this.getConnection(phoneNumber).sendReceipts(keys, type);
   }
 
-  getProfilePicture(
+  profilePictureUrl(
     phoneNumber: string,
     jid: string,
     type?: "preview" | "image",
   ) {
-    return this.getConnection(phoneNumber).getProfilePicture(jid, type);
+    return this.getConnection(phoneNumber).profilePictureUrl(jid, type);
   }
 
   onWhatsApp(phoneNumber: string, jids: string[]) {

--- a/src/baileys/connectionsHandler.ts
+++ b/src/baileys/connectionsHandler.ts
@@ -125,6 +125,14 @@ export class BaileysConnectionsHandler {
     return this.getConnection(phoneNumber).sendReceipts(keys, type);
   }
 
+  getProfilePicture(
+    phoneNumber: string,
+    jid: string,
+    type?: "preview" | "image",
+  ) {
+    return this.getConnection(phoneNumber).getProfilePicture(jid, type);
+  }
+
   onWhatsApp(phoneNumber: string, jids: string[]) {
     return this.getConnection(phoneNumber).onWhatsApp(jids);
   }

--- a/src/controllers/connections/index.ts
+++ b/src/controllers/connections/index.ts
@@ -251,6 +251,48 @@ const connectionsController = new Elysia({
       },
     },
   )
+  .get(
+    "/:phoneNumber/profile-pic",
+    async ({ params, query }) => {
+      const { phoneNumber } = params;
+      const { jid, type } = query;
+
+      const profilePicUrl = await baileys.getProfilePicture(
+        phoneNumber,
+        jid,
+        type,
+      );
+
+      return {
+        data: {
+          jid,
+          profilePictureUrl: profilePicUrl || null,
+        },
+      };
+    },
+    {
+      params: phoneNumberParams,
+      query: t.Object({
+        jid: jid("JID of the contact/group to get profile picture for"),
+        type: t.Optional(
+          t.Union([t.Literal("preview"), t.Literal("image")], {
+            description: "Picture quality type",
+            default: "image",
+          }),
+        ),
+      }),
+      detail: {
+        responses: {
+          200: {
+            description: "Profile picture URL retrieved successfully",
+          },
+          404: {
+            description: "Phone number not connected",
+          },
+        },
+      },
+    },
+  )
   .post(
     "/:phoneNumber/on-whatsapp",
     async ({ params, body }) => {

--- a/src/controllers/connections/index.ts
+++ b/src/controllers/connections/index.ts
@@ -257,18 +257,25 @@ const connectionsController = new Elysia({
       const { phoneNumber } = params;
       const { jid, type } = query;
 
-      const profilePicUrl = await baileys.getProfilePicture(
-        phoneNumber,
-        jid,
-        type,
-      );
-
-      return {
-        data: {
+      try {
+        const profilePicUrl = await baileys.getProfilePicture(
+          phoneNumber,
           jid,
-          profilePictureUrl: profilePicUrl || null,
-        },
-      };
+          type,
+        );
+
+        return {
+          data: {
+            jid,
+            profilePictureUrl: profilePicUrl || null,
+          },
+        };
+      } catch (e) {
+        if ((e as Error).message === "item-not-found") {
+          return new Response("Profile picture not found", { status: 404 });
+        }
+        throw e;
+      }
     },
     {
       params: phoneNumberParams,

--- a/src/controllers/connections/index.ts
+++ b/src/controllers/connections/index.ts
@@ -280,22 +280,51 @@ const connectionsController = new Elysia({
     {
       params: phoneNumberParams,
       query: t.Object({
-        jid: jid("JID of the contact/group to get profile picture for"),
+        jid: jid(),
         type: t.Optional(
-          t.Union([t.Literal("preview"), t.Literal("image")], {
-            description: "Picture quality type",
-            default: "image",
-          }),
+          t.Union(
+            [
+              t.Literal("preview", { title: "preview" }),
+              t.Literal("image", { title: "image" }),
+            ],
+            {
+              description: "Picture quality type",
+              default: "preview",
+            },
+          ),
         ),
       }),
       detail: {
         responses: {
           200: {
             description: "Profile picture URL retrieved successfully",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    data: {
+                      type: "object",
+                      properties: {
+                        jid: {
+                          type: "string",
+                          description: "WhatsApp JID of the phone number",
+                          example: "551234567890@s.whatsapp.net",
+                        },
+                        profilePictureUrl: {
+                          type: "string",
+                          nullable: true,
+                          example:
+                            "https://pps.whatsapp.net/v/t61.24694-24/...",
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
           },
-          404: {
-            description: "Phone number not connected",
-          },
+          404: { description: "Profile picture not found" },
         },
       },
     },

--- a/src/controllers/connections/index.ts
+++ b/src/controllers/connections/index.ts
@@ -252,13 +252,13 @@ const connectionsController = new Elysia({
     },
   )
   .get(
-    "/:phoneNumber/profile-pic",
+    "/:phoneNumber/profile-picture-url",
     async ({ params, query }) => {
       const { phoneNumber } = params;
       const { jid, type } = query;
 
       try {
-        const profilePicUrl = await baileys.getProfilePicture(
+        const profilePictureUrl = await baileys.profilePictureUrl(
           phoneNumber,
           jid,
           type,
@@ -267,7 +267,7 @@ const connectionsController = new Elysia({
         return {
           data: {
             jid,
-            profilePictureUrl: profilePicUrl || null,
+            profilePictureUrl: profilePictureUrl || null,
           },
         };
       } catch (e) {

--- a/swagger.json
+++ b/swagger.json
@@ -186,8 +186,7 @@
                 "required": [
                   "webhookUrl",
                   "webhookVerifyToken"
-                ],
-                "additionalProperties": false
+                ]
               }
             },
             "multipart/form-data": {
@@ -225,8 +224,7 @@
                 "required": [
                   "webhookUrl",
                   "webhookVerifyToken"
-                ],
-                "additionalProperties": false
+                ]
               }
             },
             "text/plain": {
@@ -264,8 +262,7 @@
                 "required": [
                   "webhookUrl",
                   "webhookVerifyToken"
-                ],
-                "additionalProperties": false
+                ]
               }
             }
           }
@@ -1600,6 +1597,97 @@
         }
       }
     },
+    "/connections/{phoneNumber}/profile-picture-url": {
+      "get": {
+        "parameters": [
+          {
+            "description": "Phone number for connection. Must have + prefix.",
+            "schema": {
+              "type": "string",
+              "minLength": 6,
+              "maxLength": 16,
+              "pattern": "^\\+\\d{5,15}$",
+              "example": "+551234567890"
+            },
+            "in": "path",
+            "name": "phoneNumber",
+            "required": true
+          },
+          {
+            "description": "Recipient whatsapp jid",
+            "schema": {
+              "type": "string",
+              "example": "551101234567@s.whatsapp.net"
+            },
+            "in": "query",
+            "name": "jid",
+            "required": true
+          },
+          {
+            "description": "Picture quality type",
+            "schema": {
+              "default": "preview",
+              "anyOf": [
+                {
+                  "title": "preview",
+                  "const": "preview",
+                  "type": "string"
+                },
+                {
+                  "title": "image",
+                  "const": "image",
+                  "type": "string"
+                }
+              ]
+            },
+            "in": "query",
+            "name": "type",
+            "required": false
+          }
+        ],
+        "operationId": "getConnectionsByPhoneNumberProfile-picture-url",
+        "tags": [
+          "Connections"
+        ],
+        "security": [
+          {
+            "xApiKey": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Profile picture URL retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "jid": {
+                          "type": "string",
+                          "description": "WhatsApp JID of the phone number",
+                          "example": "551234567890@s.whatsapp.net"
+                        },
+                        "profilePictureUrl": {
+                          "type": "string",
+                          "nullable": true,
+                          "example": "https://pps.whatsapp.net/v/t61.24694-24/..."
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Profile picture not found"
+          }
+        }
+      }
+    },
     "/connections/{phoneNumber}/on-whatsapp": {
       "post": {
         "parameters": [
@@ -1680,8 +1768,7 @@
                 },
                 "required": [
                   "jids"
-                ],
-                "additionalProperties": false
+                ]
               }
             },
             "multipart/form-data": {
@@ -1703,8 +1790,7 @@
                 },
                 "required": [
                   "jids"
-                ],
-                "additionalProperties": false
+                ]
               }
             },
             "text/plain": {
@@ -1726,8 +1812,7 @@
                 },
                 "required": [
                   "jids"
-                ],
-                "additionalProperties": false
+                ]
               }
             }
           }


### PR DESCRIPTION
relates to fazer-ai/chatwoot#93

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/baileys-api/115)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Fetch a contact’s profile picture (preview or full).
  - New GET endpoint: /connections/:phoneNumber/profile-picture-url with query params jid (required) and type=preview|image (optional, default preview). Returns { jid, profilePictureUrl } (string|null); 404 if not found.

- API / Documentation
  - OpenAPI spec updated to include the new endpoint and relax strict request-body constraints for existing connection endpoints (allows additional properties).

- Tests
  - Added tests covering profile-picture retrieval: not found, correct delegation, and successful URL return.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->