### PR TITLE
release v3.0.2

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -15,12 +15,6 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v6
 
-      - name: Cache Bun Installation
-        uses: actions/cache@v5
-        with:
-          path: ~/.bun
-          key: ${{ runner.os }}-bun
-
       - name: Install Bun
         uses: oven-sh/setup-bun@v2
 
@@ -28,9 +22,9 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-deps-${{ hashFiles('bun.lockb') }}
+          key: ${{ runner.os }}-bun-deps-v2-${{ hashFiles('bun.lock') }}
           restore-keys: |
-            ${{ runner.os }}-bun-deps-
+            ${{ runner.os }}-bun-deps-v2-
 
       - name: Install Dependencies
         run: bun install

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,12 +14,6 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v6
 
-      - name: Cache Bun Installation
-        uses: actions/cache@v5
-        with:
-          path: ~/.bun
-          key: ${{ runner.os }}-bun
-
       - name: Install Bun
         uses: oven-sh/setup-bun@v2
 
@@ -27,9 +21,9 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-deps-${{ hashFiles('bun.lockb') }}
+          key: ${{ runner.os }}-bun-deps-v2-${{ hashFiles('bun.lock') }}
           restore-keys: |
-            ${{ runner.os }}-bun-deps-
+            ${{ runner.os }}-bun-deps-v2-
 
       - name: Install Dependencies
         run: bun install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,12 +15,6 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v6
 
-      - name: Cache Bun Installation
-        uses: actions/cache@v5
-        with:
-          path: ~/.bun
-          key: ${{ runner.os }}-bun
-
       - name: Install Bun
         uses: oven-sh/setup-bun@v2
 
@@ -28,9 +22,9 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-deps-${{ hashFiles('bun.lockb') }}
+          key: ${{ runner.os }}-bun-deps-v2-${{ hashFiles('bun.lock') }}
           restore-keys: |
-            ${{ runner.os }}-bun-deps-
+            ${{ runner.os }}-bun-deps-v2-
 
       - name: Install All Dependencies
         run: bun install

--- a/src/baileys/connectionsHandler.spec.ts
+++ b/src/baileys/connectionsHandler.spec.ts
@@ -111,20 +111,6 @@ class MockBaileysConnection {
   groupFetchAllParticipating = mockGroupFetchAllParticipating;
 }
 
-mock.module("@/baileys/connection", () => ({
-  BaileysConnection: MockBaileysConnection,
-  BaileysNotConnectedError: class BaileysNotConnectedError extends Error {
-    constructor() {
-      super("Phone number not connected");
-    }
-  },
-  BaileysConnectionForbiddenError: class BaileysConnectionForbiddenError extends Error {
-    constructor() {
-      super("Connection not owned by this API key");
-    }
-  },
-}));
-
 mock.module("@/baileys/redisAuthState", () => ({
   getRedisSavedAuthStateIds: mock(async () => []),
 }));
@@ -146,7 +132,9 @@ describe("BaileysConnectionsHandler", () => {
   };
 
   beforeEach(() => {
-    handler = new BaileysConnectionsHandler();
+    handler = new BaileysConnectionsHandler(
+      (phone, opts) => new MockBaileysConnection(phone, opts) as any,
+    );
     mockConnectionInstances.clear();
     mockConnect.mockClear();
     mockLogout.mockClear();

--- a/src/baileys/connectionsHandler.ts
+++ b/src/baileys/connectionsHandler.ts
@@ -25,8 +25,19 @@ import type {
 import { asyncSleep } from "@/helpers/asyncSleep";
 import logger from "@/lib/logger";
 
+type ConnectionFactory = (
+  phoneNumber: string,
+  options: BaileysConnectionOptions,
+) => BaileysConnection;
+
 export class BaileysConnectionsHandler {
   private connections: Record<string, BaileysConnection> = {};
+  private createConnection: ConnectionFactory;
+
+  constructor(createConnection?: ConnectionFactory) {
+    this.createConnection =
+      createConnection || ((phone, opts) => new BaileysConnection(phone, opts));
+  }
 
   async reconnectFromAuthStore() {
     const savedConnections =
@@ -51,7 +62,7 @@ export class BaileysConnectionsHandler {
       await Promise.allSettled(
         chunk.map(async ({ id, metadata }) => {
           await asyncSleep(Math.floor(Math.random() * 100));
-          const connection = new BaileysConnection(id, {
+          const connection = this.createConnection(id, {
             onConnectionClose: () => {
               delete this.connections[id];
               logger.debug(
@@ -88,7 +99,7 @@ export class BaileysConnectionsHandler {
       }
     }
 
-    const connection = new BaileysConnection(phoneNumber, {
+    const connection = this.createConnection(phoneNumber, {
       ...options,
       onConnectionClose: () => {
         delete this.connections[phoneNumber];

--- a/src/controllers/connections/index.ts
+++ b/src/controllers/connections/index.ts
@@ -153,9 +153,10 @@ const connectionsController = new Elysia({
       const { phoneNumber } = params;
       const { jid, messageContent, chatwootMessageId } = body;
 
-      const idempotencyKey = chatwootMessageId
-        ? `@baileys-api:idempotency:send-message:${phoneNumber}:${chatwootMessageId}`
-        : null;
+      const idempotencyKey =
+        chatwootMessageId !== undefined && chatwootMessageId !== null
+          ? `@baileys-api:idempotency:send-message:${phoneNumber}:${String(chatwootMessageId)}`
+          : null;
 
       const result = await withIdempotency(idempotencyKey, async () => {
         const { messageContent: builtContent, quoted } =

--- a/src/controllers/connections/index.ts
+++ b/src/controllers/connections/index.ts
@@ -192,9 +192,7 @@ const connectionsController = new Elysia({
       body: t.Object({
         jid: anyJid(),
         messageContent: anyMessageContent,
-        chatwootMessageId: t.Optional(
-          t.Union([t.String(), t.Number()]),
-        ),
+        chatwootMessageId: t.Optional(t.Union([t.String(), t.Number()])),
       }),
       detail: {
         responses: {

--- a/src/controllers/connections/index.ts
+++ b/src/controllers/connections/index.ts
@@ -8,6 +8,7 @@ import {
   buildEditableMessageContent,
   buildMessageContent,
 } from "@/controllers/connections/helpers";
+import { withIdempotency } from "@/helpers/withIdempotency";
 import { authMiddleware } from "@/middlewares/auth";
 import {
   anyJid,
@@ -150,33 +151,50 @@ const connectionsController = new Elysia({
     "/:phoneNumber/send-message",
     async ({ params, body }) => {
       const { phoneNumber } = params;
-      const { jid, messageContent } = body;
+      const { jid, messageContent, chatwootMessageId } = body;
 
-      const { messageContent: builtContent, quoted } =
-        buildMessageContent(messageContent);
+      const idempotencyKey = chatwootMessageId
+        ? `@baileys-api:idempotency:send-message:${phoneNumber}:${chatwootMessageId}`
+        : null;
 
-      const response = await baileys.sendMessage(phoneNumber, {
-        jid,
-        messageContent: builtContent,
-        quoted,
+      const result = await withIdempotency(idempotencyKey, async () => {
+        const { messageContent: builtContent, quoted } =
+          buildMessageContent(messageContent);
+
+        const response = await baileys.sendMessage(phoneNumber, {
+          jid,
+          messageContent: builtContent,
+          quoted,
+        });
+
+        if (!response) return null;
+
+        return {
+          key: response.key,
+          messageTimestamp: response.messageTimestamp,
+        };
       });
 
-      if (!response) {
+      if (result.status === "processing") {
+        return new Response("Message is already being processed", {
+          status: 409,
+        });
+      }
+
+      if (result.status === "failed") {
         return new Response("Message not sent", { status: 500 });
       }
 
-      return {
-        data: {
-          key: response.key,
-          messageTimestamp: response.messageTimestamp,
-        },
-      };
+      return { data: result.value };
     },
     {
       params: phoneNumberParams,
       body: t.Object({
         jid: anyJid(),
         messageContent: anyMessageContent,
+        chatwootMessageId: t.Optional(
+          t.Union([t.String(), t.Number()]),
+        ),
       }),
       detail: {
         responses: {
@@ -192,6 +210,9 @@ const connectionsController = new Elysia({
                 }),
               },
             },
+          },
+          409: {
+            description: "Message is already being processed",
           },
           500: {
             description: "Message not sent",

--- a/src/helpers/withIdempotency.spec.ts
+++ b/src/helpers/withIdempotency.spec.ts
@@ -1,0 +1,110 @@
+import { afterEach, describe, expect, it, mock } from "bun:test";
+import redis from "@/lib/redis";
+import { withIdempotency } from "./withIdempotency";
+
+const stringData = (redis as any).__stringData as Map<string, string>;
+
+describe("withIdempotency", () => {
+  afterEach(() => {
+    stringData.clear();
+  });
+
+  describe("without idempotency key", () => {
+    it("executes the function and returns executed status", async () => {
+      const fn = mock(async () => ({ id: "msg_1" }));
+
+      const result = await withIdempotency(null, fn);
+
+      expect(result).toEqual({ status: "executed", value: { id: "msg_1" } });
+      expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    it("returns failed status when function returns null", async () => {
+      const fn = mock(async () => null);
+
+      const result = await withIdempotency(null, fn);
+
+      expect(result).toEqual({ status: "failed" });
+      expect(fn).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("with idempotency key, first request", () => {
+    it("acquires lock, executes, and caches the result", async () => {
+      const fn = mock(async () => ({ id: "msg_1" }));
+
+      const result = await withIdempotency("test-key", fn);
+
+      expect(result).toEqual({ status: "executed", value: { id: "msg_1" } });
+      expect(fn).toHaveBeenCalledTimes(1);
+      expect(stringData.get("test-key")).toBe(JSON.stringify({ id: "msg_1" }));
+    });
+
+    it("clears lock when function returns null", async () => {
+      const fn = mock(async () => null);
+
+      const result = await withIdempotency("test-key", fn);
+
+      expect(result).toEqual({ status: "failed" });
+      expect(fn).toHaveBeenCalledTimes(1);
+      expect(stringData.has("test-key")).toBe(false);
+    });
+  });
+
+  describe("with idempotency key, duplicate request (cached result)", () => {
+    it("returns cached result without calling function", async () => {
+      stringData.set("test-key", JSON.stringify({ id: "msg_1" }));
+      const fn = mock(async () => ({ id: "msg_2" }));
+
+      const result = await withIdempotency("test-key", fn);
+
+      expect(result).toEqual({ status: "cached", value: { id: "msg_1" } });
+      expect(fn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("with idempotency key, request in progress", () => {
+    it("returns processing status without calling function", async () => {
+      stringData.set("test-key", "processing");
+      const fn = mock(async () => ({ id: "msg_2" }));
+
+      const result = await withIdempotency("test-key", fn);
+
+      expect(result).toEqual({ status: "processing" });
+      expect(fn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("redis failures (fail-open)", () => {
+    it("executes function when lock acquire fails", async () => {
+      const originalSet = redis.set;
+      (redis as any).set = mock(async () => {
+        throw new Error("Redis down");
+      });
+
+      const fn = mock(async () => ({ id: "msg_1" }));
+      const result = await withIdempotency("test-key", fn);
+
+      expect(result).toEqual({ status: "executed", value: { id: "msg_1" } });
+      expect(fn).toHaveBeenCalledTimes(1);
+
+      (redis as any).set = originalSet;
+    });
+
+    it("returns processing when cache read fails after lock not acquired", async () => {
+      stringData.set("test-key", "processing");
+      const originalGet = redis.get;
+      (redis as any).get = mock(async () => {
+        throw new Error("Redis down");
+      });
+
+      const fn = mock(async () => ({ id: "msg_1" }));
+      const result = await withIdempotency("test-key", fn);
+
+      expect(result).toEqual({ status: "processing" });
+      expect(fn).not.toHaveBeenCalled();
+
+      (redis as any).get = originalGet;
+    });
+  });
+});

--- a/src/helpers/withIdempotency.spec.ts
+++ b/src/helpers/withIdempotency.spec.ts
@@ -89,6 +89,29 @@ describe("withIdempotency", () => {
     });
   });
 
+  describe("with idempotency key, cache write fails after successful send", () => {
+    it("releases lock and still returns executed", async () => {
+      const originalSet = redis.set;
+      let callCount = 0;
+      (redis as any).set = mock(async () => {
+        callCount++;
+        if (callCount === 1) return "OK";
+        throw new Error("Cache write failed");
+      });
+
+      try {
+        const fn = mock(async () => ({ id: "msg_1" }));
+        const result = await withIdempotency("test-key", fn);
+
+        expect(result).toEqual({ status: "executed", value: { id: "msg_1" } });
+        expect(fn).toHaveBeenCalledTimes(1);
+        expect(stringData.has("test-key")).toBe(false);
+      } finally {
+        (redis as any).set = originalSet;
+      }
+    });
+  });
+
   describe("redis failures (fail-open)", () => {
     it("executes function when lock acquire fails", async () => {
       const originalSet = redis.set;

--- a/src/helpers/withIdempotency.spec.ts
+++ b/src/helpers/withIdempotency.spec.ts
@@ -75,6 +75,20 @@ describe("withIdempotency", () => {
     });
   });
 
+  describe("with idempotency key, function throws", () => {
+    it("releases the lock and rethrows the error", async () => {
+      const fn = mock(async () => {
+        throw new Error("send failed");
+      });
+
+      await expect(withIdempotency("test-key", fn)).rejects.toThrow(
+        "send failed",
+      );
+      expect(fn).toHaveBeenCalledTimes(1);
+      expect(stringData.has("test-key")).toBe(false);
+    });
+  });
+
   describe("redis failures (fail-open)", () => {
     it("executes function when lock acquire fails", async () => {
       const originalSet = redis.set;
@@ -82,13 +96,15 @@ describe("withIdempotency", () => {
         throw new Error("Redis down");
       });
 
-      const fn = mock(async () => ({ id: "msg_1" }));
-      const result = await withIdempotency("test-key", fn);
+      try {
+        const fn = mock(async () => ({ id: "msg_1" }));
+        const result = await withIdempotency("test-key", fn);
 
-      expect(result).toEqual({ status: "executed", value: { id: "msg_1" } });
-      expect(fn).toHaveBeenCalledTimes(1);
-
-      (redis as any).set = originalSet;
+        expect(result).toEqual({ status: "executed", value: { id: "msg_1" } });
+        expect(fn).toHaveBeenCalledTimes(1);
+      } finally {
+        (redis as any).set = originalSet;
+      }
     });
 
     it("returns processing when cache read fails after lock not acquired", async () => {
@@ -98,13 +114,15 @@ describe("withIdempotency", () => {
         throw new Error("Redis down");
       });
 
-      const fn = mock(async () => ({ id: "msg_1" }));
-      const result = await withIdempotency("test-key", fn);
+      try {
+        const fn = mock(async () => ({ id: "msg_1" }));
+        const result = await withIdempotency("test-key", fn);
 
-      expect(result).toEqual({ status: "processing" });
-      expect(fn).not.toHaveBeenCalled();
-
-      (redis as any).get = originalGet;
+        expect(result).toEqual({ status: "processing" });
+        expect(fn).not.toHaveBeenCalled();
+      } finally {
+        (redis as any).get = originalGet;
+      }
     });
   });
 });

--- a/src/helpers/withIdempotency.ts
+++ b/src/helpers/withIdempotency.ts
@@ -29,15 +29,22 @@ export async function withIdempotency<T>(
     return { status: "processing" };
   }
 
-  const value = await fn();
+  try {
+    const value = await fn();
 
-  if (value === null) {
+    if (value === null) {
+      await releaseLock(key);
+      return { status: "failed" };
+    }
+
+    const cached = await cacheResult(key, value);
+    if (!cached) await releaseLock(key);
+
+    return { status: "executed", value };
+  } catch (error) {
     await releaseLock(key);
-    return { status: "failed" };
+    throw error;
   }
-
-  await cacheResult(key, value);
-  return { status: "executed", value };
 }
 
 async function acquireLock(key: string): Promise<boolean> {
@@ -80,13 +87,15 @@ async function releaseLock(key: string): Promise<void> {
   }
 }
 
-async function cacheResult<T>(key: string, value: T): Promise<void> {
+async function cacheResult<T>(key: string, value: T): Promise<boolean> {
   try {
     await redis.set(key, JSON.stringify(value), { EX: IDEMPOTENCY_TTL });
+    return true;
   } catch (error) {
     logger.warn(
       "[withIdempotency] cache write failed: %s",
       errorToString(error),
     );
+    return false;
   }
 }

--- a/src/helpers/withIdempotency.ts
+++ b/src/helpers/withIdempotency.ts
@@ -5,7 +5,7 @@ import redis from "@/lib/redis";
 const IDEMPOTENCY_TTL = 600;
 const PROCESSING_VALUE = "processing";
 
-type IdempotencyResult<T> =
+export type IdempotencyResult<T> =
   | { status: "executed"; value: T }
   | { status: "cached"; value: T }
   | { status: "processing" }

--- a/src/helpers/withIdempotency.ts
+++ b/src/helpers/withIdempotency.ts
@@ -1,0 +1,92 @@
+import { errorToString } from "@/helpers/errorToString";
+import logger from "@/lib/logger";
+import redis from "@/lib/redis";
+
+const IDEMPOTENCY_TTL = 600;
+const PROCESSING_VALUE = "processing";
+
+type IdempotencyResult<T> =
+  | { status: "executed"; value: T }
+  | { status: "cached"; value: T }
+  | { status: "processing" }
+  | { status: "failed" };
+
+export async function withIdempotency<T>(
+  key: string | null,
+  fn: () => Promise<T | null>,
+): Promise<IdempotencyResult<T>> {
+  if (!key) {
+    const value = await fn();
+    return value !== null
+      ? { status: "executed", value }
+      : { status: "failed" };
+  }
+
+  const acquired = await acquireLock(key);
+  if (!acquired) {
+    const cached = await getCachedResult<T>(key);
+    if (cached !== null) return { status: "cached", value: cached };
+    return { status: "processing" };
+  }
+
+  const value = await fn();
+
+  if (value === null) {
+    await releaseLock(key);
+    return { status: "failed" };
+  }
+
+  await cacheResult(key, value);
+  return { status: "executed", value };
+}
+
+async function acquireLock(key: string): Promise<boolean> {
+  try {
+    const result = await redis.set(key, PROCESSING_VALUE, {
+      NX: true,
+      EX: IDEMPOTENCY_TTL,
+    });
+    return result === "OK";
+  } catch (error) {
+    logger.warn(
+      "[withIdempotency] lock acquire failed, proceeding without cache: %s",
+      errorToString(error),
+    );
+    return true;
+  }
+}
+
+async function getCachedResult<T>(key: string): Promise<T | null> {
+  try {
+    const cached = await redis.get(key);
+    if (cached && cached !== PROCESSING_VALUE) {
+      return JSON.parse(cached) as T;
+    }
+    return null;
+  } catch (error) {
+    logger.warn(
+      "[withIdempotency] cache read failed: %s",
+      errorToString(error),
+    );
+    return null;
+  }
+}
+
+async function releaseLock(key: string): Promise<void> {
+  try {
+    await redis.del(key);
+  } catch {
+    /* fail-open */
+  }
+}
+
+async function cacheResult<T>(key: string, value: T): Promise<void> {
+  try {
+    await redis.set(key, JSON.stringify(value), { EX: IDEMPOTENCY_TTL });
+  } catch (error) {
+    logger.warn(
+      "[withIdempotency] cache write failed: %s",
+      errorToString(error),
+    );
+  }
+}

--- a/src/services/mediaCleanup.spec.ts
+++ b/src/services/mediaCleanup.spec.ts
@@ -1,12 +1,4 @@
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  mock,
-  spyOn,
-} from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
 import { promises as fs } from "node:fs";
 import { MediaCleanupService } from "./mediaCleanup";
 
@@ -24,7 +16,9 @@ describe("MediaCleanupService", () => {
 
   afterEach(() => {
     service.stop();
-    mock.restore();
+    for (const method of ["readdir", "stat", "unlink"] as const) {
+      (fs[method] as any)?.mockRestore?.();
+    }
   });
 
   describe("constructor", () => {

--- a/src/test/preload.ts
+++ b/src/test/preload.ts
@@ -41,6 +41,17 @@ const mockRedis = {
   get: mock(async (key: string) => {
     return stringData.get(key) ?? null;
   }),
+  set: mock(
+    async (
+      key: string,
+      value: string,
+      options?: { NX?: boolean; EX?: number },
+    ) => {
+      if (options?.NX && stringData.has(key)) return null;
+      stringData.set(key, value);
+      return "OK";
+    },
+  ),
   multi: mock(() => {
     multiCommands.length = 0;
     return {


### PR DESCRIPTION
## Summary

- Adds `withIdempotency` helper for two-phase Redis-based idempotent request handling
- Accepts optional `chatwootMessageId` in the send-message endpoint body
- Returns cached result for duplicate requests, 409 for in-flight requests
- Fail-open on Redis errors (no message loss)

## How to test

1. Send a message with `chatwootMessageId` in the body
2. Send the same request again: should return cached result without re-sending
3. Send while first request is in-flight: should return 409
4. Send without `chatwootMessageId`: should behave as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/baileys-api/287)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Idempotent message sending: optional external message ID prevents duplicate processing; successful responses include message key and timestamp.
  * Endpoint now returns 409 when a message is already being processed and 500 for failed sends.

* **Tests**
  * Added comprehensive idempotency tests covering deduplication, processing state, error paths and Redis fail-open behavior.

* **Documentation**
  * API schema updated to document the optional external message ID and the new 409 response.

* **Chores**
  * Test Redis mock enhanced to support conditional set behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->