### PR TITLE
feat: add presence subscribe endpoint and auto-subscribe

### DIFF
--- a/src/baileys/connection.spec.ts
+++ b/src/baileys/connection.spec.ts
@@ -555,6 +555,26 @@ describe("BaileysConnection", () => {
       ]);
     });
 
+    it("falls back to original JID when LID resolution fails", async () => {
+      await connection.connect();
+      mockSocket.presenceSubscribe.mockClear();
+      mockSocket.signalRepository.lidMapping.getPNForLID.mockRejectedValueOnce(
+        new Error("lookup failed"),
+      );
+
+      const result = await connection.presenceSubscribe([
+        "999@lid",
+        "user2@s.whatsapp.net",
+      ]);
+
+      expect(mockSocket.presenceSubscribe).toHaveBeenCalledTimes(2);
+      expect(mockSocket.presenceSubscribe).toHaveBeenCalledWith("999@lid");
+      expect(mockSocket.presenceSubscribe).toHaveBeenCalledWith(
+        "user2@s.whatsapp.net",
+      );
+      expect(result.subscribed).toEqual(["999@lid", "user2@s.whatsapp.net"]);
+    });
+
     it("subscribes again on repeated calls (no cache)", async () => {
       await connection.connect();
       mockSocket.presenceSubscribe.mockClear();

--- a/src/baileys/connection.spec.ts
+++ b/src/baileys/connection.spec.ts
@@ -45,6 +45,7 @@ describe("BaileysConnection", () => {
     mockSocket.groupSettingUpdate.mockClear();
     mockSocket.groupToggleEphemeral.mockClear();
     mockSocket.groupFetchAllParticipating.mockClear();
+    mockSocket.signalRepository.lidMapping.getPNForLID.mockClear();
 
     // Clear redis state
     (redis as any).__hashData.clear();
@@ -522,6 +523,285 @@ describe("BaileysConnection", () => {
         const body = JSON.parse(fetchCalls[0].body);
         expect(body.event).toBe("group-participants.update");
       });
+    });
+  });
+
+  describe("#presenceSubscribe", () => {
+    it("throws BaileysNotConnectedError if not connected", async () => {
+      await expect(
+        connection.presenceSubscribe(["user@s.whatsapp.net"]),
+      ).rejects.toThrow(BaileysNotConnectedError);
+    });
+
+    it("calls socket.presenceSubscribe for each JID", async () => {
+      await connection.connect();
+      mockSocket.presenceSubscribe.mockClear();
+
+      const result = await connection.presenceSubscribe([
+        "user1@s.whatsapp.net",
+        "user2@s.whatsapp.net",
+      ]);
+
+      expect(mockSocket.presenceSubscribe).toHaveBeenCalledTimes(2);
+      expect(mockSocket.presenceSubscribe).toHaveBeenCalledWith(
+        "user1@s.whatsapp.net",
+      );
+      expect(mockSocket.presenceSubscribe).toHaveBeenCalledWith(
+        "user2@s.whatsapp.net",
+      );
+      expect(result.subscribed).toEqual([
+        "user1@s.whatsapp.net",
+        "user2@s.whatsapp.net",
+      ]);
+    });
+
+    it("subscribes again on repeated calls (no cache)", async () => {
+      await connection.connect();
+      mockSocket.presenceSubscribe.mockClear();
+
+      await connection.presenceSubscribe(["user1@s.whatsapp.net"]);
+      mockSocket.presenceSubscribe.mockClear();
+
+      const result = await connection.presenceSubscribe([
+        "user1@s.whatsapp.net",
+      ]);
+
+      expect(mockSocket.presenceSubscribe).toHaveBeenCalledTimes(1);
+      expect(result.subscribed).toEqual(["user1@s.whatsapp.net"]);
+    });
+  });
+
+  describe("autoSubscribePresence", () => {
+    it("auto-subscribes on sendMessage when enabled", async () => {
+      const conn = new BaileysConnection("+5511999999999", {
+        ...defaultOptions,
+        autoPresenceSubscribe: true,
+      });
+      await conn.connect();
+      mockSocket.presenceSubscribe.mockClear();
+
+      await conn.sendMessage("user@s.whatsapp.net", { text: "hi" });
+
+      // Give the fire-and-forget promise time to resolve
+      await new Promise((r) => setTimeout(r, 10));
+      expect(mockSocket.presenceSubscribe).toHaveBeenCalledWith(
+        "user@s.whatsapp.net",
+      );
+    });
+
+    it("does NOT auto-subscribe when disabled (default)", async () => {
+      await connection.connect();
+      mockSocket.presenceSubscribe.mockClear();
+
+      await connection.sendMessage("user@s.whatsapp.net", { text: "hi" });
+
+      await new Promise((r) => setTimeout(r, 10));
+      expect(mockSocket.presenceSubscribe).not.toHaveBeenCalled();
+    });
+
+    it("auto-subscribes on sendPresenceUpdate with composing/recording/paused", async () => {
+      const conn = new BaileysConnection("+5511999999999", {
+        ...defaultOptions,
+        autoPresenceSubscribe: true,
+      });
+      await conn.connect();
+      mockSocket.presenceSubscribe.mockClear();
+
+      await conn.sendPresenceUpdate("composing", "user@s.whatsapp.net");
+
+      await new Promise((r) => setTimeout(r, 10));
+      expect(mockSocket.presenceSubscribe).toHaveBeenCalledWith(
+        "user@s.whatsapp.net",
+      );
+    });
+
+    it("does NOT auto-subscribe on sendPresenceUpdate with available/unavailable", async () => {
+      const conn = new BaileysConnection("+5511999999999", {
+        ...defaultOptions,
+        autoPresenceSubscribe: true,
+      });
+      await conn.connect();
+      mockSocket.presenceSubscribe.mockClear();
+
+      await conn.sendPresenceUpdate("available");
+
+      await new Promise((r) => setTimeout(r, 10));
+      expect(mockSocket.presenceSubscribe).not.toHaveBeenCalled();
+    });
+
+    it("auto-subscribes on incoming messages (type: notify)", async () => {
+      const conn = new BaileysConnection("+5511999999999", {
+        ...defaultOptions,
+        autoPresenceSubscribe: true,
+      });
+      await conn.connect();
+      mockSocket.presenceSubscribe.mockClear();
+
+      const handler = mockEventHandlers.get("messages.upsert")!;
+      await handler({
+        type: "notify",
+        messages: [
+          {
+            key: { remoteJid: "sender@s.whatsapp.net", id: "msg-1" },
+            message: { conversation: "hello" },
+          },
+        ],
+      });
+
+      await new Promise((r) => setTimeout(r, 10));
+      expect(mockSocket.presenceSubscribe).toHaveBeenCalledWith(
+        "sender@s.whatsapp.net",
+      );
+    });
+
+    it("does NOT auto-subscribe on history sync messages", async () => {
+      const conn = new BaileysConnection("+5511999999999", {
+        ...defaultOptions,
+        autoPresenceSubscribe: true,
+      });
+      await conn.connect();
+      mockSocket.presenceSubscribe.mockClear();
+
+      const handler = mockEventHandlers.get("messages.upsert")!;
+      await handler({
+        type: "append",
+        messages: [
+          {
+            key: { remoteJid: "sender@s.whatsapp.net", id: "msg-1" },
+            message: { conversation: "hello" },
+          },
+        ],
+      });
+
+      await new Promise((r) => setTimeout(r, 10));
+      expect(mockSocket.presenceSubscribe).not.toHaveBeenCalled();
+    });
+
+    it("skips group JIDs in auto-subscribe", async () => {
+      const conn = new BaileysConnection("+5511999999999", {
+        ...defaultOptions,
+        autoPresenceSubscribe: true,
+      });
+      await conn.connect();
+      mockSocket.presenceSubscribe.mockClear();
+
+      await conn.sendMessage("group@g.us", { text: "hi" });
+
+      await new Promise((r) => setTimeout(r, 10));
+      expect(mockSocket.presenceSubscribe).not.toHaveBeenCalled();
+    });
+
+    it("re-subscribes on repeated auto-subscribe calls (no cache)", async () => {
+      const conn = new BaileysConnection("+5511999999999", {
+        ...defaultOptions,
+        autoPresenceSubscribe: true,
+      });
+      await conn.connect();
+      mockSocket.presenceSubscribe.mockClear();
+
+      await conn.sendMessage("user@s.whatsapp.net", { text: "hi" });
+      await new Promise((r) => setTimeout(r, 10));
+      expect(mockSocket.presenceSubscribe).toHaveBeenCalledTimes(1);
+
+      mockSocket.presenceSubscribe.mockClear();
+      await conn.sendMessage("user@s.whatsapp.net", { text: "hi again" });
+      await new Promise((r) => setTimeout(r, 10));
+      expect(mockSocket.presenceSubscribe).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("LID resolution in presence events", () => {
+    beforeEach(async () => {
+      await connection.connect();
+    });
+
+    it("adds jidAlt when LID is resolved by Baileys signalRepository", async () => {
+      mockSocket.signalRepository.lidMapping.getPNForLID.mockResolvedValueOnce(
+        "553499503261@s.whatsapp.net",
+      );
+
+      const presenceHandler = mockEventHandlers.get("presence.update")!;
+      await presenceHandler({
+        id: "167392323834034@lid",
+        presences: {
+          "167392323834034@lid": { lastKnownPresence: "composing" },
+        },
+      });
+
+      expect(
+        mockSocket.signalRepository.lidMapping.getPNForLID,
+      ).toHaveBeenCalledWith("167392323834034@lid");
+      const presenceCall = fetchCalls.find((c) => {
+        const body = JSON.parse(c.body);
+        return body.event === "presence.update";
+      });
+      expect(presenceCall).toBeDefined();
+      const body = JSON.parse(presenceCall!.body);
+      expect(body.data.jidAlt).toBe("553499503261@s.whatsapp.net");
+    });
+
+    it("does not add jidAlt when presence id is not a LID", async () => {
+      const presenceHandler = mockEventHandlers.get("presence.update")!;
+      await presenceHandler({
+        id: "553499503261@s.whatsapp.net",
+        presences: {
+          "553499503261@s.whatsapp.net": { lastKnownPresence: "available" },
+        },
+      });
+
+      expect(
+        mockSocket.signalRepository.lidMapping.getPNForLID,
+      ).not.toHaveBeenCalled();
+      const presenceCall = fetchCalls.find((c) => {
+        const body = JSON.parse(c.body);
+        return body.event === "presence.update";
+      });
+      const body = JSON.parse(presenceCall!.body);
+      expect(body.data.jidAlt).toBeUndefined();
+    });
+
+    it("does not add jidAlt when LID has no known mapping", async () => {
+      mockSocket.signalRepository.lidMapping.getPNForLID.mockResolvedValueOnce(
+        null,
+      );
+
+      const presenceHandler = mockEventHandlers.get("presence.update")!;
+      await presenceHandler({
+        id: "999999999@lid",
+        presences: {
+          "999999999@lid": { lastKnownPresence: "composing" },
+        },
+      });
+
+      const presenceCall = fetchCalls.find((c) => {
+        const body = JSON.parse(c.body);
+        return body.event === "presence.update";
+      });
+      const body = JSON.parse(presenceCall!.body);
+      expect(body.data.jidAlt).toBeUndefined();
+    });
+
+    it("still forwards presence event if LID resolution fails", async () => {
+      mockSocket.signalRepository.lidMapping.getPNForLID.mockRejectedValueOnce(
+        new Error("resolution failed"),
+      );
+
+      const presenceHandler = mockEventHandlers.get("presence.update")!;
+      await presenceHandler({
+        id: "167392323834034@lid",
+        presences: {
+          "167392323834034@lid": { lastKnownPresence: "composing" },
+        },
+      });
+
+      const presenceCall = fetchCalls.find((c) => {
+        const body = JSON.parse(c.body);
+        return body.event === "presence.update";
+      });
+      expect(presenceCall).toBeDefined();
+      const body = JSON.parse(presenceCall!.body);
+      expect(body.data.jidAlt).toBeUndefined();
+      expect(body.data.id).toBe("167392323834034@lid");
     });
   });
 

--- a/src/baileys/connection.ts
+++ b/src/baileys/connection.ts
@@ -313,6 +313,10 @@ export class BaileysConnection {
 
   private async close() {
     this.stopGroupActivityFlush();
+    if (this.clearOnlinePresenceTimeout) {
+      clearTimeout(this.clearOnlinePresenceTimeout);
+      this.clearOnlinePresenceTimeout = null;
+    }
     await this.clearAuthState?.();
     this.clearAuthState = null;
     this.socket = null;
@@ -394,6 +398,7 @@ export class BaileysConnection {
         }
         if (type === "available") {
           this.clearOnlinePresenceTimeout = setTimeout(() => {
+            this.clearOnlinePresenceTimeout = null;
             this.socket?.sendPresenceUpdate("unavailable", toJid);
           }, 60000);
         }
@@ -429,14 +434,14 @@ export class BaileysConnection {
 
     this.resolveToPN(jid)
       .then((pnJid) => {
-        if (!pnJid) return;
+        const targetJid = pnJid ?? jid;
         return this.ensureAvailablePresence()
-          .then(() => this.safeSocket().presenceSubscribe(pnJid))
+          .then(() => this.safeSocket().presenceSubscribe(targetJid))
           .then(() => {
             logger.debug(
               "[%s] [autoSubscribePresence] Subscribed to %s",
               this.phoneNumber,
-              pnJid,
+              targetJid,
             );
           });
       })
@@ -800,9 +805,7 @@ export class BaileysConnection {
     });
   }
 
-  private async handlePresenceUpdate(
-    data: BaileysEventMap["presence.update"],
-  ) {
+  private async handlePresenceUpdate(data: BaileysEventMap["presence.update"]) {
     const enrichedData = { ...data } as BaileysEventMap["presence.update"] & {
       jidAlt?: string;
     };

--- a/src/baileys/connection.ts
+++ b/src/baileys/connection.ts
@@ -112,6 +112,7 @@ export class BaileysConnection {
     null;
   private reconnectCount = 0;
   private groupsEnabled: boolean;
+  private autoPresenceSubscribe: boolean;
   private _apiKeyHash: string | null;
   private groupActivityMap: Map<
     string,
@@ -132,6 +133,7 @@ export class BaileysConnection {
     this.includeMedia = options.includeMedia ?? true;
     this.syncFullHistory = options.syncFullHistory ?? false;
     this.groupsEnabled = options.groupsEnabled ?? true;
+    this.autoPresenceSubscribe = options.autoPresenceSubscribe ?? false;
     this._apiKeyHash = options.apiKeyHash ?? null;
   }
 
@@ -175,6 +177,7 @@ export class BaileysConnection {
       }
     }
 
+    this.autoPresenceSubscribe = options.autoPresenceSubscribe ?? false;
     this._apiKeyHash = options.apiKeyHash ?? this._apiKeyHash;
     this.persistMetadata();
   }
@@ -191,6 +194,7 @@ export class BaileysConnection {
         includeMedia: this.includeMedia,
         syncFullHistory: this.syncFullHistory,
         groupsEnabled: this.groupsEnabled,
+        autoPresenceSubscribe: this.autoPresenceSubscribe,
         apiKeyHash: this._apiKeyHash,
       }),
     );
@@ -208,6 +212,7 @@ export class BaileysConnection {
       includeMedia: this.includeMedia,
       syncFullHistory: this.syncFullHistory,
       groupsEnabled: this.groupsEnabled,
+      autoPresenceSubscribe: this.autoPresenceSubscribe,
       apiKeyHash: this._apiKeyHash,
     });
     this.clearAuthState = state.keys.clear;
@@ -284,6 +289,10 @@ export class BaileysConnection {
         "handleGroupParticipantsUpdate",
         this.handleGroupParticipantsUpdate,
       ),
+      "presence.update": this.withErrorHandling(
+        "handlePresenceUpdate",
+        this.handlePresenceUpdate,
+      ),
     };
 
     Object.entries(handledEvents).forEach(([event, handler]) => {
@@ -330,6 +339,7 @@ export class BaileysConnection {
     options?: { quoted?: WAMessage },
   ) {
     this.safeSocket();
+    this.autoSubscribePresence(jid);
 
     let waveformProxy: Buffer | null = null;
     try {
@@ -368,6 +378,10 @@ export class BaileysConnection {
       return;
     }
 
+    if (toJid && ["composing", "recording", "paused"].includes(type)) {
+      this.autoSubscribePresence(toJid);
+    }
+
     return this.safeSocket()
       .sendPresenceUpdate(type, toJid)
       .then(() => {
@@ -384,6 +398,66 @@ export class BaileysConnection {
           }, 60000);
         }
       });
+  }
+
+  async presenceSubscribe(jids: string[]) {
+    this.safeSocket();
+    await this.ensureAvailablePresence();
+    const subscribed: string[] = [];
+
+    for (const jid of jids) {
+      const resolvedJid = (await this.resolveToPN(jid)) ?? jid;
+      try {
+        await this.safeSocket().presenceSubscribe(resolvedJid);
+        subscribed.push(jid);
+      } catch (error) {
+        logger.error(
+          "[%s] [presenceSubscribe] Failed to subscribe to %s: %s",
+          this.phoneNumber,
+          resolvedJid,
+          errorToString(error),
+        );
+      }
+    }
+
+    return { subscribed };
+  }
+
+  private autoSubscribePresence(jid: string) {
+    if (!this.autoPresenceSubscribe) return;
+    if (isJidGroup(jid)) return;
+
+    this.resolveToPN(jid)
+      .then((pnJid) => {
+        if (!pnJid) return;
+        return this.ensureAvailablePresence()
+          .then(() => this.safeSocket().presenceSubscribe(pnJid))
+          .then(() => {
+            logger.debug(
+              "[%s] [autoSubscribePresence] Subscribed to %s",
+              this.phoneNumber,
+              pnJid,
+            );
+          });
+      })
+      .catch((error) => {
+        logger.error(
+          "[%s] [autoSubscribePresence] Failed for %s: %s",
+          this.phoneNumber,
+          jid,
+          errorToString(error),
+        );
+      });
+  }
+
+  private async resolveToPN(jid: string): Promise<string | null> {
+    if (!jid.endsWith("@lid")) return jid;
+    return this.safeSocket().signalRepository.lidMapping.getPNForLID(jid);
+  }
+
+  private async ensureAvailablePresence() {
+    if (this.clearOnlinePresenceTimeout) return;
+    await this.sendPresenceUpdate("available");
   }
 
   readMessages(keys: proto.IMessageKey[]) {
@@ -626,6 +700,15 @@ export class BaileysConnection {
   }
 
   private async handleMessagesUpsert(data: BaileysEventMap["messages.upsert"]) {
+    if (data.type === "notify") {
+      for (const msg of data.messages) {
+        const remoteJid = msg.key?.remoteJid;
+        if (remoteJid) {
+          this.autoSubscribePresence(remoteJid);
+        }
+      }
+    }
+
     let messagesData = data;
 
     if (!this.groupsEnabled) {
@@ -714,6 +797,38 @@ export class BaileysConnection {
     this.sendToWebhook({
       event: "group-participants.update",
       data,
+    });
+  }
+
+  private async handlePresenceUpdate(
+    data: BaileysEventMap["presence.update"],
+  ) {
+    const enrichedData = { ...data } as BaileysEventMap["presence.update"] & {
+      jidAlt?: string;
+    };
+
+    if (data.id.endsWith("@lid")) {
+      try {
+        const pn =
+          await this.safeSocket().signalRepository.lidMapping.getPNForLID(
+            data.id,
+          );
+        if (pn) {
+          enrichedData.jidAlt = pn;
+        }
+      } catch (error) {
+        logger.error(
+          "[%s] [handlePresenceUpdate] Failed to resolve LID %s: %s",
+          this.phoneNumber,
+          data.id,
+          errorToString(error),
+        );
+      }
+    }
+
+    this.sendToWebhook({
+      event: "presence.update",
+      data: enrichedData,
     });
   }
 

--- a/src/baileys/connection.ts
+++ b/src/baileys/connection.ts
@@ -411,15 +411,16 @@ export class BaileysConnection {
     const subscribed: string[] = [];
 
     for (const jid of jids) {
-      const resolvedJid = (await this.resolveToPN(jid)) ?? jid;
       try {
+        const resolvedJid =
+          (await this.resolveToPN(jid).catch(() => null)) ?? jid;
         await this.safeSocket().presenceSubscribe(resolvedJid);
         subscribed.push(jid);
       } catch (error) {
         logger.error(
           "[%s] [presenceSubscribe] Failed to subscribe to %s: %s",
           this.phoneNumber,
-          resolvedJid,
+          jid,
           errorToString(error),
         );
       }

--- a/src/baileys/connectionsHandler.spec.ts
+++ b/src/baileys/connectionsHandler.spec.ts
@@ -60,6 +60,9 @@ const mockGroupJoinApprovalMode = mock(async function (this: any) {});
 const mockGroupFetchAllParticipating = mock(async function (this: any) {
   return {};
 });
+const mockPresenceSubscribe = mock(async function (this: any) {
+  return { subscribed: [] };
+});
 
 class MockBaileysConnection {
   phoneNumber: string;
@@ -109,6 +112,7 @@ class MockBaileysConnection {
   groupMemberAddMode = mockGroupMemberAddMode;
   groupJoinApprovalMode = mockGroupJoinApprovalMode;
   groupFetchAllParticipating = mockGroupFetchAllParticipating;
+  presenceSubscribe = mockPresenceSubscribe;
 }
 
 mock.module("@/baileys/redisAuthState", () => ({
@@ -169,6 +173,7 @@ describe("BaileysConnectionsHandler", () => {
     mockGroupMemberAddMode.mockClear();
     mockGroupJoinApprovalMode.mockClear();
     mockGroupFetchAllParticipating.mockClear();
+    mockPresenceSubscribe.mockClear();
   });
 
   describe("#reconnectFromAuthStore", () => {
@@ -761,6 +766,27 @@ describe("BaileysConnectionsHandler", () => {
       await handler.connect("+5511999", defaultOptions);
       handler.groupFetchAllParticipating("+5511999");
       expect(mockGroupFetchAllParticipating).toHaveBeenCalled();
+    });
+  });
+
+  describe("#presenceSubscribe", () => {
+    it("throws BaileysNotConnectedError when connection does not exist", () => {
+      expect(() =>
+        handler.presenceSubscribe("+5511999", ["user@s.whatsapp.net"]),
+      ).toThrow(BaileysNotConnectedError);
+    });
+
+    it("delegates to the connection", async () => {
+      await handler.connect("+5511999", defaultOptions);
+      mockPresenceSubscribe.mockClear();
+      handler.presenceSubscribe("+5511999", [
+        "user1@s.whatsapp.net",
+        "user2@s.whatsapp.net",
+      ]);
+      expect(mockPresenceSubscribe).toHaveBeenCalledWith([
+        "user1@s.whatsapp.net",
+        "user2@s.whatsapp.net",
+      ]);
     });
   });
 });

--- a/src/baileys/connectionsHandler.ts
+++ b/src/baileys/connectionsHandler.ts
@@ -145,6 +145,10 @@ export class BaileysConnectionsHandler {
     return this.getConnection(phoneNumber).sendPresenceUpdate(type, toJid);
   }
 
+  presenceSubscribe(phoneNumber: string, jids: string[]) {
+    return this.getConnection(phoneNumber).presenceSubscribe(jids);
+  }
+
   sendMessage(
     phoneNumber: string,
     {

--- a/src/baileys/types.ts
+++ b/src/baileys/types.ts
@@ -11,6 +11,7 @@ export interface BaileysConnectionOptions {
   includeMedia?: boolean;
   syncFullHistory?: boolean;
   groupsEnabled?: boolean;
+  autoPresenceSubscribe?: boolean;
   apiKeyHash?: string;
   isReconnect?: boolean;
   onConnectionClose?: () => void;

--- a/src/controllers/connections/index.ts
+++ b/src/controllers/connections/index.ts
@@ -100,6 +100,13 @@ const connectionsController = new Elysia({
             default: true,
           }),
         ),
+        autoPresenceSubscribe: t.Optional(
+          t.Boolean({
+            description:
+              "Automatically subscribe to presence updates when sending/receiving messages or typing status to/from a contact. Subscriptions are ephemeral and re-established automatically.",
+            default: false,
+          }),
+        ),
       }),
       detail: {
         responses: {
@@ -142,6 +149,38 @@ const connectionsController = new Elysia({
         responses: {
           200: {
             description: "Presence update sent successfully",
+          },
+        },
+      },
+    },
+  )
+  .post(
+    "/:phoneNumber/presence-subscribe",
+    async ({ params, body }) => {
+      const { phoneNumber } = params;
+      const { jids } = body;
+
+      const result = await baileys.presenceSubscribe(phoneNumber, jids);
+      return { data: result };
+    },
+    {
+      params: phoneNumberParams,
+      body: t.Object({
+        jids: t.Array(
+          anyJid("WhatsApp JID to subscribe to presence updates for"),
+          {
+            description: "Array of JIDs to subscribe to presence updates",
+            minItems: 1,
+            maxItems: 50,
+          },
+        ),
+      }),
+      detail: {
+        description:
+          "Subscribe to presence updates for one or more JIDs. Presence updates will be forwarded via the `presence.update` webhook event. Subscriptions are ephemeral, so re-subscribe periodically for continuous monitoring. LID JIDs are automatically resolved to phone number JIDs before subscribing.",
+        responses: {
+          200: {
+            description: "Presence subscription result",
           },
         },
       },

--- a/src/test/preload.ts
+++ b/src/test/preload.ts
@@ -242,6 +242,12 @@ function createMockSocket() {
     groupMemberAddMode: mock(async () => {}),
     groupJoinApprovalMode: mock(async () => {}),
     groupFetchAllParticipating: mock(async () => ({})),
+    presenceSubscribe: mock(async () => {}),
+    signalRepository: {
+      lidMapping: {
+        getPNForLID: mock(async () => null),
+      },
+    },
   };
 }
 


### PR DESCRIPTION
## Summary
- Add `POST /:phoneNumber/presence-subscribe` endpoint for explicit presence subscription (accepts up to 50 JIDs)
- Add `autoPresenceSubscribe` connection option that automatically subscribes to presence on message send/receive and typing status updates
- Resolve LID JIDs to phone number JIDs before subscribing via Baileys' internal `signalRepository.lidMapping`
- Enrich `presence.update` webhook events with `jidAlt` field when the presence ID is a LID with known mapping
- Ensure `sendPresenceUpdate("available")` is called before any `presenceSubscribe` to guarantee WhatsApp delivers presence events

## Test plan
- [ ] Run `bun test` (242 tests passing)
- [ ] Connect with `autoPresenceSubscribe: true`, send a message, verify presence events arrive via webhook
- [ ] Call `POST /presence-subscribe` with JIDs, verify subscription works
- [ ] Restart server, verify auto-subscribe resumes on next interaction
- [ ] Verify `jidAlt` field appears in `presence.update` webhook payloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/baileys-api/294)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional automatic presence subscription (off by default) triggered by sending messages and composing/recording/paused presence.
  * Manual presence subscription API that returns which JIDs were processed; presence events may include resolved alternate IDs.

* **API**
  * Connection creation accepts autoPresenceSubscribe (default: false).
  * New POST /connections/:phoneNumber/presence-subscribe endpoint (1–50 JIDs).

* **Tests**
  * Added coverage for subscription flows, auto-subscribe triggers, LID→PN resolution, webhook payload enrichment, and caching behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->