### PR TITLE
fix(connection): backoff on tight connectionReplaced (440) loop

### DIFF
--- a/src/baileys/connection.spec.ts
+++ b/src/baileys/connection.spec.ts
@@ -6,6 +6,7 @@ const originalFetch = globalThis.fetch;
 
 import * as baileysModule from "@whiskeysockets/baileys";
 import config from "@/config";
+import { asyncSleep } from "@/helpers/asyncSleep";
 import redis from "@/lib/redis";
 import { BaileysConnection, BaileysNotConnectedError } from "./connection";
 
@@ -454,6 +455,49 @@ describe("BaileysConnection", () => {
         expect(fetchCalls[0].url).toBe("https://example.com/webhook");
         const body = JSON.parse(fetchCalls[0].body);
         expect(body.webhookVerifyToken).toBe("test-token");
+      });
+
+      describe("connectionReplaced (440 conflict/replaced)", () => {
+        const conflictClosePayload = {
+          connection: "close" as const,
+          lastDisconnect: {
+            error: {
+              output: {
+                statusCode: 440,
+                payload: {
+                  statusCode: 440,
+                  error: "Unknown",
+                  message: "Stream Errored (conflict)",
+                },
+              },
+              message: "Stream Errored (conflict)",
+            },
+          },
+        };
+
+        beforeEach(() => {
+          (asyncSleep as any).mockClear();
+        });
+
+        it("reconnects without backoff on a single occurrence", async () => {
+          const handler = mockEventHandlers.get("connection.update")!;
+          await handler(conflictClosePayload);
+
+          expect((asyncSleep as any).mock.calls.length).toBe(0);
+        });
+
+        it("backs off after 5 occurrences within the window", async () => {
+          const handler = mockEventHandlers.get("connection.update")!;
+
+          for (let i = 0; i < 4; i++) {
+            await handler(conflictClosePayload);
+          }
+          expect((asyncSleep as any).mock.calls.length).toBe(0);
+
+          await handler(conflictClosePayload);
+          expect((asyncSleep as any).mock.calls.length).toBe(1);
+          expect((asyncSleep as any).mock.calls[0][0]).toBe(30_000);
+        });
       });
     });
 

--- a/src/baileys/connection.spec.ts
+++ b/src/baileys/connection.spec.ts
@@ -1,4 +1,12 @@
-import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  mock,
+  setSystemTime,
+} from "bun:test";
 
 // Track fetch calls for webhook tests
 const fetchCalls: Array<{ url: string; body: string }> = [];
@@ -497,6 +505,27 @@ describe("BaileysConnection", () => {
           await handler(conflictClosePayload);
           expect((asyncSleep as any).mock.calls.length).toBe(1);
           expect((asyncSleep as any).mock.calls[0][0]).toBe(30_000);
+        });
+
+        it("does not back off when events are spread beyond the sliding window", async () => {
+          const handler = mockEventHandlers.get("connection.update")!;
+          const base = Date.now();
+
+          try {
+            for (let i = 0; i < 4; i++) {
+              setSystemTime(new Date(base + i * 1_000));
+              await handler(conflictClosePayload);
+            }
+            expect((asyncSleep as any).mock.calls.length).toBe(0);
+
+            // Jump past the window so the prior 4 timestamps are evicted.
+            setSystemTime(new Date(base + 35_000));
+            await handler(conflictClosePayload);
+
+            expect((asyncSleep as any).mock.calls.length).toBe(0);
+          } finally {
+            setSystemTime();
+          }
         });
       });
     });

--- a/src/baileys/connection.ts
+++ b/src/baileys/connection.ts
@@ -36,6 +36,14 @@ import { errorToString } from "@/helpers/errorToString";
 import logger, { baileysLogger, deepSanitizeObject } from "@/lib/logger";
 import redis from "@/lib/redis";
 
+// `connectionReplaced` (440 conflict/replaced) usually clears on the next attempt,
+// so default behavior is a normal reconnect. When the same disconnect repeats
+// rapidly it indicates another session is competing for this slot and the tight
+// retry only feeds the loop, so after the threshold we add a backoff.
+const CONNECTION_REPLACED_LOOP_WINDOW_MS = 30_000;
+const CONNECTION_REPLACED_LOOP_THRESHOLD = 5;
+const CONNECTION_REPLACED_BACKOFF_MS = 30_000;
+
 export class BaileysNotConnectedError extends Error {
   constructor() {
     super("Phone number not connected");
@@ -116,6 +124,7 @@ export class BaileysConnection {
   private clearOnlinePresenceTimeout: ReturnType<typeof setTimeout> | null =
     null;
   private reconnectCount = 0;
+  private connectionReplacedTimestamps: number[] = [];
   private groupsEnabled: boolean;
   private autoPresenceSubscribe: boolean;
   private _apiKeyHash: string | null;
@@ -326,6 +335,7 @@ export class BaileysConnection {
     this.clearAuthState = null;
     this.socket = null;
     this.reconnectCount = 0;
+    this.connectionReplacedTimestamps = [];
     this.onConnectionClose?.();
   }
 
@@ -671,6 +681,21 @@ export class BaileysConnection {
         await this.handleReconnecting();
         // NOTE: We don't call `this.close()` here because we want to keep the auth state.
         this.socket = null;
+
+        if (statusCode === DisconnectReason.connectionReplaced) {
+          const recentCount = this.trackConnectionReplaced();
+          if (recentCount >= CONNECTION_REPLACED_LOOP_THRESHOLD) {
+            logger.warn(
+              "[%s] [handleConnectionUpdate] connectionReplaced loop detected (%d events in %dms window), backing off %dms before reconnect",
+              this.phoneNumber,
+              recentCount,
+              CONNECTION_REPLACED_LOOP_WINDOW_MS,
+              CONNECTION_REPLACED_BACKOFF_MS,
+            );
+            await asyncSleep(CONNECTION_REPLACED_BACKOFF_MS);
+          }
+        }
+
         this.connect();
         return;
       }
@@ -864,6 +889,16 @@ export class BaileysConnection {
       event: "connection.update",
       data: { connection: "reconnecting" as WAConnectionState },
     });
+  }
+
+  private trackConnectionReplaced(): number {
+    const now = Date.now();
+    this.connectionReplacedTimestamps =
+      this.connectionReplacedTimestamps.filter(
+        (ts) => now - ts <= CONNECTION_REPLACED_LOOP_WINDOW_MS,
+      );
+    this.connectionReplacedTimestamps.push(now);
+    return this.connectionReplacedTimestamps.length;
   }
 
   private startGroupActivityFlush() {

--- a/src/test/preload.ts
+++ b/src/test/preload.ts
@@ -273,7 +273,11 @@ mock.module("@whiskeysockets/baileys", () => ({
     return _latestMockSocket;
   }),
   Browsers: { windows: (name: string) => ["Windows", name, "10"] },
-  DisconnectReason: { loggedOut: 401, badSession: 500 },
+  DisconnectReason: {
+    loggedOut: 401,
+    badSession: 500,
+    connectionReplaced: 440,
+  },
   makeCacheableSignalKeyStore: mock((keys: any) => keys),
   fetchLatestWaWebVersion: mock(async () => ({ version: [2, 2400, 0] })),
   isJidGroup: (jid: string) => jid?.endsWith("@g.us") ?? false,


### PR DESCRIPTION
## Summary

- Detects tight loops of `DisconnectReason.connectionReplaced` (440 `conflict/replaced`) using a sliding window of timestamps.
- Sleeps 30s before the next `connect()` once 5 events occur within 30s, breaking the runaway reconnect loop without changing behavior for isolated 440 events.
- Adds `connectionReplaced: 440` to the `DisconnectReason` test mock and two unit tests covering single-event and threshold-trip cases.

## Context

In production a customer's connection looped between connected and disconnected ~1 cycle per second, with `stream:error{conflict,replaced}` on every iteration. The existing close handler reconnects on any non-`loggedOut` close, and the brief `connection: open` window between each error resets `reconnectCount`, so the existing >10 retry guard never trips. This change is the least-aggressive intervention that breaks the loop: it preserves normal recovery for one-off 440s and only adds a backoff once the pattern is clearly a loop.

## Test plan

- [x] `bun run check` — lint, tsc, full test suite (245 pass)
- [x] New unit tests:
  - reconnects without backoff on a single 440
  - calls `asyncSleep(30_000)` on the 5th 440 within the 30s window
- [ ] Manual verification on the affected number once deployed (out of scope here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/baileys-api/309)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved connection stability: detects repeated connection-replacement events within a 30s window, applies a 30s backoff when thresholds are exceeded, and clears history on full shutdown to avoid stale state.

* **Tests**
  * Added tests covering connection-replacement scenarios, verifying reconnection retry, backoff behavior, and timing/window handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->