### PR TITLE
fix: handle null/undefined in logger sanitizeItem

### DIFF
--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -15,6 +15,9 @@ function sanitizeItem(
   item: unknown,
   options?: DeepSanitizeObjectOptions,
 ): unknown {
+  if (item === null || item === undefined) {
+    return item;
+  }
   if (typeof item === "string") {
     return `${item.slice(0, 50)}${item.length > 50 ? "..." : ""}`;
   }


### PR DESCRIPTION
## Problema

`sanitizeItem` em `src/lib/logger.ts` caía na pegadinha de `typeof null === "object"`: um valor `null` entrava no ramo de objeto e executava `Object.keys(null)`, lançando `TypeError: null is not an object`.

Isso aparecia como `[UNHANDLED_REJECTION]` vindo do `onAfterResponse` ao logar respostas em desenvolvimento (`deepSanitizeObject(response)`), sempre que a resposta tinha um campo `null`.

## Correção

Guard de `null`/`undefined` antes do ramo `typeof === "object"`, retornando o valor como está.

## Impacto

Baixo: o caminho só roda em dev (log de resposta sanitizado) e dispara após a resposta já ter sido enviada, então não afetava a API nem derrubava o processo (era capturado pelo handler global de `unhandledRejection`). Era ruído de log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/baileys-api/325)
<!-- Reviewable:end -->
