### PR TITLE
feat(media): extract media from rich message headers

### DIFF
--- a/src/baileys/connectionsHandler.spec.ts
+++ b/src/baileys/connectionsHandler.spec.ts
@@ -1,4 +1,12 @@
-import { beforeEach, describe, expect, it, mock } from "bun:test";
+import {
+  afterAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  mock,
+  spyOn,
+} from "bun:test";
 
 // Logger and asyncSleep are mocked in preload.ts
 
@@ -117,17 +125,27 @@ class MockBaileysConnection {
   presenceSubscribe = mockPresenceSubscribe;
 }
 
-mock.module("@/baileys/redisAuthState", () => ({
-  getRedisSavedAuthStateIds: mock(async () => []),
-}));
-
 import {
   BaileysConnectionForbiddenError,
   BaileysNotConnectedError,
 } from "@/baileys/connection";
-import { getRedisSavedAuthStateIds } from "@/baileys/redisAuthState";
+import * as redisAuthState from "@/baileys/redisAuthState";
 import redis from "@/lib/redis";
 import { BaileysConnectionsHandler } from "./connectionsHandler";
+
+// Spy on getRedisSavedAuthStateIds rather than mock.module-ing the whole module:
+// bun's mock.module is process-global and leaks into redisAuthState.spec.ts
+// (which tests the real implementation), making that suite intermittently
+// exercise this stub instead and fail depending on file evaluation order. A spy
+// is scoped to this file and restored afterwards.
+const getRedisSavedAuthStateIds = spyOn(
+  redisAuthState,
+  "getRedisSavedAuthStateIds",
+).mockResolvedValue([]);
+
+afterAll(() => {
+  getRedisSavedAuthStateIds.mockRestore();
+});
 
 describe("BaileysConnectionsHandler", () => {
   let handler: BaileysConnectionsHandler;

--- a/src/baileys/helpers/downloadMediaFromMessages.spec.ts
+++ b/src/baileys/helpers/downloadMediaFromMessages.spec.ts
@@ -189,6 +189,10 @@ describe("downloadMediaFromMessages", () => {
 
     await downloadMediaFromMessages(messages);
     expect(downloadContentFromMessage).toHaveBeenCalledTimes(1);
+    expect(downloadContentFromMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ url: "https://example.com/invoice.pdf" }),
+      "document",
+    );
   });
 
   it("extracts media from an interactive message header", async () => {
@@ -205,6 +209,10 @@ describe("downloadMediaFromMessages", () => {
 
     await downloadMediaFromMessages(messages);
     expect(downloadContentFromMessage).toHaveBeenCalledTimes(1);
+    expect(downloadContentFromMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ url: "https://example.com/img" }),
+      "image",
+    );
   });
 
   it("extracts media from a buttons message header", async () => {
@@ -222,6 +230,10 @@ describe("downloadMediaFromMessages", () => {
 
     await downloadMediaFromMessages(messages);
     expect(downloadContentFromMessage).toHaveBeenCalledTimes(1);
+    expect(downloadContentFromMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ url: "https://example.com/vid" }),
+      "video",
+    );
   });
 
   it("extracts media from an interactive template header (nested WABA shape)", async () => {
@@ -240,6 +252,10 @@ describe("downloadMediaFromMessages", () => {
 
     await downloadMediaFromMessages(messages);
     expect(downloadContentFromMessage).toHaveBeenCalledTimes(1);
+    expect(downloadContentFromMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ url: "https://example.com/vid.enc" }),
+      "video",
+    );
   });
 
   it("returns null for a text-only template message", async () => {
@@ -254,6 +270,7 @@ describe("downloadMediaFromMessages", () => {
       } as any,
     ]);
     expect(result).toBeNull();
+    expect(downloadContentFromMessage).not.toHaveBeenCalled();
   });
 
   it("processes multiple messages concurrently in chunks", async () => {

--- a/src/baileys/helpers/downloadMediaFromMessages.spec.ts
+++ b/src/baileys/helpers/downloadMediaFromMessages.spec.ts
@@ -258,6 +258,33 @@ describe("downloadMediaFromMessages", () => {
     );
   });
 
+  it("prefers later header media when earlier header has no media", async () => {
+    const messages = [
+      {
+        key: { id: "msg-mixed-header" },
+        message: {
+          templateMessage: {
+            // Earlier container is present but carries no media...
+            hydratedFourRowTemplate: { hydratedContentText: "no media here" },
+            // ...while a later container does.
+            interactiveMessageTemplate: {
+              header: {
+                imageMessage: { url: "https://example.com/later.jpg" },
+              },
+            },
+          },
+        },
+      },
+    ] as any;
+
+    await downloadMediaFromMessages(messages);
+    expect(downloadContentFromMessage).toHaveBeenCalledTimes(1);
+    expect(downloadContentFromMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ url: "https://example.com/later.jpg" }),
+      "image",
+    );
+  });
+
   it("returns null for a text-only template message", async () => {
     const result = await downloadMediaFromMessages([
       {

--- a/src/baileys/helpers/downloadMediaFromMessages.spec.ts
+++ b/src/baileys/helpers/downloadMediaFromMessages.spec.ts
@@ -172,6 +172,90 @@ describe("downloadMediaFromMessages", () => {
     expect(downloadContentFromMessage).toHaveBeenCalledTimes(1);
   });
 
+  it("extracts media from a template message header", async () => {
+    const messages = [
+      {
+        key: { id: "msg-tpl-doc" },
+        message: {
+          templateMessage: {
+            hydratedTemplate: {
+              hydratedContentText: "Your invoice",
+              documentMessage: { url: "https://example.com/invoice.pdf" },
+            },
+          },
+        },
+      },
+    ] as any;
+
+    await downloadMediaFromMessages(messages);
+    expect(downloadContentFromMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it("extracts media from an interactive message header", async () => {
+    const messages = [
+      {
+        key: { id: "msg-interactive-img" },
+        message: {
+          interactiveMessage: {
+            header: { imageMessage: { url: "https://example.com/img" } },
+          },
+        },
+      },
+    ] as any;
+
+    await downloadMediaFromMessages(messages);
+    expect(downloadContentFromMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it("extracts media from a buttons message header", async () => {
+    const messages = [
+      {
+        key: { id: "msg-buttons-vid" },
+        message: {
+          buttonsMessage: {
+            contentText: "Choose",
+            videoMessage: { url: "https://example.com/vid" },
+          },
+        },
+      },
+    ] as any;
+
+    await downloadMediaFromMessages(messages);
+    expect(downloadContentFromMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it("extracts media from an interactive template header (nested WABA shape)", async () => {
+    const messages = [
+      {
+        key: { id: "msg-interactive-tpl-vid" },
+        message: {
+          templateMessage: {
+            interactiveMessageTemplate: {
+              header: { videoMessage: { url: "https://example.com/vid.enc" } },
+            },
+          },
+        },
+      },
+    ] as any;
+
+    await downloadMediaFromMessages(messages);
+    expect(downloadContentFromMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns null for a text-only template message", async () => {
+    const result = await downloadMediaFromMessages([
+      {
+        key: { id: "msg-tpl-text" },
+        message: {
+          templateMessage: {
+            hydratedTemplate: { hydratedContentText: "no media here" },
+          },
+        },
+      } as any,
+    ]);
+    expect(result).toBeNull();
+  });
+
   it("processes multiple messages concurrently in chunks", async () => {
     // Create 5 messages to test chunking (CONCURRENCY = 3)
     const messages = Array.from({ length: 5 }, (_, i) => ({

--- a/src/baileys/helpers/downloadMediaFromMessages.ts
+++ b/src/baileys/helpers/downloadMediaFromMessages.ts
@@ -105,7 +105,46 @@ function extractMediaMessage(message: proto.IMessage): {
     }
   }
 
-  return { mediaMessage: null, mediaType: null };
+  return (
+    extractHeaderMediaMessage(message) ?? {
+      mediaMessage: null,
+      mediaType: null,
+    }
+  );
+}
+
+// "Rich" messages (template / interactive / buttons) can carry a media header
+// nested inside their payload instead of at the top level, e.g. an invoice PDF
+// in a template header. Surface it so it is downloaded and served like any
+// other attachment.
+function extractHeaderMediaMessage(message: proto.IMessage): {
+  mediaMessage: MediaMessage;
+  mediaType: MediaType;
+} | null {
+  const header =
+    message.templateMessage?.hydratedFourRowTemplate ??
+    message.templateMessage?.hydratedTemplate ??
+    message.interactiveMessage?.header ??
+    message.templateMessage?.interactiveMessageTemplate?.header ??
+    message.buttonsMessage;
+  if (!header) {
+    return null;
+  }
+
+  const headerMapping: [string, MediaType][] = [
+    ["imageMessage", "image"],
+    ["videoMessage", "video"],
+    ["documentMessage", "document"],
+  ];
+
+  for (const [field, type] of headerMapping) {
+    const node = (header as Record<string, unknown>)[field];
+    if (node) {
+      return { mediaMessage: node as MediaMessage, mediaType: type };
+    }
+  }
+
+  return null;
 }
 
 async function streamToBuffer(stream: AsyncIterable<Buffer>): Promise<Buffer> {

--- a/src/baileys/helpers/downloadMediaFromMessages.ts
+++ b/src/baileys/helpers/downloadMediaFromMessages.ts
@@ -129,6 +129,8 @@ function extractHeaderMediaMessage(message: proto.IMessage): {
     message.buttonsMessage,
   ];
 
+  // Rich headers only carry image, video, or document attachments; audio and
+  // stickers don't appear in these header positions, so they're omitted here.
   const headerMapping: [string, MediaType][] = [
     ["imageMessage", "image"],
     ["videoMessage", "video"],
@@ -136,8 +138,8 @@ function extractHeaderMediaMessage(message: proto.IMessage): {
   ];
 
   // A non-null header container doesn't guarantee it carries media, so scan
-  // every candidate instead of committing to the first non-null one — the
-  // media may live in a later container.
+  // every candidate instead of committing to the first non-null one. The media
+  // may live in a later container.
   for (const header of headers) {
     if (!header) {
       continue;

--- a/src/baileys/helpers/downloadMediaFromMessages.ts
+++ b/src/baileys/helpers/downloadMediaFromMessages.ts
@@ -121,15 +121,13 @@ function extractHeaderMediaMessage(message: proto.IMessage): {
   mediaMessage: MediaMessage;
   mediaType: MediaType;
 } | null {
-  const header =
-    message.templateMessage?.hydratedFourRowTemplate ??
-    message.templateMessage?.hydratedTemplate ??
-    message.interactiveMessage?.header ??
-    message.templateMessage?.interactiveMessageTemplate?.header ??
-    message.buttonsMessage;
-  if (!header) {
-    return null;
-  }
+  const headers = [
+    message.templateMessage?.hydratedFourRowTemplate,
+    message.templateMessage?.hydratedTemplate,
+    message.interactiveMessage?.header,
+    message.templateMessage?.interactiveMessageTemplate?.header,
+    message.buttonsMessage,
+  ];
 
   const headerMapping: [string, MediaType][] = [
     ["imageMessage", "image"],
@@ -137,10 +135,18 @@ function extractHeaderMediaMessage(message: proto.IMessage): {
     ["documentMessage", "document"],
   ];
 
-  for (const [field, type] of headerMapping) {
-    const node = (header as Record<string, unknown>)[field];
-    if (node) {
-      return { mediaMessage: node as MediaMessage, mediaType: type };
+  // A non-null header container doesn't guarantee it carries media, so scan
+  // every candidate instead of committing to the first non-null one — the
+  // media may live in a later container.
+  for (const header of headers) {
+    if (!header) {
+      continue;
+    }
+    for (const [field, type] of headerMapping) {
+      const node = (header as Record<string, unknown>)[field];
+      if (node) {
+        return { mediaMessage: node as MediaMessage, mediaType: type };
+      }
     }
   }
 

--- a/src/test/preload.ts
+++ b/src/test/preload.ts
@@ -53,20 +53,24 @@ const mockRedis = {
     },
   ),
   multi: mock(() => {
-    multiCommands.length = 0;
+    // Each multi() invocation owns its own command buffer. A shared module-level
+    // buffer races when concurrent/interleaved multi() calls reset it mid-flight
+    // (e.g. one pipeline's execAsPipeline awaiting while another multi() zeroes
+    // the buffer), silently dropping the queued commands.
+    const commands: Array<{ op: string; args: any[] }> = [];
     return {
       hSet: (key: string, field: string, value: string) => {
-        multiCommands.push({ op: "hSet", args: [key, field, value] });
+        commands.push({ op: "hSet", args: [key, field, value] });
       },
       hDel: (key: string, field: string) => {
-        multiCommands.push({ op: "hDel", args: [key, field] });
+        commands.push({ op: "hDel", args: [key, field] });
       },
       hGet: (key: string, field: string) => {
-        multiCommands.push({ op: "hGet", args: [key, field] });
+        commands.push({ op: "hGet", args: [key, field] });
       },
       execAsPipeline: mock(async () => {
         const results: any[] = [];
-        for (const cmd of multiCommands) {
+        for (const cmd of commands) {
           if (cmd.op === "hSet") {
             const [key, field, value] = cmd.args;
             if (!hashData.has(key)) hashData.set(key, new Map());


### PR DESCRIPTION
Template, interactive and buttons messages can carry a media attachment in their header (for example an invoice PDF or a banner image at the top of a template), nested inside the payload instead of at the top level. The bridge missed these, so it served no bytes and the dashboard rendered the rich card without its header media.

This is the bridge half of fazer-ai/chatwoot#315 (WhatsApp rich messages). It is backward compatible: plain media messages are unchanged, and a header with no media still returns null.

## How to test

1. Send a WABA/Cloud-API **template with media in the header** (image or an invoice PDF) to a Baileys-connected number.
2. Confirm the bridge downloads and serves the header attachment (the dashboard, with chatwoot#315, then shows the media inside the rich card).
3. Send a text-only template and confirm nothing regresses (no media served).

## What changed

- `extractMediaMessage` now falls back to a new `extractHeaderMediaMessage`, which unwraps the template (`hydratedFourRowTemplate` / `hydratedTemplate`), interactive (`header`), nested WABA interactive template (`templateMessage.interactiveMessageTemplate.header`) and buttons headers, and surfaces any `imageMessage` / `videoMessage` / `documentMessage`.
- Added spec coverage for each header shape and a text-only no-media case.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/baileys-api/329)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved media handling to detect and download images, videos, and documents embedded in template, interactive, and button message headers; when multiple headers exist, media found in later headers is preferred.

* **Tests**
  * Added unit tests validating header-based media extraction across message types and edge cases, including empty earlier headers and text-only messages (no media returned).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->