### PR TITLE
fix(connections): serialize concurrent connects to avoid parallel sockets

### DIFF
--- a/src/baileys/connection.spec.ts
+++ b/src/baileys/connection.spec.ts
@@ -136,6 +136,55 @@ describe("BaileysConnection", () => {
       expect(mockSocket.logout).toHaveBeenCalledTimes(1);
       expect(redis.del).toHaveBeenCalled();
     });
+
+    it("marks the connection discarded before the logout RPC so a mid-logout close event cannot resurrect the socket", async () => {
+      // Park `socket.logout()` on a deferred promise. While the logout RPC
+      // is in flight, fire a non-loggedOut close (e.g. another device
+      // grabbed the session) and assert that handleConnectionUpdate does
+      // NOT try to reconnect — i.e. makeWASocket is not invoked.
+      await connection.connect();
+      const handler = mockEventHandlers.get("connection.update")!;
+      const baileys = (await import("@whiskeysockets/baileys")) as any;
+      const makeSocket = baileys.default as ReturnType<typeof mock>;
+
+      let releaseLogout: () => void = () => {};
+      const logoutDeferred = new Promise<void>((res) => {
+        releaseLogout = res;
+      });
+      mockSocket.logout.mockImplementationOnce(() => logoutDeferred);
+
+      const logoutPromise = connection.logout();
+      // Yield until logout is parked on the deferred RPC.
+      while (mockSocket.logout.mock.calls.length === 0) {
+        await new Promise((r) => setImmediate(r));
+      }
+
+      const callsBefore = makeSocket.mock.calls.length;
+
+      // Simulate a connectionReplaced close arriving mid-logout.
+      await handler({
+        connection: "close" as const,
+        lastDisconnect: {
+          error: {
+            output: {
+              statusCode: 440,
+              payload: {
+                statusCode: 440,
+                error: "Unknown",
+                message: "Stream Errored (conflict)",
+              },
+            },
+            message: "Stream Errored (conflict)",
+          },
+        },
+      });
+
+      releaseLogout();
+      await logoutPromise;
+
+      // The mid-logout close must NOT have triggered a reconnect.
+      expect(makeSocket.mock.calls.length).toBe(callsBefore);
+    });
   });
 
   describe("#discard", () => {

--- a/src/baileys/connection.spec.ts
+++ b/src/baileys/connection.spec.ts
@@ -138,6 +138,65 @@ describe("BaileysConnection", () => {
     });
   });
 
+  describe("#discard", () => {
+    it("prevents subsequent connect() from opening a new socket", async () => {
+      const makeSocket = ((await import("@whiskeysockets/baileys")) as any)
+        .default as ReturnType<typeof mock>;
+      const callsBefore = makeSocket.mock.calls.length;
+
+      connection.discard();
+      await connection.connect();
+
+      expect(makeSocket.mock.calls.length).toBe(callsBefore);
+    });
+
+    it("aborts the post-backoff reconnect after connectionReplaced", async () => {
+      // Reproduces the race that survived the in-flight lock: after
+      // connectionReplaced threshold, BaileysConnection sleeps for the
+      // backoff. If the handler discards the connection during that sleep
+      // (because a POST drove it into the BaileysNotConnectedError
+      // recovery path and spawned a replacement), the post-sleep
+      // this.connect() must NOT bring up a second socket — that would
+      // race the replacement on the same identity.
+      await connection.connect();
+      const handler = mockEventHandlers.get("connection.update")!;
+      const conflictClosePayload = {
+        connection: "close" as const,
+        lastDisconnect: {
+          error: {
+            output: {
+              statusCode: 440,
+              payload: {
+                statusCode: 440,
+                error: "Unknown",
+                message: "Stream Errored (conflict)",
+              },
+            },
+            message: "Stream Errored (conflict)",
+          },
+        },
+      };
+
+      // Cross the backoff threshold.
+      for (let i = 0; i < 5; i++) {
+        await handler(conflictClosePayload);
+      }
+      // The fifth close triggered asyncSleep(30_000); since asyncSleep is
+      // mocked to resolve immediately, we cannot interleave the discard with
+      // the sleep in real time — instead, count makeWASocket calls before
+      // and after, then discard and run another close cycle.
+      const makeSocket = ((await import("@whiskeysockets/baileys")) as any)
+        .default as ReturnType<typeof mock>;
+      const callsBefore = makeSocket.mock.calls.length;
+
+      connection.discard();
+      await handler(conflictClosePayload);
+
+      // After discard, no new socket may be created on the post-backoff path.
+      expect(makeSocket.mock.calls.length).toBe(callsBefore);
+    });
+  });
+
   describe("#sendMessage", () => {
     it("throws BaileysNotConnectedError if not connected", async () => {
       await expect(

--- a/src/baileys/connection.spec.ts
+++ b/src/baileys/connection.spec.ts
@@ -150,6 +150,50 @@ describe("BaileysConnection", () => {
       expect(makeSocket.mock.calls.length).toBe(callsBefore);
     });
 
+    it("makes handleConnectionUpdate a no-op so no reconnecting webhook fires after discard", async () => {
+      // `socket.end()` emits a final connection.update {close} synchronously.
+      // Without the early guard in handleConnectionUpdate, the handler would
+      // dispatch a `reconnecting` webhook for a connection that is gone.
+      await connection.connect();
+      const handler = mockEventHandlers.get("connection.update")!;
+      fetchCalls.length = 0;
+
+      connection.discard();
+
+      // Simulate the close event that end() emits.
+      await handler({
+        connection: "close" as const,
+        lastDisconnect: {
+          error: { output: { statusCode: 500, payload: {} }, message: "x" },
+        },
+      });
+
+      const reconnectingHits = fetchCalls.filter((c) =>
+        c.body?.includes('"connection":"reconnecting"'),
+      );
+      expect(reconnectingHits.length).toBe(0);
+    });
+
+    it("re-checks isDiscarded after each await in connect()", async () => {
+      // discard() may run while connect() is awaiting useRedisAuthState or
+      // the version fetch. Without per-await guards, the stale instance
+      // would still call makeWASocket and race the replacement.
+      const baileys = (await import("@whiskeysockets/baileys")) as any;
+      const makeSocket = baileys.default as ReturnType<typeof mock>;
+
+      // Make useRedisAuthState (mocked via redis hash data) settle quickly
+      // and trip the discard between its resolution and makeWASocket.
+      const connectPromise = connection.connect();
+      // Let the first await (useRedisAuthState) settle, then discard before
+      // makeWASocket runs.
+      await new Promise((r) => setImmediate(r));
+      connection.discard();
+      const callsBefore = makeSocket.mock.calls.length;
+      await connectPromise;
+
+      expect(makeSocket.mock.calls.length).toBe(callsBefore);
+    });
+
     it("aborts the post-backoff reconnect after connectionReplaced", async () => {
       // Reproduces the race that survived the in-flight lock: after
       // connectionReplaced threshold, BaileysConnection sleeps for the

--- a/src/baileys/connection.spec.ts
+++ b/src/baileys/connection.spec.ts
@@ -177,31 +177,53 @@ describe("BaileysConnection", () => {
     it("re-checks isDiscarded after each await in connect()", async () => {
       // discard() may run while connect() is awaiting useRedisAuthState or
       // the version fetch. Without per-await guards, the stale instance
-      // would still call makeWASocket and race the replacement.
+      // would still call makeWASocket and race the replacement. We pin the
+      // window open with a deferred fetchLatestWaWebVersion: connect()
+      // parks on the version fetch, we discard, then release — the second
+      // guard must short-circuit before makeWASocket.
       const baileys = (await import("@whiskeysockets/baileys")) as any;
       const makeSocket = baileys.default as ReturnType<typeof mock>;
+      const fetchVersion = baileys.fetchLatestWaWebVersion as ReturnType<
+        typeof mock
+      >;
 
-      // Make useRedisAuthState (mocked via redis hash data) settle quickly
-      // and trip the discard between its resolution and makeWASocket.
-      const connectPromise = connection.connect();
-      // Let the first await (useRedisAuthState) settle, then discard before
-      // makeWASocket runs.
-      await new Promise((r) => setImmediate(r));
-      connection.discard();
+      let releaseFetch: () => void = () => {};
+      const fetchDeferred = new Promise<{
+        version: [number, number, number];
+      }>((res) => {
+        releaseFetch = () => res({ version: [2, 2400, 0] });
+      });
+      fetchVersion.mockImplementationOnce(() => fetchDeferred);
+
       const callsBefore = makeSocket.mock.calls.length;
+      const connectPromise = connection.connect();
+
+      // Yield until connect() is parked on the deferred fetch. Polling
+      // beats a fixed setImmediate count because it doesn't bake the
+      // number of intermediate awaits into the test.
+      while (fetchVersion.mock.calls.length === 0) {
+        await new Promise((r) => setImmediate(r));
+      }
+      // Socket can't have been created yet — connect() is awaiting the fetch.
+      expect(makeSocket.mock.calls.length).toBe(callsBefore);
+
+      connection.discard();
+      releaseFetch();
       await connectPromise;
 
+      // After resuming, the post-fetch isDiscarded guard must bail before
+      // makeWASocket runs.
       expect(makeSocket.mock.calls.length).toBe(callsBefore);
     });
 
     it("aborts the post-backoff reconnect after connectionReplaced", async () => {
-      // Reproduces the race that survived the in-flight lock: after
-      // connectionReplaced threshold, BaileysConnection sleeps for the
-      // backoff. If the handler discards the connection during that sleep
-      // (because a POST drove it into the BaileysNotConnectedError
-      // recovery path and spawned a replacement), the post-sleep
-      // this.connect() must NOT bring up a second socket — that would
-      // race the replacement on the same identity.
+      // The exact race that motivated discard(): after the 5th
+      // connectionReplaced in the window, BaileysConnection sleeps for the
+      // backoff. If the handler discards during that sleep (because a POST
+      // drove it into the recovery path and spawned a replacement), the
+      // post-sleep this.connect() must NOT bring up a second socket.
+      // We pin the window open with a deferred asyncSleep so the discard
+      // happens strictly inside the sleep, not after it.
       await connection.connect();
       const handler = mockEventHandlers.get("connection.update")!;
       const conflictClosePayload = {
@@ -221,22 +243,51 @@ describe("BaileysConnection", () => {
         },
       };
 
-      // Cross the backoff threshold.
-      for (let i = 0; i < 5; i++) {
+      // First 4 closes set up the threshold. Each schedules a
+      // fire-and-forget this.connect(); drain those before snapshotting.
+      for (let i = 0; i < 4; i++) {
         await handler(conflictClosePayload);
       }
-      // The fifth close triggered asyncSleep(30_000); since asyncSleep is
-      // mocked to resolve immediately, we cannot interleave the discard with
-      // the sleep in real time — instead, count makeWASocket calls before
-      // and after, then discard and run another close cycle.
-      const makeSocket = ((await import("@whiskeysockets/baileys")) as any)
-        .default as ReturnType<typeof mock>;
+      const baileys = (await import("@whiskeysockets/baileys")) as any;
+      const makeSocket = baileys.default as ReturnType<typeof mock>;
+      const sleepMock = asyncSleep as ReturnType<typeof mock>;
+      // Settle any pending fire-and-forget reconnects so callsBefore is
+      // stable. Poll until two consecutive ticks show no growth.
+      let prev = -1;
+      while (prev !== makeSocket.mock.calls.length) {
+        prev = makeSocket.mock.calls.length;
+        await new Promise((r) => setImmediate(r));
+      }
+
+      // Arm the 5th close to park on asyncSleep until we release it.
+      let releaseSleep: () => void = () => {};
+      const sleepDeferred = new Promise<void>((res) => {
+        releaseSleep = res;
+      });
+      const sleepCallsBefore = sleepMock.mock.calls.length;
+      sleepMock.mockImplementationOnce(() => sleepDeferred);
+
+      const fifthClose = handler(conflictClosePayload);
+      // Yield until handleConnectionUpdate has entered the deferred sleep.
+      while (sleepMock.mock.calls.length === sleepCallsBefore) {
+        await new Promise((r) => setImmediate(r));
+      }
+
       const callsBefore = makeSocket.mock.calls.length;
 
+      // Discard strictly inside the backoff window.
       connection.discard();
-      await handler(conflictClosePayload);
 
-      // After discard, no new socket may be created on the post-backoff path.
+      releaseSleep();
+      await fifthClose;
+      // Drain the fire-and-forget this.connect() the handler queued.
+      let stable = -1;
+      while (stable !== makeSocket.mock.calls.length) {
+        stable = makeSocket.mock.calls.length;
+        await new Promise((r) => setImmediate(r));
+      }
+
+      // Post-backoff this.connect() must have honored isDiscarded.
       expect(makeSocket.mock.calls.length).toBe(callsBefore);
     });
   });

--- a/src/baileys/connection.ts
+++ b/src/baileys/connection.ts
@@ -125,6 +125,7 @@ export class BaileysConnection {
     null;
   private reconnectCount = 0;
   private connectionReplacedTimestamps: number[] = [];
+  private isDiscarded = false;
   private groupsEnabled: boolean;
   private autoPresenceSubscribe: boolean;
   private _apiKeyHash: string | null;
@@ -215,7 +216,7 @@ export class BaileysConnection {
   }
 
   async connect() {
-    if (this.socket) {
+    if (this.isDiscarded || this.socket) {
       return;
     }
 
@@ -350,6 +351,36 @@ export class BaileysConnection {
       );
     }
     await this.close();
+  }
+
+  // Atomically disowns this connection so it cannot resurrect itself.
+  // Used by the handler when a stale connection is being replaced (e.g.
+  // recovery path from BaileysNotConnectedError, or a stuck reconnect
+  // backoff). Does NOT clear the Redis auth state — the replacement will
+  // reuse the same identity — and does NOT fire onConnectionClose — the
+  // handler driving the discard already owns the replacement, and a late
+  // callback would only race with it.
+  discard() {
+    if (this.isDiscarded) {
+      return;
+    }
+    this.isDiscarded = true;
+    this.onConnectionClose = null;
+    this.stopGroupActivityFlush();
+    if (this.clearOnlinePresenceTimeout) {
+      clearTimeout(this.clearOnlinePresenceTimeout);
+      this.clearOnlinePresenceTimeout = null;
+    }
+    try {
+      this.socket?.end(undefined);
+    } catch (error) {
+      logger.warn(
+        "[%s] [discard] error while ending socket: %s",
+        this.phoneNumber,
+        errorToString(error),
+      );
+    }
+    this.socket = null;
   }
 
   async sendMessage(
@@ -696,6 +727,9 @@ export class BaileysConnection {
           }
         }
 
+        if (this.isDiscarded) {
+          return;
+        }
         this.connect();
         return;
       }

--- a/src/baileys/connection.ts
+++ b/src/baileys/connection.ts
@@ -230,7 +230,26 @@ export class BaileysConnection {
       autoPresenceSubscribe: this.autoPresenceSubscribe,
       apiKeyHash: this._apiKeyHash,
     });
+    // Re-check after each await — discard() may have run while we were
+    // loading auth state or fetching the version. Without this, the
+    // discarded instance would still call makeWASocket() and race the
+    // replacement on the same identity.
+    if (this.isDiscarded) {
+      return;
+    }
     this.clearAuthState = state.keys.clear;
+
+    const version = await fetchBaileysClientVersion().catch((error) => {
+      logger.error(
+        "[%s] [fetchBaileysVersion] Failed to fetch latest WhatsApp Web version, falling back to internal version. %s",
+        this.phoneNumber,
+        errorToString(error),
+      );
+      return undefined;
+    });
+    if (this.isDiscarded) {
+      return;
+    }
 
     const socketOptions: UserFacingSocketConfig = {
       auth: {
@@ -242,14 +261,7 @@ export class BaileysConnection {
       browser: Browsers.windows(this.clientName),
       syncFullHistory: this.syncFullHistory,
       shouldIgnoreJid,
-      version: await fetchBaileysClientVersion().catch((error) => {
-        logger.error(
-          "[%s] [fetchBaileysVersion] Failed to fetch latest WhatsApp Web version, falling back to internal version. %s",
-          this.phoneNumber,
-          errorToString(error),
-        );
-        return undefined;
-      }),
+      version,
     };
 
     try {
@@ -372,6 +384,11 @@ export class BaileysConnection {
       this.clearOnlinePresenceTimeout = null;
     }
     try {
+      // Drop listeners first so the synchronous `connection.update {close}`
+      // that `end()` emits doesn't reach handleConnectionUpdate at all.
+      // The flag guards a second line of defense, but unsubscribing keeps
+      // the handler graph clean even if a stray event slips through.
+      this.socket?.ev.removeAllListeners("connection.update");
       this.socket?.end(undefined);
     } catch (error) {
       logger.warn(
@@ -669,6 +686,14 @@ export class BaileysConnection {
   }
 
   private async handleConnectionUpdate(data: Partial<ConnectionState>) {
+    // A discarded connection must be inert. `socket.end()` fires a final
+    // connection.update before the listeners are torn down; without this
+    // guard the handler would dispatch `reconnecting` webhooks and even
+    // attempt a reconnect on a connection the handler already replaced.
+    if (this.isDiscarded) {
+      return;
+    }
+
     const { connection, qr, lastDisconnect, isNewLogin, isOnline } = data;
 
     // NOTE: Reconnection flow
@@ -727,9 +752,6 @@ export class BaileysConnection {
           }
         }
 
-        if (this.isDiscarded) {
-          return;
-        }
         this.connect();
         return;
       }

--- a/src/baileys/connection.ts
+++ b/src/baileys/connection.ts
@@ -353,6 +353,12 @@ export class BaileysConnection {
   }
 
   async logout() {
+    // Mark as discarded up front so any close event the socket emits during
+    // the logout flow (e.g. a connectionReplaced from another device while
+    // we're awaiting the WhatsApp logout RPC) is treated as terminal by
+    // handleConnectionUpdate and does not schedule a reconnect that would
+    // resurrect the socket while logout is still in flight.
+    this.isDiscarded = true;
     try {
       await this.safeSocket().logout();
     } catch (error) {

--- a/src/baileys/connectionsHandler.spec.ts
+++ b/src/baileys/connectionsHandler.spec.ts
@@ -376,6 +376,49 @@ describe("BaileysConnectionsHandler", () => {
       expect(mockSendPresenceUpdate).toHaveBeenCalledWith("available");
     });
 
+    it("re-validates state after BaileysNotConnectedError instead of spawning unconditionally", async () => {
+      // Two concurrent callers can both reach `sendPresenceUpdate` on the same
+      // stale connection, both receive BaileysNotConnectedError, and both
+      // unconditionally call spawnConnection. The second caller must re-check
+      // the in-flight slot after the recovery branch, otherwise we end up with
+      // two parallel replacement sockets — the exact bug the lock is meant to
+      // prevent, just shifted to the recovery path.
+      await handler.connect("+5511999", defaultOptions);
+      expect(mockConnect).toHaveBeenCalledTimes(1);
+
+      let rejectSpu1: (e: unknown) => void = () => {};
+      let rejectSpu2: (e: unknown) => void = () => {};
+      mockSendPresenceUpdate.mockImplementationOnce(
+        () =>
+          new Promise((_, rej) => {
+            rejectSpu1 = rej;
+          }),
+      );
+      mockSendPresenceUpdate.mockImplementationOnce(
+        () =>
+          new Promise((_, rej) => {
+            rejectSpu2 = rej;
+          }),
+      );
+
+      const first = handler.connect("+5511999", defaultOptions);
+      const second = handler.connect("+5511999", defaultOptions);
+
+      // Let both callers park on `await sendPresenceUpdate`.
+      await new Promise((r) => setImmediate(r));
+      await new Promise((r) => setImmediate(r));
+
+      // Both fail at once with the stale-socket error.
+      rejectSpu1(new BaileysNotConnectedError());
+      rejectSpu2(new BaileysNotConnectedError());
+
+      await first;
+      await second;
+
+      // 1 initial + 1 replacement spawn — NOT 3 (initial + 2 parallel replacements).
+      expect(mockConnect).toHaveBeenCalledTimes(2);
+    });
+
     it("does not let an old connection's onConnectionClose evict a replacement", async () => {
       // After the inconsistent-state recovery path (BaileysNotConnectedError),
       // a new connection takes the slot. If the OLD connection later fires

--- a/src/baileys/connectionsHandler.spec.ts
+++ b/src/baileys/connectionsHandler.spec.ts
@@ -280,6 +280,124 @@ describe("BaileysConnectionsHandler", () => {
         handler.sendPresenceUpdate("+5511999", { type: "available" }),
       ).toThrow(BaileysNotConnectedError);
     });
+
+    it("does not spawn a parallel connection when called while reconnectFromAuthStore is in flight", async () => {
+      // Reproduces the race condition where a POST /connections/<phone> arrives
+      // while reconnectFromAuthStore is mid-flight: the in-flight connection has
+      // already been registered in `this.connections[id]` but its `connect()` is
+      // still awaiting (in production: useRedisAuthState before makeWASocket), so
+      // `sendPresenceUpdate` throws BaileysNotConnectedError. Without proper
+      // serialization the handler then creates a SECOND parallel connection with
+      // the same identity, producing two sockets that fight on the WhatsApp side
+      // with conflict/replaced in a loop.
+      let resolveSlowConnect: () => void = () => {};
+      const slowConnect = new Promise<void>((res) => {
+        resolveSlowConnect = res;
+      });
+      let connectACompleted = false;
+
+      // First connect() (from reconnectFromAuthStore) blocks until released.
+      // Mirrors `await useRedisAuthState()` running before `makeWASocket()`.
+      mockConnect.mockImplementationOnce(async () => {
+        await slowConnect;
+        connectACompleted = true;
+      });
+
+      // sendPresenceUpdate throws only while the socket isn't ready (i.e. the
+      // in-flight connect hasn't completed yet). After it completes, the
+      // socket exists and presence updates succeed.
+      mockSendPresenceUpdate.mockImplementationOnce(async () => {
+        if (!connectACompleted) throw new BaileysNotConnectedError();
+      });
+
+      (
+        getRedisSavedAuthStateIds as ReturnType<typeof mock>
+      ).mockResolvedValueOnce([
+        {
+          id: "+5511999",
+          metadata: {
+            webhookUrl: "https://hook.com",
+            webhookVerifyToken: "t",
+          },
+        },
+      ]);
+
+      // Fire reconnectFromAuthStore without awaiting — it registers
+      // this.connections[+5511999] and parks on slowConnect.
+      const reconnectPromise = handler.reconnectFromAuthStore();
+      // Let the reconnect microtasks run so the connection is registered.
+      await new Promise((r) => setImmediate(r));
+      await new Promise((r) => setImmediate(r));
+
+      // Simulate POST /connections/+5511999 from chatwoot mid-flight.
+      // Don't await yet — the fix makes this await the in-flight connect.
+      const connectPromise = handler.connect("+5511999", defaultOptions);
+      // Yield enough times for connect() to reach `await inFlight`.
+      await new Promise((r) => setImmediate(r));
+      await new Promise((r) => setImmediate(r));
+
+      // Unblock the in-flight connect() and let everything finish.
+      resolveSlowConnect();
+      await connectPromise;
+      await reconnectPromise;
+
+      // Exactly one BaileysConnection.connect() must have happened — the in-flight
+      // one. The handler must NOT have created a parallel socket.
+      expect(mockConnect).toHaveBeenCalledTimes(1);
+    });
+
+    it("serializes concurrent connect calls for the same number", async () => {
+      // Two POSTs arriving at the same time for the same number must not produce
+      // two parallel BaileysConnections, since both would auth with the same
+      // identity and the WhatsApp server kicks both with conflict/replaced.
+      let resolveFirstConnect: () => void = () => {};
+      const firstConnect = new Promise<void>((res) => {
+        resolveFirstConnect = res;
+      });
+
+      mockConnect.mockImplementationOnce(async () => {
+        await firstConnect;
+      });
+
+      const first = handler.connect("+5511999", defaultOptions);
+      const second = handler.connect("+5511999", defaultOptions);
+
+      // Let microtasks settle so both callers parked appropriately.
+      await new Promise((r) => setImmediate(r));
+      await new Promise((r) => setImmediate(r));
+
+      resolveFirstConnect();
+      await first;
+      await second;
+
+      // Only one BaileysConnection.connect() call: the second caller reused
+      // the first one via sendPresenceUpdate, not a parallel socket.
+      expect(mockConnect).toHaveBeenCalledTimes(1);
+      expect(mockSendPresenceUpdate).toHaveBeenCalledWith("available");
+    });
+
+    it("does not let an old connection's onConnectionClose evict a replacement", async () => {
+      // After the inconsistent-state recovery path (BaileysNotConnectedError),
+      // a new connection takes the slot. If the OLD connection later fires
+      // onConnectionClose, it must NOT delete the replacement's entry.
+      await handler.connect("+5511999", defaultOptions);
+      const oldInstance = mockConnectionInstances.get("+5511999");
+
+      mockSendPresenceUpdate.mockRejectedValueOnce(
+        new BaileysNotConnectedError(),
+      );
+      await handler.connect("+5511999", defaultOptions);
+      const newInstance = mockConnectionInstances.get("+5511999");
+      expect(newInstance).not.toBe(oldInstance);
+
+      // Old connection's WS finally closes long after the replacement is live.
+      oldInstance.options.onConnectionClose();
+
+      // Replacement must still be tracked.
+      expect(() =>
+        handler.sendPresenceUpdate("+5511999", { type: "available" }),
+      ).not.toThrow();
+    });
   });
 
   describe("#verifyConnectionAccess", () => {

--- a/src/baileys/connectionsHandler.spec.ts
+++ b/src/baileys/connectionsHandler.spec.ts
@@ -7,6 +7,7 @@ const mockConnectionInstances: Map<string, any> = new Map();
 
 const mockConnect = mock(async function (this: any) {});
 const mockLogout = mock(async function (this: any) {});
+const mockDiscard = mock(function (this: any) {});
 const mockSendPresenceUpdate = mock(async function (this: any) {});
 const mockSendMessage = mock(async function (this: any) {});
 const mockReadMessages = mock(async function (this: any) {});
@@ -81,6 +82,7 @@ class MockBaileysConnection {
   }
   connect = mockConnect;
   logout = mockLogout;
+  discard = mockDiscard;
   sendPresenceUpdate = mockSendPresenceUpdate;
   sendMessage = mockSendMessage;
   readMessages = mockReadMessages;
@@ -142,6 +144,7 @@ describe("BaileysConnectionsHandler", () => {
     mockConnectionInstances.clear();
     mockConnect.mockClear();
     mockLogout.mockClear();
+    mockDiscard.mockClear();
     mockSendPresenceUpdate.mockClear();
     mockSendMessage.mockClear();
     mockReadMessages.mockClear();
@@ -248,8 +251,11 @@ describe("BaileysConnectionsHandler", () => {
       );
 
       await handler.connect("+5511999", defaultOptions);
-      // Should create a new connection
+      // Should create a new connection and discard the stale one so its
+      // pending reconnect (e.g. after a connectionReplaced backoff) cannot
+      // resurrect a parallel socket.
       expect(mockConnect).toHaveBeenCalledTimes(1);
+      expect(mockDiscard).toHaveBeenCalledTimes(1);
     });
 
     it("re-throws non-BaileysNotConnectedError errors", async () => {
@@ -642,6 +648,50 @@ describe("BaileysConnectionsHandler", () => {
         BaileysNotConnectedError,
       );
     });
+
+    it("waits for an in-flight connect before logging out", async () => {
+      // A DELETE arriving while reconnectFromAuthStore is mid-flight must not
+      // beat the spawn — otherwise the freshly created socket would survive
+      // a logout that thought there was nothing to do, leaving an orphaned
+      // BaileysConnection authenticated with that identity.
+      let resolveSlowConnect: () => void = () => {};
+      mockConnect.mockImplementationOnce(
+        () =>
+          new Promise<void>((res) => {
+            resolveSlowConnect = res;
+          }),
+      );
+
+      (
+        getRedisSavedAuthStateIds as ReturnType<typeof mock>
+      ).mockResolvedValueOnce([
+        {
+          id: "+5511999",
+          metadata: { webhookUrl: "https://h.com", webhookVerifyToken: "t" },
+        },
+      ]);
+
+      const reconnectPromise = handler.reconnectFromAuthStore();
+      await new Promise((r) => setImmediate(r));
+      await new Promise((r) => setImmediate(r));
+
+      const logoutPromise = handler.logout("+5511999");
+      // Yield so logout reaches the in-flight drain.
+      await new Promise((r) => setImmediate(r));
+      await new Promise((r) => setImmediate(r));
+
+      // Logout must not have called the connection's logout yet — the spawn
+      // is still running.
+      expect(mockLogout).not.toHaveBeenCalled();
+
+      resolveSlowConnect();
+      await reconnectPromise;
+      await logoutPromise;
+
+      // After both settle, the logout drove a real WhatsApp logout on the
+      // freshly spawned connection.
+      expect(mockLogout).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe("#logoutAll", () => {
@@ -662,6 +712,46 @@ describe("BaileysConnectionsHandler", () => {
     it("handles empty handler gracefully", async () => {
       await handler.logoutAll();
       // Should not throw
+    });
+
+    it("waits for in-flight spawns before iterating connections", async () => {
+      // logoutAll must wait for any connection that is still being spawned
+      // (e.g. by reconnectFromAuthStore on boot). Otherwise the new socket
+      // would survive the bulk logout, leaving an orphaned BaileysConnection
+      // authenticated with our identity.
+      let resolveSlowConnect: () => void = () => {};
+      mockConnect.mockImplementationOnce(
+        () =>
+          new Promise<void>((res) => {
+            resolveSlowConnect = res;
+          }),
+      );
+
+      (
+        getRedisSavedAuthStateIds as ReturnType<typeof mock>
+      ).mockResolvedValueOnce([
+        {
+          id: "+5511999",
+          metadata: { webhookUrl: "https://h.com", webhookVerifyToken: "t" },
+        },
+      ]);
+
+      const reconnectPromise = handler.reconnectFromAuthStore();
+      await new Promise((r) => setImmediate(r));
+      await new Promise((r) => setImmediate(r));
+
+      const logoutAllPromise = handler.logoutAll();
+      await new Promise((r) => setImmediate(r));
+      await new Promise((r) => setImmediate(r));
+
+      expect(mockLogout).not.toHaveBeenCalled();
+
+      resolveSlowConnect();
+      await reconnectPromise;
+      await logoutAllPromise;
+
+      // The spawned connection was reaped by logoutAll once the spawn settled.
+      expect(mockLogout).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/baileys/connectionsHandler.spec.ts
+++ b/src/baileys/connectionsHandler.spec.ts
@@ -220,6 +220,41 @@ describe("BaileysConnectionsHandler", () => {
         handler.sendPresenceUpdate("+5521888", { type: "available" }),
       ).not.toThrow();
     });
+
+    it("reuses an already-active entry instead of tearing it down", async () => {
+      // If reconnectFromAuthStore runs while a connection is already live
+      // (re-entrant call, future admin trigger, etc.), it must not discard
+      // the existing socket and spawn a replacement — the active socket
+      // would race the new one on the same identity.
+      await handler.connect("+5511999", {
+        webhookUrl: "https://h.com",
+        webhookVerifyToken: "t",
+      });
+      const original = mockConnectionInstances.get("+5511999");
+      mockConnect.mockClear();
+      mockDiscard.mockClear();
+
+      (
+        getRedisSavedAuthStateIds as ReturnType<typeof mock>
+      ).mockResolvedValueOnce([
+        {
+          id: "+5511999",
+          metadata: {
+            webhookUrl: "https://h.com",
+            webhookVerifyToken: "t",
+          },
+        },
+      ]);
+
+      await handler.reconnectFromAuthStore();
+
+      // No spawn, no discard — the active connection was reused via
+      // sendPresenceUpdate("available").
+      expect(mockConnect).not.toHaveBeenCalled();
+      expect(mockDiscard).not.toHaveBeenCalled();
+      expect(mockConnectionInstances.get("+5511999")).toBe(original);
+      expect(mockSendPresenceUpdate).toHaveBeenCalledWith("available");
+    });
   });
 
   describe("#connect", () => {

--- a/src/baileys/connectionsHandler.ts
+++ b/src/baileys/connectionsHandler.ts
@@ -72,14 +72,23 @@ export class BaileysConnectionsHandler {
     }
   }
 
-  // Reserves the inFlightOps slot for `phoneNumber` synchronously and runs
-  // `fn` inside it. Serializes concurrent connect/logout calls for the same
-  // number so we never have two parallel sockets with the same identity
-  // (which the WhatsApp server kicks with conflict/replaced).
+  // Drains any in-flight op for `phoneNumber`, reserves a fresh slot
+  // synchronously, and runs `fn` inside it. Serializes concurrent
+  // connect/logout calls for the same number so we never have two parallel
+  // sockets with the same identity (which the WhatsApp server kicks with
+  // conflict/replaced). The internal drain is defense-in-depth so callers
+  // can't accidentally bypass the lock by skipping a prior drain.
   private async withInFlightOp<T>(
     phoneNumber: string,
     fn: () => Promise<T>,
   ): Promise<T> {
+    // Loop because multiple callers may have been parked on the same slot;
+    // when one resolves, all wake — only the first to assign synchronously
+    // below wins the slot. Single-threaded JS makes this safe: nothing can
+    // run between the while-exit and the synchronous slot assignment.
+    while (this.inFlightOps[phoneNumber]) {
+      await this.inFlightOps[phoneNumber].catch(() => {});
+    }
     let resolveSlot: () => void = () => {};
     const slot = new Promise<void>((res) => {
       resolveSlot = res;
@@ -428,12 +437,9 @@ export class BaileysConnectionsHandler {
   }
 
   async logout(phoneNumber: string) {
-    // Park behind any in-flight connect/logout for this number so we don't
-    // race a freshly spawned socket (e.g. from reconnectFromAuthStore on
-    // boot) that hasn't registered itself in `connections` yet.
-    while (this.inFlightOps[phoneNumber]) {
-      await this.inFlightOps[phoneNumber].catch(() => {});
-    }
+    // `withInFlightOp` drains any pending connect/logout for the same
+    // number before reserving its slot, so a logout that arrives while
+    // a connect is mid-spawn parks until the spawn settles.
     await this.withInFlightOp(phoneNumber, async () => {
       await this.getConnection(phoneNumber).logout();
       delete this.connections[phoneNumber];

--- a/src/baileys/connectionsHandler.ts
+++ b/src/baileys/connectionsHandler.ts
@@ -114,34 +114,45 @@ export class BaileysConnectionsHandler {
   }
 
   async connect(phoneNumber: string, options: BaileysConnectionOptions) {
-    // Drain any in-flight connects for this number before deciding what to do.
-    // Loops because multiple callers may have been parked here; each one that
-    // wakes must re-check the slot. Without this, two concurrent callers can
-    // both pass the check and create parallel BaileysConnections with the
-    // same identity, causing conflict/replaced loops on the WhatsApp side.
-    while (this.inFlightConnects[phoneNumber]) {
-      await this.inFlightConnects[phoneNumber].catch(() => {});
-    }
+    // Loops because every decision must be re-validated after an await:
+    //   1. Drain any in-flight connect for this number (multiple callers can
+    //      have parked on the same slot).
+    //   2. If a connection is registered, try to reuse it via
+    //      sendPresenceUpdate. If that throws BaileysNotConnectedError, the
+    //      socket died — evict only if it is still the entry we observed,
+    //      then restart the decision instead of unconditionally spawning a
+    //      replacement (two callers hitting the same stale connection would
+    //      otherwise both spawn parallel sockets with the same identity).
+    //   3. Otherwise spawn a new connection.
+    for (;;) {
+      while (this.inFlightConnects[phoneNumber]) {
+        await this.inFlightConnects[phoneNumber].catch(() => {});
+      }
 
-    if (this.connections[phoneNumber]) {
-      this.connections[phoneNumber].updateOptions(options);
+      const existing = this.connections[phoneNumber];
+      if (!existing) {
+        await this.spawnConnection(phoneNumber, options);
+        return;
+      }
+
+      existing.updateOptions(options);
       try {
         // NOTE: This triggers a `connection.update` event.
-        await this.connections[phoneNumber].sendPresenceUpdate("available");
+        await existing.sendPresenceUpdate("available");
         return;
       } catch (error) {
         if (!(error instanceof BaileysNotConnectedError)) {
           throw error;
         }
-        delete this.connections[phoneNumber];
+        if (this.connections[phoneNumber] === existing) {
+          delete this.connections[phoneNumber];
+        }
         logger.debug(
           "Handled inconsistent connection state for %s",
           phoneNumber,
         );
       }
     }
-
-    await this.spawnConnection(phoneNumber, options);
   }
 
   async verifyConnectionAccess(phoneNumber: string, apiKeyHash: string | null) {

--- a/src/baileys/connectionsHandler.ts
+++ b/src/baileys/connectionsHandler.ts
@@ -72,21 +72,43 @@ export class BaileysConnectionsHandler {
     }
   }
 
-  // Reserves the inFlightOps slot for `phoneNumber` synchronously and
-  // creates/connects a BaileysConnection. Serializes concurrent connect calls
-  // for the same number so we never have two parallel sockets with the same
-  // identity (which the WhatsApp server kicks with conflict/replaced).
-  private async spawnConnection(
+  // Reserves the inFlightOps slot for `phoneNumber` synchronously and runs
+  // `fn` inside it. Serializes concurrent connect/logout calls for the same
+  // number so we never have two parallel sockets with the same identity
+  // (which the WhatsApp server kicks with conflict/replaced).
+  private async withInFlightOp<T>(
     phoneNumber: string,
-    options: BaileysConnectionOptions,
-  ) {
+    fn: () => Promise<T>,
+  ): Promise<T> {
     let resolveSlot: () => void = () => {};
     const slot = new Promise<void>((res) => {
       resolveSlot = res;
     });
     this.inFlightOps[phoneNumber] = slot;
-
     try {
+      return await fn();
+    } finally {
+      if (this.inFlightOps[phoneNumber] === slot) {
+        delete this.inFlightOps[phoneNumber];
+      }
+      resolveSlot();
+    }
+  }
+
+  private async spawnConnection(
+    phoneNumber: string,
+    options: BaileysConnectionOptions,
+  ) {
+    await this.withInFlightOp(phoneNumber, async () => {
+      // If another connection is already registered for this number, discard
+      // it before overwriting. Otherwise its socket would stay alive,
+      // unreachable from `connections` but still racing on our identity.
+      // Guards a re-entrant reconnectFromAuthStore or any future caller
+      // that ends up spawning twice for the same number.
+      const previous = this.connections[phoneNumber];
+      if (previous) {
+        previous.discard();
+      }
       const connection = this.createConnection(phoneNumber, {
         ...options,
         onConnectionClose: () => {
@@ -105,12 +127,7 @@ export class BaileysConnectionsHandler {
       });
       this.connections[phoneNumber] = connection;
       await connection.connect();
-    } finally {
-      if (this.inFlightOps[phoneNumber] === slot) {
-        delete this.inFlightOps[phoneNumber];
-      }
-      resolveSlot();
-    }
+    });
   }
 
   async connect(phoneNumber: string, options: BaileysConnectionOptions) {
@@ -417,34 +434,22 @@ export class BaileysConnectionsHandler {
     while (this.inFlightOps[phoneNumber]) {
       await this.inFlightOps[phoneNumber].catch(() => {});
     }
-
-    let resolveSlot: () => void = () => {};
-    const slot = new Promise<void>((res) => {
-      resolveSlot = res;
-    });
-    this.inFlightOps[phoneNumber] = slot;
-    try {
+    await this.withInFlightOp(phoneNumber, async () => {
       await this.getConnection(phoneNumber).logout();
       delete this.connections[phoneNumber];
       logger.debug(
         "Now tracking %d connections",
         Object.keys(this.connections).length,
       );
-    } finally {
-      if (this.inFlightOps[phoneNumber] === slot) {
-        delete this.inFlightOps[phoneNumber];
-      }
-      resolveSlot();
-    }
+    });
   }
 
   async logoutAll() {
-    // Wait out any in-flight connect/logout so a connection that hasn't been
-    // registered yet (e.g. mid-spawn from reconnectFromAuthStore) is not
-    // left orphaned with a live socket after we clear `connections`.
-    const inFlight = Object.values(this.inFlightOps);
-    if (inFlight.length > 0) {
-      await Promise.allSettled(inFlight);
+    // Drain in-flight ops in a loop, not a single snapshot — a spawn that
+    // started after our first await would otherwise survive the bulk logout
+    // with a live socket, leaving an orphan authenticated with our identity.
+    while (Object.keys(this.inFlightOps).length > 0) {
+      await Promise.allSettled(Object.values(this.inFlightOps));
     }
     const connections = Object.values(this.connections);
     await Promise.allSettled(connections.map((c) => c.logout()));

--- a/src/baileys/connectionsHandler.ts
+++ b/src/baileys/connectionsHandler.ts
@@ -63,7 +63,12 @@ export class BaileysConnectionsHandler {
       await Promise.allSettled(
         chunk.map(async ({ id, metadata }) => {
           await asyncSleep(Math.floor(Math.random() * 100));
-          await this.spawnConnection(id, {
+          // Go through `connect` (not `spawnConnection` directly) so any
+          // existing entry under this number is reused via sendPresenceUpdate
+          // instead of torn down. Today this only runs on boot when
+          // `connections` is empty, but the indirection makes the call safe
+          // against any future caller that runs it after startup.
+          await this.connect(id, {
             isReconnect: true,
             ...metadata,
           });

--- a/src/baileys/connectionsHandler.ts
+++ b/src/baileys/connectionsHandler.ts
@@ -32,6 +32,7 @@ type ConnectionFactory = (
 
 export class BaileysConnectionsHandler {
   private connections: Record<string, BaileysConnection> = {};
+  private inFlightConnects: Record<string, Promise<void>> = {};
   private createConnection: ConnectionFactory;
 
   constructor(createConnection?: ConnectionFactory) {
@@ -62,25 +63,66 @@ export class BaileysConnectionsHandler {
       await Promise.allSettled(
         chunk.map(async ({ id, metadata }) => {
           await asyncSleep(Math.floor(Math.random() * 100));
-          const connection = this.createConnection(id, {
-            onConnectionClose: () => {
-              delete this.connections[id];
-              logger.debug(
-                "Now tracking %d connections",
-                Object.keys(this.connections).length,
-              );
-            },
+          await this.spawnConnection(id, {
             isReconnect: true,
             ...metadata,
           });
-          this.connections[id] = connection;
-          await connection.connect();
         }),
       );
     }
   }
 
+  // Reserves the inFlightConnects slot for `phoneNumber` synchronously and
+  // creates/connects a BaileysConnection. Serializes concurrent connect calls
+  // for the same number so we never have two parallel sockets with the same
+  // identity (which the WhatsApp server kicks with conflict/replaced).
+  private async spawnConnection(
+    phoneNumber: string,
+    options: BaileysConnectionOptions,
+  ) {
+    let resolveSlot: () => void = () => {};
+    const slot = new Promise<void>((res) => {
+      resolveSlot = res;
+    });
+    this.inFlightConnects[phoneNumber] = slot;
+
+    try {
+      const connection = this.createConnection(phoneNumber, {
+        ...options,
+        onConnectionClose: () => {
+          // Only clear the slot if it still points at this connection — a
+          // newer connection may have replaced this one (e.g. via the
+          // BaileysNotConnectedError recovery path in `connect`).
+          if (this.connections[phoneNumber] === connection) {
+            delete this.connections[phoneNumber];
+          }
+          logger.debug(
+            "Now tracking %d connections",
+            Object.keys(this.connections).length,
+          );
+          options.onConnectionClose?.();
+        },
+      });
+      this.connections[phoneNumber] = connection;
+      await connection.connect();
+    } finally {
+      if (this.inFlightConnects[phoneNumber] === slot) {
+        delete this.inFlightConnects[phoneNumber];
+      }
+      resolveSlot();
+    }
+  }
+
   async connect(phoneNumber: string, options: BaileysConnectionOptions) {
+    // Drain any in-flight connects for this number before deciding what to do.
+    // Loops because multiple callers may have been parked here; each one that
+    // wakes must re-check the slot. Without this, two concurrent callers can
+    // both pass the check and create parallel BaileysConnections with the
+    // same identity, causing conflict/replaced loops on the WhatsApp side.
+    while (this.inFlightConnects[phoneNumber]) {
+      await this.inFlightConnects[phoneNumber].catch(() => {});
+    }
+
     if (this.connections[phoneNumber]) {
       this.connections[phoneNumber].updateOptions(options);
       try {
@@ -99,19 +141,7 @@ export class BaileysConnectionsHandler {
       }
     }
 
-    const connection = this.createConnection(phoneNumber, {
-      ...options,
-      onConnectionClose: () => {
-        delete this.connections[phoneNumber];
-        options.onConnectionClose?.();
-      },
-    });
-    await connection.connect();
-    this.connections[phoneNumber] = connection;
-    logger.debug(
-      "Now tracking %d connections",
-      Object.keys(this.connections).length,
-    );
+    await this.spawnConnection(phoneNumber, options);
   }
 
   async verifyConnectionAccess(phoneNumber: string, apiKeyHash: string | null) {

--- a/src/baileys/connectionsHandler.ts
+++ b/src/baileys/connectionsHandler.ts
@@ -32,7 +32,7 @@ type ConnectionFactory = (
 
 export class BaileysConnectionsHandler {
   private connections: Record<string, BaileysConnection> = {};
-  private inFlightConnects: Record<string, Promise<void>> = {};
+  private inFlightOps: Record<string, Promise<void>> = {};
   private createConnection: ConnectionFactory;
 
   constructor(createConnection?: ConnectionFactory) {
@@ -72,7 +72,7 @@ export class BaileysConnectionsHandler {
     }
   }
 
-  // Reserves the inFlightConnects slot for `phoneNumber` synchronously and
+  // Reserves the inFlightOps slot for `phoneNumber` synchronously and
   // creates/connects a BaileysConnection. Serializes concurrent connect calls
   // for the same number so we never have two parallel sockets with the same
   // identity (which the WhatsApp server kicks with conflict/replaced).
@@ -84,7 +84,7 @@ export class BaileysConnectionsHandler {
     const slot = new Promise<void>((res) => {
       resolveSlot = res;
     });
-    this.inFlightConnects[phoneNumber] = slot;
+    this.inFlightOps[phoneNumber] = slot;
 
     try {
       const connection = this.createConnection(phoneNumber, {
@@ -106,8 +106,8 @@ export class BaileysConnectionsHandler {
       this.connections[phoneNumber] = connection;
       await connection.connect();
     } finally {
-      if (this.inFlightConnects[phoneNumber] === slot) {
-        delete this.inFlightConnects[phoneNumber];
+      if (this.inFlightOps[phoneNumber] === slot) {
+        delete this.inFlightOps[phoneNumber];
       }
       resolveSlot();
     }
@@ -125,8 +125,8 @@ export class BaileysConnectionsHandler {
     //      otherwise both spawn parallel sockets with the same identity).
     //   3. Otherwise spawn a new connection.
     for (;;) {
-      while (this.inFlightConnects[phoneNumber]) {
-        await this.inFlightConnects[phoneNumber].catch(() => {});
+      while (this.inFlightOps[phoneNumber]) {
+        await this.inFlightOps[phoneNumber].catch(() => {});
       }
 
       const existing = this.connections[phoneNumber];
@@ -145,6 +145,10 @@ export class BaileysConnectionsHandler {
           throw error;
         }
         if (this.connections[phoneNumber] === existing) {
+          // Discard the stale connection synchronously so any pending
+          // reconnect (e.g. after a connectionReplaced backoff) cannot
+          // resurrect a parallel socket once we spawn the replacement.
+          existing.discard();
           delete this.connections[phoneNumber];
         }
         logger.debug(
@@ -407,15 +411,41 @@ export class BaileysConnectionsHandler {
   }
 
   async logout(phoneNumber: string) {
-    await this.getConnection(phoneNumber).logout();
-    delete this.connections[phoneNumber];
-    logger.debug(
-      "Now tracking %d connections",
-      Object.keys(this.connections).length,
-    );
+    // Park behind any in-flight connect/logout for this number so we don't
+    // race a freshly spawned socket (e.g. from reconnectFromAuthStore on
+    // boot) that hasn't registered itself in `connections` yet.
+    while (this.inFlightOps[phoneNumber]) {
+      await this.inFlightOps[phoneNumber].catch(() => {});
+    }
+
+    let resolveSlot: () => void = () => {};
+    const slot = new Promise<void>((res) => {
+      resolveSlot = res;
+    });
+    this.inFlightOps[phoneNumber] = slot;
+    try {
+      await this.getConnection(phoneNumber).logout();
+      delete this.connections[phoneNumber];
+      logger.debug(
+        "Now tracking %d connections",
+        Object.keys(this.connections).length,
+      );
+    } finally {
+      if (this.inFlightOps[phoneNumber] === slot) {
+        delete this.inFlightOps[phoneNumber];
+      }
+      resolveSlot();
+    }
   }
 
   async logoutAll() {
+    // Wait out any in-flight connect/logout so a connection that hasn't been
+    // registered yet (e.g. mid-spawn from reconnectFromAuthStore) is not
+    // left orphaned with a live socket after we clear `connections`.
+    const inFlight = Object.values(this.inFlightOps);
+    if (inFlight.length > 0) {
+      await Promise.allSettled(inFlight);
+    }
     const connections = Object.values(this.connections);
     await Promise.allSettled(connections.map((c) => c.logout()));
     this.connections = {};


### PR DESCRIPTION
## Summary

Fixes a race condition in `BaileysConnectionsHandler` that creates two parallel `BaileysConnection`s for the same number, both authenticating with the same identity and getting kicked by WhatsApp with `conflict/replaced` (statusCode 440) in a loop.

Two paths could trip the race:

1. **POST `/connections/<phone>` arriving while `reconnectFromAuthStore` is mid-flight.** The reconnect path registers `this.connections[id] = connection` *before* `await connection.connect()` completes (which has `await useRedisAuthState()` before `makeWASocket()`), so an incoming POST sees the entry, tries `sendPresenceUpdate("available")`, gets `BaileysNotConnectedError` because the socket is still null, falls into the recovery branch and creates a **second** parallel connection. Both auth with the same identity → conflict/replaced loop.
2. **Two concurrent POSTs for the same number.** Both pass the empty `this.connections` check before either registers, then both create connections.

Re-pairing the number doesn't help because the same race re-triggers on every container boot.

## Fix

- All spawns now go through `spawnConnection(phoneNumber, options)`, which **synchronously reserves** an `inFlightConnects[phoneNumber]` slot before any await. `connect()` drains the slot in a loop before deciding what to do — any concurrent caller is parked until the in-flight spawn finishes, then either reuses the live connection via `sendPresenceUpdate` or falls into the (now actually inconsistent) recovery branch.
- Each connection's `onConnectionClose` callback now only clears `this.connections[phoneNumber]` if it still points at this connection. Without this, a late close from a connection that was already replaced via the recovery branch would evict its replacement.

## Test plan

- [x] New test `does not spawn a parallel connection when called while reconnectFromAuthStore is in flight` reproduces path #1; fails before the fix with `Expected 1, Received 2` on `mockConnect`.
- [x] New test `serializes concurrent connect calls for the same number` covers path #2.
- [x] New test `does not let an old connection's onConnectionClose evict a replacement` covers the late-close eviction bug.
- [x] All 249 existing tests still pass.
- [x] `bun lint` and `bun build-check` clean.
- [ ] Deploy to staging and watch for `Handled inconsistent connection state` / `connectionReplaced loop detected` log lines — they should disappear for the previously-stuck numbers.

## Related

Builds on #309 (backoff on tight connectionReplaced loop), which mitigated the *symptom* without fixing the cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/baileys-api/312)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Public discard operation to atomically retire replaced connections and per-phone serialization to avoid parallel connect/logout races.

* **Bug Fixes**
  * Prevent duplicate connections from concurrent attempts and from presence-update failures.
  * Ensure late/old closures do not evict newer connections.
  * logout/logoutAll now wait for in-flight ops to finish, preventing orphaned sockets.

* **Tests**
  * Expanded concurrency, discard, reconnection and logout sequencing tests.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fazer-ai/baileys-api/pull/312)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->