### PR TITLE
fix: preserve auth state when aborting a reconnect loop

### DIFF
--- a/src/baileys/connection.spec.ts
+++ b/src/baileys/connection.spec.ts
@@ -341,6 +341,82 @@ describe("BaileysConnection", () => {
     });
   });
 
+  describe("reconnect loop abort", () => {
+    // Each `isNewLogin` connection.update routes through handleReconnecting
+    // and bumps reconnectCount. Past the threshold (>10) the connection must
+    // give up WITHOUT clearing the Redis auth state: the destructive close()
+    // used to DEL the shared authState hash, which in a multi-instance
+    // setup wipes the identity out from under the legitimate owner and
+    // forces a new QR scan.
+    it("preserves auth state, notifies the webhook, and evicts itself past the reconnect threshold", async () => {
+      let closeCalls = 0;
+      const conn = new BaileysConnection("+5511999999999", {
+        ...defaultOptions,
+        onConnectionClose: () => {
+          closeCalls += 1;
+        },
+      });
+      await conn.connect();
+      const handler = mockEventHandlers.get("connection.update")!;
+
+      for (let i = 0; i < 11; i++) {
+        await handler({ isNewLogin: true });
+      }
+
+      // Auth state preserved: no DEL of the authState hash.
+      expect((redis.del as any).mock.calls.length).toBe(0);
+      // Handler eviction fired exactly once.
+      expect(closeCalls).toBe(1);
+
+      // The structured error webhook must reach the client.
+      while (
+        !fetchCalls.some((c) =>
+          c.body?.includes('"error":"reconnect_loop_detected"'),
+        )
+      ) {
+        await new Promise((r) => setImmediate(r));
+      }
+    });
+
+    it("does not resurrect the socket via the post-close reconnect after aborting", async () => {
+      await connection.connect();
+      const handler = mockEventHandlers.get("connection.update")!;
+
+      // Drive the count to the threshold with isNewLogin updates.
+      for (let i = 0; i < 10; i++) {
+        await handler({ isNewLogin: true });
+      }
+
+      const baileys = (await import("@whiskeysockets/baileys")) as any;
+      const makeSocket = baileys.default as ReturnType<typeof mock>;
+      // Settle any pending fire-and-forget reconnects before snapshotting.
+      let prev = -1;
+      while (prev !== makeSocket.mock.calls.length) {
+        prev = makeSocket.mock.calls.length;
+        await new Promise((r) => setImmediate(r));
+      }
+      const callsBefore = makeSocket.mock.calls.length;
+
+      // The 11th increment arrives via a close event whose handler queues a
+      // fire-and-forget this.connect() right after handleReconnecting —
+      // abort() must have flagged the connection so that connect no-ops.
+      await handler({
+        connection: "close" as const,
+        lastDisconnect: {
+          error: { output: { statusCode: 500, payload: {} }, message: "x" },
+        },
+      });
+      let stable = -1;
+      while (stable !== makeSocket.mock.calls.length) {
+        stable = makeSocket.mock.calls.length;
+        await new Promise((r) => setImmediate(r));
+      }
+
+      expect(makeSocket.mock.calls.length).toBe(callsBefore);
+      expect((redis.del as any).mock.calls.length).toBe(0);
+    });
+  });
+
   describe("#sendMessage", () => {
     it("throws BaileysNotConnectedError if not connected", async () => {
       await expect(

--- a/src/baileys/connection.ts
+++ b/src/baileys/connection.ts
@@ -175,7 +175,7 @@ export class BaileysConnection {
     };
   }
 
-  updateOptions(options: BaileysConnectionOptions) {
+  async updateOptions(options: BaileysConnectionOptions) {
     this.clientName = options.clientName || "Chrome";
     this.webhookUrl = options.webhookUrl;
     this.webhookVerifyToken = options.webhookVerifyToken;
@@ -194,12 +194,12 @@ export class BaileysConnection {
 
     this.autoPresenceSubscribe = options.autoPresenceSubscribe ?? false;
     this._apiKeyHash = options.apiKeyHash ?? this._apiKeyHash;
-    this.persistMetadata();
+    await this.persistMetadata();
   }
 
-  private persistMetadata() {
+  private async persistMetadata() {
     const key = `@baileys-api:connections:${this.phoneNumber}:authState`;
-    redis.hSet(
+    await redis.hSet(
       key,
       "metadata",
       JSON.stringify({
@@ -404,6 +404,18 @@ export class BaileysConnection {
       );
     }
     this.socket = null;
+  }
+
+  // Terminal teardown for a connection that gives up on itself (e.g. a
+  // reconnect loop that never stabilizes). Unlike close(), preserves the
+  // Redis auth state so the same identity can be resumed later — by a new
+  // POST /connections or by another instance sharing this Redis. Unlike
+  // discard(), fires onConnectionClose so the handler evicts this instance
+  // from its registry.
+  private abort() {
+    const onConnectionClose = this.onConnectionClose;
+    this.discard();
+    onConnectionClose?.();
   }
 
   async sendMessage(
@@ -941,10 +953,14 @@ export class BaileysConnection {
     this.reconnectCount += 1;
     if (this.reconnectCount > 10) {
       logger.warn(
-        "[%s] [handleReconnecting] Reconnect count exceeded 10, resetting connection",
+        "[%s] [handleReconnecting] Reconnect count exceeded 10, aborting reconnection (auth state preserved)",
         this.phoneNumber,
       );
-      await this.close();
+      this.sendToWebhook({
+        event: "connection.update",
+        data: { error: "reconnect_loop_detected" },
+      });
+      this.abort();
       return;
     }
     this.sendToWebhook({

--- a/src/baileys/connectionsHandler.ts
+++ b/src/baileys/connectionsHandler.ts
@@ -166,7 +166,7 @@ export class BaileysConnectionsHandler {
         return;
       }
 
-      existing.updateOptions(options);
+      await existing.updateOptions(options);
       try {
         // NOTE: This triggers a `connection.update` event.
         await existing.sendPresenceUpdate("available");


### PR DESCRIPTION
## Summary

Groundwork for #315 (distributed multi-instance support).

`handleReconnecting` past the threshold (>10 attempts) called `close()`, which runs `clearAuthState()` and DELs the entire `@baileys-api:connections:<phone>:authState` hash in Redis. In any split-brain window (two instances briefly fighting over the same identity, e.g. during a rolling deploy), the losing side ends up in exactly this reconnect loop, and after 10 attempts it would wipe the shared credentials out from under the legitimate owner, forcing a new QR scan for the number.

Changes:
- New private `abort()`: `discard()` (socket teardown, auth state **preserved**) + fire `onConnectionClose` so the handler evicts the instance from its registry.
- The reconnect-loop path now sends a structured `connection.update` webhook with `error: "reconnect_loop_detected"` (same pattern as `wrong_phone_number`) and calls `abort()` instead of the destructive `close()`.
- `clearAuthState` now only runs on real `loggedOut` / "QR refs attempts ended" / explicit logout.
- `persistMetadata` is awaited (was fire-and-forget; silent failures could leave another instance reading stale webhook config from Redis).

## Tests

- `reconnect loop abort` specs: auth state hash is never DELed, eviction callback fires exactly once, structured error webhook is delivered, and the post-close fire-and-forget reconnect cannot resurrect the socket.
- `bun test`: 266 pass. `biome check`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/baileys-api/330)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of reconnect loops by detecting and aborting connections after exceeding reconnection thresholds while preserving authentication state.
  * Fixed async timing issue where connection option updates could race with subsequent operations.

* **Tests**
  * Added comprehensive test coverage for reconnect loop detection and abort behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->