### PR TITLE
fix: route wrong-phone teardown through inFlightOps lock (#313)

### DIFF
--- a/src/baileys/connection.spec.ts
+++ b/src/baileys/connection.spec.ts
@@ -191,6 +191,52 @@ describe("BaileysConnection", () => {
     });
   });
 
+  describe("wrong phone number", () => {
+    const wrongUserId = "5511888888888:0@s.whatsapp.net";
+
+    it("routes teardown through requestLogout when the handler wired one", async () => {
+      const requestLogout = mock(() => {});
+      const conn = new BaileysConnection("+5511999999999", {
+        ...defaultOptions,
+        requestLogout,
+      });
+      await conn.connect();
+      const handler = mockEventHandlers.get("connection.update")!;
+      // Socket opened paired with a DIFFERENT number than the registered one.
+      mockSocket.user = { id: wrongUserId };
+      mockSocket.logout.mockClear();
+
+      await handler({ connection: "open" });
+
+      // The wrong-phone webhook fired...
+      expect(
+        fetchCalls.some((c) =>
+          c.body?.includes('"error":"wrong_phone_number"'),
+        ),
+      ).toBe(true);
+      // ...and teardown was delegated to the handler, NOT a direct socket logout.
+      expect(requestLogout).toHaveBeenCalledTimes(1);
+      expect(mockSocket.logout).not.toHaveBeenCalled();
+    });
+
+    it("falls back to a direct logout when no requestLogout is wired", async () => {
+      await connection.connect();
+      const handler = mockEventHandlers.get("connection.update")!;
+      mockSocket.user = { id: wrongUserId };
+      mockSocket.logout.mockClear();
+
+      await handler({ connection: "open" });
+
+      expect(
+        fetchCalls.some((c) =>
+          c.body?.includes('"error":"wrong_phone_number"'),
+        ),
+      ).toBe(true);
+      // No handler wired -> direct connection.logout() -> socket.logout().
+      expect(mockSocket.logout).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe("#discard", () => {
     it("prevents subsequent connect() from opening a new socket", async () => {
       const makeSocket = ((await import("@whiskeysockets/baileys")) as any)

--- a/src/baileys/connection.ts
+++ b/src/baileys/connection.ts
@@ -133,6 +133,7 @@ export class BaileysConnection {
   private includeMedia: boolean;
   private syncFullHistory: boolean;
   private onConnectionClose: (() => void) | null;
+  private requestLogout: (() => void) | null;
   private socket: ReturnType<typeof makeWASocket> | null;
   private clearAuthState: AuthenticationState["keys"]["clear"] | null;
   private clearOnlinePresenceTimeout: ReturnType<typeof setTimeout> | null =
@@ -165,6 +166,7 @@ export class BaileysConnection {
     this.webhookUrl = options.webhookUrl;
     this.webhookVerifyToken = options.webhookVerifyToken;
     this.onConnectionClose = options.onConnectionClose || null;
+    this.requestLogout = options.requestLogout ?? null;
     this.socket = null;
     this.clearAuthState = null;
     this.isReconnect = !!options.isReconnect;
@@ -1125,7 +1127,15 @@ export class BaileysConnection {
       data: { error: "wrong_phone_number" },
     });
     this.socket?.ev.removeAllListeners("connection.update");
-    this.logout();
+    // Route teardown through the handler so the logout participates in
+    // inFlightOps (serializes with any concurrent connect/logout/discard for
+    // this number). Falls back to a direct logout when no handler wired a
+    // callback (e.g. a standalone BaileysConnection). See issue #313.
+    if (this.requestLogout) {
+      this.requestLogout();
+    } else {
+      this.logout();
+    }
   }
 
   private async handleReconnecting() {

--- a/src/baileys/connectionsHandler.spec.ts
+++ b/src/baileys/connectionsHandler.spec.ts
@@ -730,6 +730,88 @@ describe("BaileysConnectionsHandler", () => {
     });
   });
 
+  describe("wrong-phone teardown (requestLogout)", () => {
+    it("wires a requestLogout that tears the connection down through the lock", async () => {
+      await handler.connect("+5511999", defaultOptions);
+      const instance = mockConnectionInstances.get("+5511999")!;
+      expect(typeof instance.options.requestLogout).toBe("function");
+      mockLogout.mockClear();
+
+      // handleWrongPhoneNumber would call this callback.
+      instance.options.requestLogout();
+      // Fire-and-forget — drain it until the teardown removes the connection.
+      while (handler.hasConnection("+5511999")) {
+        await new Promise((r) => setImmediate(r));
+      }
+
+      expect(mockLogout).toHaveBeenCalledTimes(1);
+      expect(handler.hasConnection("+5511999")).toBe(false);
+    });
+
+    it("does not run concurrently with an in-flight connect (issue #313)", async () => {
+      // A spawn holds the inFlightOps slot. The wrong-phone teardown must park
+      // on the lock instead of tearing down (and mutating connections) in
+      // parallel with the spawn.
+      let releaseConnect: () => void = () => {};
+      mockConnect.mockImplementationOnce(
+        () =>
+          new Promise<void>((res) => {
+            releaseConnect = res;
+          }),
+      );
+
+      const connectPromise = handler.connect("+5511999", defaultOptions);
+      await new Promise((r) => setImmediate(r));
+      await new Promise((r) => setImmediate(r));
+
+      const instance = mockConnectionInstances.get("+5511999")!;
+      mockLogout.mockClear();
+      instance.options.requestLogout();
+      await new Promise((r) => setImmediate(r));
+      await new Promise((r) => setImmediate(r));
+
+      // Parked on the lock: the connection's logout has NOT run yet.
+      expect(mockLogout).not.toHaveBeenCalled();
+
+      releaseConnect();
+      await connectPromise;
+      while (handler.hasConnection("+5511999")) {
+        await new Promise((r) => setImmediate(r));
+      }
+
+      // After serializing behind the spawn, the teardown ran exactly once.
+      expect(mockLogout).toHaveBeenCalledTimes(1);
+      expect(handler.hasConnection("+5511999")).toBe(false);
+    });
+
+    it("does not tear down a replacement that already took the slot", async () => {
+      // The old connection (the one that saw the wrong number) fires its
+      // teardown after a replacement has taken its place. The identity check
+      // must make it a no-op so the replacement (and the shared auth state it
+      // reuses) is left intact.
+      await handler.connect("+5511999", defaultOptions);
+      const oldInstance = mockConnectionInstances.get("+5511999")!;
+
+      // Force the recovery path so a replacement instance takes the slot.
+      mockSendPresenceUpdate.mockRejectedValueOnce(
+        new BaileysNotConnectedError(),
+      );
+      await handler.connect("+5511999", defaultOptions);
+      const newInstance = mockConnectionInstances.get("+5511999")!;
+      expect(newInstance).not.toBe(oldInstance);
+
+      mockLogout.mockClear();
+      // Old connection's wrong-phone teardown fires late.
+      oldInstance.options.requestLogout();
+      await new Promise((r) => setImmediate(r));
+      await new Promise((r) => setImmediate(r));
+
+      // No logout happened (neither old nor new); replacement still tracked.
+      expect(mockLogout).not.toHaveBeenCalled();
+      expect(handler.hasConnection("+5511999")).toBe(true);
+    });
+  });
+
   describe("#logoutAll", () => {
     it("calls logout on all connections and clears the handler", async () => {
       await handler.connect("+5511999", defaultOptions);

--- a/src/baileys/connectionsHandler.ts
+++ b/src/baileys/connectionsHandler.ts
@@ -19,6 +19,7 @@ import type {
   MessageKeyWithId,
   SendReceiptsOptions,
 } from "@/baileys/types";
+import { errorToString } from "@/helpers/errorToString";
 import logger from "@/lib/logger";
 
 type ConnectionFactory = (
@@ -163,6 +164,28 @@ export class BaileysConnectionsHandler {
             Object.keys(this.connections).length,
           );
           options.onConnectionClose?.();
+        },
+        requestLogout: () => {
+          // Wrong-phone teardown must serialize through inFlightOps so it
+          // can't race a concurrent connect/logout/discard for this number
+          // (issue #313). Mirror onConnectionClose's identity check: a
+          // replacement may already hold the slot, and only the instance that
+          // saw the wrong number should be torn down — logout() clears the
+          // shared auth state, which we must not wipe out from under a live
+          // replacement.
+          void this.withInFlightOp(phoneNumber, async () => {
+            if (this.connections[phoneNumber] !== connection) {
+              return;
+            }
+            await connection.logout();
+            delete this.connections[phoneNumber];
+          }).catch((error) => {
+            logger.error(
+              "[%s] [requestLogout] %s",
+              phoneNumber,
+              errorToString(error),
+            );
+          });
         },
       });
       this.connections[phoneNumber] = connection;

--- a/src/baileys/types.ts
+++ b/src/baileys/types.ts
@@ -20,6 +20,11 @@ export interface BaileysConnectionOptions {
   // read back from Redis (a re-read could pick up a successor's epoch).
   leaseEpoch?: number | null;
   onConnectionClose?: () => void;
+  // Invoked by the connection when it must tear itself down via the handler
+  // (wrong-phone-number teardown) so the logout participates in the handler's
+  // inFlightOps lock instead of bypassing it. Wired by the handler, mirroring
+  // onConnectionClose. See issue #313.
+  requestLogout?: () => void;
 }
 
 export interface BaileysConnectionWebhookPayload {


### PR DESCRIPTION
## Problem
`BaileysConnection.handleWrongPhoneNumber()` tore the connection down by calling `this.logout()` directly, outside the handler's `inFlightOps` lock. This let the teardown run concurrently with a connect/logout/discard/spawn for the same number — two sockets with the same identity and concurrent mutation of `connections[phoneNumber]`.

## Fix
Route the wrong-phone teardown through a `requestLogout` callback wired by the handler (mirroring `onConnectionClose`), which runs the logout inside `withInFlightOp` with an identity check (only tears down if the connection is still the registered one). Falls back to a direct `logout()` when no handler wired a callback.

- `types.ts`: add optional `requestLogout` to `BaileysConnectionOptions`
- `connection.ts`: use `requestLogout` in `handleWrongPhoneNumber`, fall back to direct logout
- `connectionsHandler.ts`: wire `requestLogout` in `spawnConnection` (inFlightOps + identity check)

## Tests
Regression tests in `connection.spec.ts` (delegates to `requestLogout` when wired; falls back otherwise) and `connectionsHandler.spec.ts` (serializes through the lock; no-op when a replacement holds the slot; doesn't race an in-flight connect). `bun check` green (lint + tsc + 407 tests).

Closes #313

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/baileys-api/345)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed race conditions between concurrent connect and logout operations for the same phone number
  * Improved wrong phone number handling with reliable connection teardown

* **New Features**
  * Added optional callback support for custom logout handler coordination

* **Improvements**
  * Enhanced error logging during connection logout operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->