### PR TITLE
fix: resolve CI test failures from bun mock.module leaks

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -15,12 +15,6 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v6
 
-      - name: Cache Bun Installation
-        uses: actions/cache@v5
-        with:
-          path: ~/.bun
-          key: ${{ runner.os }}-bun
-
       - name: Install Bun
         uses: oven-sh/setup-bun@v2
 
@@ -28,9 +22,9 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-deps-${{ hashFiles('bun.lockb') }}
+          key: ${{ runner.os }}-bun-deps-v2-${{ hashFiles('bun.lock') }}
           restore-keys: |
-            ${{ runner.os }}-bun-deps-
+            ${{ runner.os }}-bun-deps-v2-
 
       - name: Install Dependencies
         run: bun install

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,12 +14,6 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v6
 
-      - name: Cache Bun Installation
-        uses: actions/cache@v5
-        with:
-          path: ~/.bun
-          key: ${{ runner.os }}-bun
-
       - name: Install Bun
         uses: oven-sh/setup-bun@v2
 
@@ -27,9 +21,9 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-deps-${{ hashFiles('bun.lockb') }}
+          key: ${{ runner.os }}-bun-deps-v2-${{ hashFiles('bun.lock') }}
           restore-keys: |
-            ${{ runner.os }}-bun-deps-
+            ${{ runner.os }}-bun-deps-v2-
 
       - name: Install Dependencies
         run: bun install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,12 +15,6 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v6
 
-      - name: Cache Bun Installation
-        uses: actions/cache@v5
-        with:
-          path: ~/.bun
-          key: ${{ runner.os }}-bun
-
       - name: Install Bun
         uses: oven-sh/setup-bun@v2
 
@@ -28,9 +22,9 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-deps-${{ hashFiles('bun.lockb') }}
+          key: ${{ runner.os }}-bun-deps-v2-${{ hashFiles('bun.lock') }}
           restore-keys: |
-            ${{ runner.os }}-bun-deps-
+            ${{ runner.os }}-bun-deps-v2-
 
       - name: Install All Dependencies
         run: bun install

--- a/src/baileys/connectionsHandler.spec.ts
+++ b/src/baileys/connectionsHandler.spec.ts
@@ -111,20 +111,6 @@ class MockBaileysConnection {
   groupFetchAllParticipating = mockGroupFetchAllParticipating;
 }
 
-mock.module("@/baileys/connection", () => ({
-  BaileysConnection: MockBaileysConnection,
-  BaileysNotConnectedError: class BaileysNotConnectedError extends Error {
-    constructor() {
-      super("Phone number not connected");
-    }
-  },
-  BaileysConnectionForbiddenError: class BaileysConnectionForbiddenError extends Error {
-    constructor() {
-      super("Connection not owned by this API key");
-    }
-  },
-}));
-
 mock.module("@/baileys/redisAuthState", () => ({
   getRedisSavedAuthStateIds: mock(async () => []),
 }));
@@ -146,7 +132,9 @@ describe("BaileysConnectionsHandler", () => {
   };
 
   beforeEach(() => {
-    handler = new BaileysConnectionsHandler();
+    handler = new BaileysConnectionsHandler(
+      (phone, opts) => new MockBaileysConnection(phone, opts) as any,
+    );
     mockConnectionInstances.clear();
     mockConnect.mockClear();
     mockLogout.mockClear();

--- a/src/baileys/connectionsHandler.ts
+++ b/src/baileys/connectionsHandler.ts
@@ -25,8 +25,19 @@ import type {
 import { asyncSleep } from "@/helpers/asyncSleep";
 import logger from "@/lib/logger";
 
+type ConnectionFactory = (
+  phoneNumber: string,
+  options: BaileysConnectionOptions,
+) => BaileysConnection;
+
 export class BaileysConnectionsHandler {
   private connections: Record<string, BaileysConnection> = {};
+  private createConnection: ConnectionFactory;
+
+  constructor(createConnection?: ConnectionFactory) {
+    this.createConnection =
+      createConnection || ((phone, opts) => new BaileysConnection(phone, opts));
+  }
 
   async reconnectFromAuthStore() {
     const savedConnections =
@@ -51,7 +62,7 @@ export class BaileysConnectionsHandler {
       await Promise.allSettled(
         chunk.map(async ({ id, metadata }) => {
           await asyncSleep(Math.floor(Math.random() * 100));
-          const connection = new BaileysConnection(id, {
+          const connection = this.createConnection(id, {
             onConnectionClose: () => {
               delete this.connections[id];
               logger.debug(
@@ -88,7 +99,7 @@ export class BaileysConnectionsHandler {
       }
     }
 
-    const connection = new BaileysConnection(phoneNumber, {
+    const connection = this.createConnection(phoneNumber, {
       ...options,
       onConnectionClose: () => {
         delete this.connections[phoneNumber];

--- a/src/services/mediaCleanup.spec.ts
+++ b/src/services/mediaCleanup.spec.ts
@@ -1,12 +1,4 @@
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  mock,
-  spyOn,
-} from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
 import { promises as fs } from "node:fs";
 import { MediaCleanupService } from "./mediaCleanup";
 
@@ -24,7 +16,9 @@ describe("MediaCleanupService", () => {
 
   afterEach(() => {
     service.stop();
-    mock.restore();
+    for (const method of ["readdir", "stat", "unlink"] as const) {
+      (fs[method] as any)?.mockRestore?.();
+    }
   });
 
   describe("constructor", () => {


### PR DESCRIPTION
## Summary

- **DI no BaileysConnectionsHandler**: aceita factory opcional para criar connections, eliminando o `mock.module("@/baileys/connection")` do spec que vazava para `connection.spec.ts` ([oven-sh/bun#12823](https://github.com/oven-sh/bun/issues/12823))
- **mock.restore() -> cleanup individual**: `mediaCleanup.spec.ts` usava `mock.restore()` que destruía todos os module mocks do preload, substituído por `.mockRestore()` individual nos spies de `fs`
- **CI cache fix**: remove cache stale da instalação do bun, corrige `hashFiles('bun.lock')` (era `bun.lockb` que não existe)

## Test plan

- [ ] CI passa nesta PR
- [ ] Re-run CI na #287 após merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/baileys-api/289)
<!-- Reviewable:end -->
