### PR TITLE
feat: import extracted WhatsApp Web session without QR

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -7,27 +7,9 @@ import clusterController from "@/controllers/cluster";
 import connectionsController from "@/controllers/connections";
 import mediaController from "@/controllers/media";
 import statusController from "@/controllers/status";
+import { errorForLog } from "@/helpers/errorForLog";
 import { errorToString } from "@/helpers/errorToString";
 import logger, { deepSanitizeObject } from "@/lib/logger";
-
-// Validation errors can carry the rejected request VALUE in their message/stack
-// (Elysia surfaces the offending payload). For import-session that payload is
-// impersonation credentials, so never log the raw error for a VALIDATION code:
-// emit only which fields failed and the schema-derived reason, not the value.
-function errorForLog(code: string | number, error: unknown): string {
-  if (code !== "VALIDATION") {
-    return errorToString(error);
-  }
-  const all = (error as { all?: Array<{ path?: string; message?: string }> })
-    ?.all;
-  if (Array.isArray(all) && all.length > 0) {
-    const details = all
-      .map((e) => `${e.path ?? "?"} (${e.message ?? "invalid"})`)
-      .join("; ");
-    return `Validation failed: ${details}`;
-  }
-  return "Validation failed";
-}
 
 const app = new Elysia()
   .onAfterResponse(({ request, response, set }) => {

--- a/src/app.ts
+++ b/src/app.ts
@@ -10,6 +10,25 @@ import statusController from "@/controllers/status";
 import { errorToString } from "@/helpers/errorToString";
 import logger, { deepSanitizeObject } from "@/lib/logger";
 
+// Validation errors can carry the rejected request VALUE in their message/stack
+// (Elysia surfaces the offending payload). For import-session that payload is
+// impersonation credentials, so never log the raw error for a VALIDATION code:
+// emit only which fields failed and the schema-derived reason, not the value.
+function errorForLog(code: string | number, error: unknown): string {
+  if (code !== "VALIDATION") {
+    return errorToString(error);
+  }
+  const all = (error as { all?: Array<{ path?: string; message?: string }> })
+    ?.all;
+  if (Array.isArray(all) && all.length > 0) {
+    const details = all
+      .map((e) => `${e.path ?? "?"} (${e.message ?? "invalid"})`)
+      .join("; ");
+    return `Validation failed: ${details}`;
+  }
+  return "Validation failed";
+}
+
 const app = new Elysia()
   .onAfterResponse(({ request, response, set }) => {
     if (config.env === "development") {
@@ -32,7 +51,7 @@ const app = new Elysia()
     }
   })
   .onError(({ path, error, code }) => {
-    logger.error("%s\n%s", path, errorToString(error));
+    logger.error("%s\n%s", path, errorForLog(code, error));
     switch (code) {
       case "INTERNAL_SERVER_ERROR": {
         const message =

--- a/src/baileys/connection.spec.ts
+++ b/src/baileys/connection.spec.ts
@@ -737,6 +737,62 @@ describe("BaileysConnection", () => {
       ) as { index: number };
       expect(stored.index).toBe(12);
     });
+
+    // advanceImportCandidate hits Redis on every reconnect, not just imports.
+    // A transient Redis failure there must not strand the connection: the error
+    // is swallowed and the normal reconnect proceeds.
+    it("falls back to a normal reconnect when advanceImportCandidate throws", async () => {
+      const authKey = "@baileys-api:connections:+5511999999999:authState";
+      (redis as any).__hashData.set(
+        authKey,
+        new Map<string, string>([
+          ["creds", JSON.stringify({})],
+          [
+            "import-candidates",
+            JSON.stringify({
+              candidates: [
+                { private: "cA==", public: "cB==" },
+                { private: "cC==", public: "cD==" },
+              ],
+              index: 0,
+            }),
+          ],
+        ]),
+      );
+
+      await connection.connect();
+      const handler = mockEventHandlers.get("connection.update")!;
+      const baileys = (await import("@whiskeysockets/baileys")) as any;
+      const makeSocket = baileys.default as ReturnType<typeof mock>;
+      const socketsBefore = makeSocket.mock.calls.length;
+
+      // The next hGet is the import-candidates read inside
+      // advanceImportCandidate; make it blow up.
+      (redis.hGet as any).mockImplementationOnce(() =>
+        Promise.reject(new Error("redis down")),
+      );
+
+      await handler({
+        connection: "close" as const,
+        lastDisconnect: {
+          error: { output: { statusCode: 500, payload: {} }, message: "x" },
+        },
+      });
+      let stable = -1;
+      while (stable !== makeSocket.mock.calls.length) {
+        stable = makeSocket.mock.calls.length;
+        await new Promise((r) => setImmediate(r));
+      }
+
+      // Despite the Redis failure, a normal reconnect still happened (a new
+      // socket was created) rather than the connection being stranded.
+      expect(makeSocket.mock.calls.length).toBeGreaterThan(socketsBefore);
+      expect(
+        fetchCalls.some((c) =>
+          c.body?.includes('"error":"reconnect_loop_detected"'),
+        ),
+      ).toBe(false);
+    });
   });
 
   describe("#sendMessage", () => {

--- a/src/baileys/connection.spec.ts
+++ b/src/baileys/connection.spec.ts
@@ -676,6 +676,69 @@ describe("BaileysConnection", () => {
     });
   });
 
+  describe("import Noise candidate cycling", () => {
+    // A just-imported session cycles through its seeded Noise candidates when it
+    // closes before opening (only one candidate is the real key). That cycling
+    // is a bounded iteration, NOT a reconnect loop, so it must not count against
+    // the >10 reconnect-loop guard — otherwise a candidate list longer than the
+    // threshold aborts before the winning candidate (here index 12) is reached,
+    // and only a coordinator re-claim could resume it.
+    it("does not trip the reconnect-loop guard while cycling candidates past the threshold", async () => {
+      const authKey = "@baileys-api:connections:+5511999999999:authState";
+      const candidates = Array.from({ length: 13 }, (_, i) => ({
+        private: Buffer.from(`private-key-${i}`.padEnd(32, "0")).toString(
+          "base64",
+        ),
+        public: Buffer.from(`public-key-${i}`.padEnd(32, "0")).toString(
+          "base64",
+        ),
+      }));
+      (redis as any).__hashData.set(
+        authKey,
+        new Map<string, string>([
+          ["creds", JSON.stringify({})],
+          ["import-candidates", JSON.stringify({ candidates, index: 0 })],
+        ]),
+      );
+
+      await connection.connect();
+      const handler = mockEventHandlers.get("connection.update")!;
+      const baileys = (await import("@whiskeysockets/baileys")) as any;
+      const makeSocket = baileys.default as ReturnType<typeof mock>;
+
+      // Drive 12 close-before-open events → 12 candidate advances (cursor 0->12).
+      // Without the guard reset in the candidate-advance branch, the 11th advance
+      // would push reconnectCount past 10 and abort with reconnect_loop_detected.
+      for (let i = 0; i < 12; i++) {
+        await handler({
+          connection: "close" as const,
+          lastDisconnect: {
+            error: { output: { statusCode: 500, payload: {} }, message: "x" },
+          },
+        });
+        let stable = -1;
+        while (stable !== makeSocket.mock.calls.length) {
+          stable = makeSocket.mock.calls.length;
+          await new Promise((r) => setImmediate(r));
+        }
+      }
+
+      // The reconnect-loop guard must not have fired while cycling candidates.
+      expect(
+        fetchCalls.some((c) =>
+          c.body?.includes('"error":"reconnect_loop_detected"'),
+        ),
+      ).toBe(false);
+      // Auth state is preserved throughout (never destructively cleared).
+      expect((redis.del as any).mock.calls.length).toBe(0);
+      // The cursor advanced through every candidate we drove.
+      const stored = JSON.parse(
+        (redis as any).__hashData.get(authKey)!.get("import-candidates")!,
+      ) as { index: number };
+      expect(stored.index).toBe(12);
+    });
+  });
+
   describe("#sendMessage", () => {
     it("throws BaileysNotConnectedError if not connected", async () => {
       await expect(

--- a/src/baileys/connection.spec.ts
+++ b/src/baileys/connection.spec.ts
@@ -793,6 +793,63 @@ describe("BaileysConnection", () => {
         ),
       ).toBe(false);
     });
+
+    // A connectionReplaced kick is a legitimate takeover signal, not a wrong
+    // -candidate one. A not-yet-open imported session must yield to the lease
+    // owner instead of consuming a candidate and fighting the owner.
+    it("does not cycle a candidate on connectionReplaced; yields to the lease owner", async () => {
+      const authKey = "@baileys-api:connections:+5511999999999:authState";
+      const leaseKey = "@baileys-api:cluster:lease:+5511999999999";
+      const candidates = [
+        { private: "cGE=", public: "cWE=" },
+        { private: "cGI=", public: "cWI=" },
+      ];
+      (redis as any).__hashData.set(
+        authKey,
+        new Map<string, string>([
+          ["creds", JSON.stringify({})],
+          ["import-candidates", JSON.stringify({ candidates, index: 0 })],
+        ]),
+      );
+      // Lease owned by a live peer → the replaced kick is a legitimate takeover.
+      (redis as any).__stringData.set(
+        leaseKey,
+        JSON.stringify({ owner: "other-instance", epoch: 7 }),
+      );
+
+      await connection.connect();
+      const handler = mockEventHandlers.get("connection.update")!;
+      const makeSocket = ((await import("@whiskeysockets/baileys")) as any)
+        .default as ReturnType<typeof mock>;
+      let stable = -1;
+      while (stable !== makeSocket.mock.calls.length) {
+        stable = makeSocket.mock.calls.length;
+        await new Promise((r) => setImmediate(r));
+      }
+      const callsBefore = makeSocket.mock.calls.length;
+
+      await handler({
+        connection: "close" as const,
+        lastDisconnect: {
+          error: {
+            output: { statusCode: 440, payload: {} },
+            message: "Stream Errored (conflict)",
+          },
+        },
+      });
+      stable = -1;
+      while (stable !== makeSocket.mock.calls.length) {
+        stable = makeSocket.mock.calls.length;
+        await new Promise((r) => setImmediate(r));
+      }
+
+      // Yielded: no new socket spawned, and the candidate cursor was untouched.
+      expect(makeSocket.mock.calls.length).toBe(callsBefore);
+      const stored = JSON.parse(
+        (redis as any).__hashData.get(authKey)!.get("import-candidates")!,
+      ) as { index: number };
+      expect(stored.index).toBe(0);
+    });
   });
 
   describe("#sendMessage", () => {

--- a/src/baileys/connection.ts
+++ b/src/baileys/connection.ts
@@ -25,7 +25,12 @@ import { fetchBaileysClientVersion } from "@/baileys/helpers/fetchBaileysClientV
 import { normalizeBrazilPhoneNumber } from "@/baileys/helpers/normalizeBrazilPhoneNumber";
 import { preprocessAudio } from "@/baileys/helpers/preprocessAudio";
 import { shouldIgnoreJid } from "@/baileys/helpers/shouldIgnoreJid";
-import { useRedisAuthState, writeAuthMetadata } from "@/baileys/redisAuthState";
+import {
+  advanceImportCandidate,
+  clearImportCandidates,
+  useRedisAuthState,
+  writeAuthMetadata,
+} from "@/baileys/redisAuthState";
 import type {
   BaileysConnectionOptions,
   BaileysConnectionWebhookPayload,
@@ -140,6 +145,10 @@ export class BaileysConnection {
   private reconnectCount = 0;
   private connectionReplacedTimestamps: number[] = [];
   private isDiscarded = false;
+  // Tracks whether this connection ever reached `open`. Imported sessions cycle
+  // Noise candidates only while they have never opened; a close after opening
+  // is a normal disconnect, not a wrong-key handshake failure.
+  private hasOpened = false;
   private _inFlightWebhooks = 0;
   private leaseEpoch: number | null = null;
   // Monotonic timestamp of the last message-level traffic (received message,
@@ -848,6 +857,30 @@ export class BaileysConnection {
         message !== "QR refs attempts ended";
 
       if (shouldReconnect) {
+        // Imported session with a wrong Noise candidate: the handshake fails
+        // and the socket closes before ever opening. Advance to the next
+        // candidate (re-seeding creds) and reconnect, until one works or the
+        // list is exhausted. A no-op for any connection with no candidates
+        // seeded (i.e. everything but a just-imported session).
+        if (
+          !this.hasOpened &&
+          (await advanceImportCandidate(this.phoneNumber))
+        ) {
+          logger.info(
+            "[%s] [handleConnectionUpdate] imported session closed before open; trying next Noise candidate",
+            this.phoneNumber,
+          );
+          // Cycling Noise candidates is a bounded iteration (advanceImportCandidate
+          // returns false once the list is exhausted), not a reconnect loop, so it
+          // must not count against the reconnect-loop guard. Without this reset a
+          // list longer than the guard threshold (10) aborts before reaching a
+          // candidate past that index, and only a coordinator re-claim can resume it.
+          this.reconnectCount = 0;
+          await this.handleReconnecting();
+          this.socket = null;
+          this.connect();
+          return;
+        }
         // Distributed fence: a conflict/replaced kick may mean another
         // instance legitimately took this identity over (its lease says so).
         // Yield instead of stealing the connection back — the in-memory
@@ -912,6 +945,9 @@ export class BaileysConnection {
 
     if (data.connection === "open") {
       this.reconnectCount = 0;
+      this.hasOpened = true;
+      // Healthy session — stop cycling Noise candidates on future reconnects.
+      void clearImportCandidates(this.phoneNumber);
       this.startGroupActivityFlush();
     }
 

--- a/src/baileys/connection.ts
+++ b/src/baileys/connection.ts
@@ -868,8 +868,16 @@ export class BaileysConnection {
         // rejection would propagate out of the withErrorHandling wrapper and
         // skip the normal reconnect below, stranding the connection. Swallow
         // it and fall through to the standard reconnect path instead.
+        //
+        // A connectionReplaced kick is NOT a wrong-Noise-candidate signal: it
+        // means another instance may legitimately own this identity. Exclude it
+        // so it falls through to the shouldYieldToLeaseOwner fence below instead
+        // of consuming candidates and fighting the owner until the list runs out.
         let advancedCandidate = false;
-        if (!this.hasOpened) {
+        if (
+          !this.hasOpened &&
+          statusCode !== DisconnectReason.connectionReplaced
+        ) {
           try {
             advancedCandidate = await advanceImportCandidate(this.phoneNumber);
           } catch (candidateError) {

--- a/src/baileys/connection.ts
+++ b/src/baileys/connection.ts
@@ -960,19 +960,23 @@ export class BaileysConnection {
 
     if (data.connection === "open") {
       this.reconnectCount = 0;
+      const isFirstOpen = !this.hasOpened;
       this.hasOpened = true;
-      // Healthy session — stop cycling Noise candidates on future reconnects.
-      // Not awaited (the open path must not block on it), but the rejection is
-      // handled so a Redis failure surfaces in logs instead of an unhandled
-      // rejection, leaving a stale cursor that a later reconnect would ignore
-      // anyway because hasOpened is now true.
-      clearImportCandidates(this.phoneNumber).catch((clearError) => {
-        logger.warn(
-          "[%s] [handleConnectionUpdate] clearImportCandidates failed; stale import cursor may remain (error=%s)",
-          this.phoneNumber,
-          errorToString(clearError),
-        );
-      });
+      if (isFirstOpen) {
+        // First healthy open — stop cycling Noise candidates on future
+        // reconnects. Gated to the first open so later reconnects don't repeat
+        // the fenced Redis write; a stale cursor is already harmless once
+        // hasOpened is true. Not awaited (the open path must not block on it),
+        // but the rejection is handled so a Redis failure surfaces in logs
+        // instead of an unhandled rejection.
+        clearImportCandidates(this.phoneNumber).catch((clearError) => {
+          logger.warn(
+            "[%s] [handleConnectionUpdate] clearImportCandidates failed; stale import cursor may remain (error=%s)",
+            this.phoneNumber,
+            errorToString(clearError),
+          );
+        });
+      }
       this.startGroupActivityFlush();
     }
 

--- a/src/baileys/connection.ts
+++ b/src/baileys/connection.ts
@@ -862,10 +862,25 @@ export class BaileysConnection {
         // candidate (re-seeding creds) and reconnect, until one works or the
         // list is exhausted. A no-op for any connection with no candidates
         // seeded (i.e. everything but a just-imported session).
-        if (
-          !this.hasOpened &&
-          (await advanceImportCandidate(this.phoneNumber))
-        ) {
+        //
+        // Guarded: advanceImportCandidate hits Redis on every reconnect (not
+        // just imports). If that call throws (transient Redis failure) the
+        // rejection would propagate out of the withErrorHandling wrapper and
+        // skip the normal reconnect below, stranding the connection. Swallow
+        // it and fall through to the standard reconnect path instead.
+        let advancedCandidate = false;
+        if (!this.hasOpened) {
+          try {
+            advancedCandidate = await advanceImportCandidate(this.phoneNumber);
+          } catch (candidateError) {
+            logger.warn(
+              "[%s] [handleConnectionUpdate] advanceImportCandidate failed; falling back to normal reconnect (error=%s)",
+              this.phoneNumber,
+              errorToString(candidateError),
+            );
+          }
+        }
+        if (advancedCandidate) {
           logger.info(
             "[%s] [handleConnectionUpdate] imported session closed before open; trying next Noise candidate",
             this.phoneNumber,
@@ -947,7 +962,17 @@ export class BaileysConnection {
       this.reconnectCount = 0;
       this.hasOpened = true;
       // Healthy session — stop cycling Noise candidates on future reconnects.
-      void clearImportCandidates(this.phoneNumber);
+      // Not awaited (the open path must not block on it), but the rejection is
+      // handled so a Redis failure surfaces in logs instead of an unhandled
+      // rejection, leaving a stale cursor that a later reconnect would ignore
+      // anyway because hasOpened is now true.
+      clearImportCandidates(this.phoneNumber).catch((clearError) => {
+        logger.warn(
+          "[%s] [handleConnectionUpdate] clearImportCandidates failed; stale import cursor may remain (error=%s)",
+          this.phoneNumber,
+          errorToString(clearError),
+        );
+      });
       this.startGroupActivityFlush();
     }
 

--- a/src/baileys/connectionsHandler.spec.ts
+++ b/src/baileys/connectionsHandler.spec.ts
@@ -291,6 +291,27 @@ describe("BaileysConnectionsHandler", () => {
       expect(mockConnect).not.toHaveBeenCalled();
     });
 
+    it("forceRestart discards a live connection and spawns a fresh one", async () => {
+      // An import re-seeds creds in Redis; a reused in-memory socket (e.g. one
+      // still emitting QRs) would ignore them, so forceRestart must replace it.
+      await handler.connect("+5511999", defaultOptions);
+      mockConnect.mockClear();
+      mockDiscard.mockClear();
+      mockSendPresenceUpdate.mockClear();
+      mockUpdateOptions.mockClear();
+
+      await handler.connect("+5511999", {
+        ...defaultOptions,
+        forceRestart: true,
+      });
+
+      // Old socket torn down, brand-new one spawned, no reuse via presence.
+      expect(mockDiscard).toHaveBeenCalledTimes(1);
+      expect(mockConnect).toHaveBeenCalledTimes(1);
+      expect(mockSendPresenceUpdate).not.toHaveBeenCalled();
+      expect(mockUpdateOptions).not.toHaveBeenCalled();
+    });
+
     it("handles inconsistent connection state when sendPresenceUpdate throws BaileysNotConnectedError", async () => {
       await handler.connect("+5511999", defaultOptions);
       mockConnect.mockClear();

--- a/src/baileys/connectionsHandler.ts
+++ b/src/baileys/connectionsHandler.ts
@@ -195,6 +195,13 @@ export class BaileysConnectionsHandler {
       if (existing && forceRestart) {
         existing.discard();
         delete this.connections[phoneNumber];
+        // Keep shutdown-drain accounting exactly like discardConnection: a
+        // discarded connection with pending webhook deliveries (e.g. a QR
+        // socket mid-retry) must stay counted so a graceful shutdown waits for
+        // them instead of exiting mid-delivery.
+        if (existing.inFlightWebhooks > 0) {
+          this.drainingWebhooks.add(existing);
+        }
         await this.spawnConnection(phoneNumber, connectOptions);
         return;
       }

--- a/src/baileys/connectionsHandler.ts
+++ b/src/baileys/connectionsHandler.ts
@@ -181,18 +181,30 @@ export class BaileysConnectionsHandler {
     //      replacement (two callers hitting the same stale connection would
     //      otherwise both spawn parallel sockets with the same identity).
     //   3. Otherwise spawn a new connection.
+    const { forceRestart, ...connectOptions } = options;
     for (;;) {
       while (this.inFlightOps[phoneNumber]) {
         await this.inFlightOps[phoneNumber].catch(() => {});
       }
 
       const existing = this.connections[phoneNumber];
-      if (!existing) {
-        await this.spawnConnection(phoneNumber, options);
+
+      // A just-seeded import/takeover must run on a fresh socket: an existing one
+      // holds stale in-memory creds and would ignore the transplanted session
+      // (e.g. a QR socket keeps emitting QRs). Discard it, then spawn anew.
+      if (existing && forceRestart) {
+        existing.discard();
+        delete this.connections[phoneNumber];
+        await this.spawnConnection(phoneNumber, connectOptions);
         return;
       }
 
-      await existing.updateOptions(options);
+      if (!existing) {
+        await this.spawnConnection(phoneNumber, connectOptions);
+        return;
+      }
+
+      await existing.updateOptions(connectOptions);
       try {
         // NOTE: This triggers a `connection.update` event.
         await existing.sendPresenceUpdate("available");

--- a/src/baileys/importSession.spec.ts
+++ b/src/baileys/importSession.spec.ts
@@ -53,13 +53,15 @@ describe("mapSessionToCreds", () => {
     );
   });
 
-  it("marks the session as registered and sets me", () => {
+  it("marks the session as registered and sets me with a normalized @lid", () => {
     const creds = mapSessionToCreds(baseSession());
     expect(creds.registered).toBe(true);
+    // me.lid is normalized to the @lid domain (like signalIdentities), not left
+    // as the raw @s.whatsapp.net JID the extractor hands over.
     expect(creds.me).toEqual({
       id: "551101234567:12@s.whatsapp.net",
       name: "Alice",
-      lid: "551101234567@s.whatsapp.net",
+      lid: "551101234567@lid",
     });
   });
 

--- a/src/baileys/importSession.spec.ts
+++ b/src/baileys/importSession.spec.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "bun:test";
+import {
+  type ExtractedSession,
+  InvalidNoiseCandidateError,
+  mapSessionToCreds,
+} from "./importSession";
+
+const b64 = (s: string) => Buffer.from(s).toString("base64");
+
+const baseSession = (): ExtractedSession => ({
+  noiseCandidates: [
+    { private: b64("noise-priv-0"), public: b64("noise-pub-0") },
+    { private: b64("noise-priv-1"), public: b64("noise-pub-1") },
+  ],
+  identityKey: { private: b64("id-priv"), public: b64("id-pub") },
+  registrationId: 42,
+  advSecretKey: b64("adv-secret"),
+  account: {
+    details: b64("acc-details"),
+    accountSignatureKey: b64("acc-sig-key"),
+    accountSignature: b64("acc-sig"),
+    deviceSignature: b64("dev-sig"),
+  },
+  id: "551101234567:12@s.whatsapp.net",
+  lid: "551101234567@s.whatsapp.net",
+  platform: "android",
+  signedPreKey: {
+    keyId: 7,
+    private: b64("spk-priv"),
+    public: b64("spk-pub"),
+    signature: b64("spk-sig"),
+  },
+  pushName: "Alice",
+});
+
+describe("mapSessionToCreds", () => {
+  it("maps base64 keypairs to Buffers", () => {
+    const creds = mapSessionToCreds(baseSession());
+    expect(creds.noiseKey.private).toEqual(Buffer.from("noise-priv-0"));
+    expect(creds.noiseKey.public).toEqual(Buffer.from("noise-pub-0"));
+    expect(creds.signedIdentityKey.private).toEqual(Buffer.from("id-priv"));
+    expect(creds.signedIdentityKey.public).toEqual(Buffer.from("id-pub"));
+  });
+
+  it("selects the requested noise candidate", () => {
+    const creds = mapSessionToCreds(baseSession(), 1);
+    expect(creds.noiseKey.private).toEqual(Buffer.from("noise-priv-1"));
+  });
+
+  it("throws when the candidate index is out of range", () => {
+    expect(() => mapSessionToCreds(baseSession(), 5)).toThrow(
+      InvalidNoiseCandidateError,
+    );
+  });
+
+  it("marks the session as registered and sets me", () => {
+    const creds = mapSessionToCreds(baseSession());
+    expect(creds.registered).toBe(true);
+    expect(creds.me).toEqual({
+      id: "551101234567:12@s.whatsapp.net",
+      name: "Alice",
+      lid: "551101234567@s.whatsapp.net",
+    });
+  });
+
+  it("passes advSecretKey through as a base64 string, not a Buffer", () => {
+    const creds = mapSessionToCreds(baseSession());
+    expect(creds.advSecretKey).toBe(b64("adv-secret"));
+  });
+
+  it("maps the ADV signed device identity fields to Buffers", () => {
+    const creds = mapSessionToCreds(baseSession());
+    expect(creds.account?.details).toEqual(Buffer.from("acc-details"));
+    expect(creds.account?.accountSignatureKey).toEqual(
+      Buffer.from("acc-sig-key"),
+    );
+    expect(creds.account?.accountSignature).toEqual(Buffer.from("acc-sig"));
+    expect(creds.account?.deviceSignature).toEqual(Buffer.from("dev-sig"));
+  });
+
+  it("builds the self signalIdentity from lid with the 0x05 prefix", () => {
+    const creds = mapSessionToCreds(baseSession());
+    expect(creds.signalIdentities).toHaveLength(1);
+    const identity = creds.signalIdentities![0];
+    expect(identity.identifier).toEqual({
+      name: "551101234567@lid",
+      deviceId: 0,
+    });
+    expect(identity.identifierKey).toEqual(
+      Buffer.concat([Buffer.from([5]), Buffer.from("acc-sig-key")]),
+    );
+  });
+
+  it("omits signalIdentities when there is no lid", () => {
+    const session = { ...baseSession(), lid: undefined };
+    const creds = mapSessionToCreds(session);
+    expect(creds.signalIdentities).toEqual([]);
+  });
+
+  it("maps a nested signedPreKey when present", () => {
+    const creds = mapSessionToCreds(baseSession());
+    expect(creds.signedPreKey.keyId).toBe(7);
+    expect(creds.signedPreKey.keyPair.private).toEqual(Buffer.from("spk-priv"));
+    expect(creds.signedPreKey.signature).toEqual(Buffer.from("spk-sig"));
+  });
+
+  it("falls back to the default signedPreKey when omitted", () => {
+    const session = { ...baseSession(), signedPreKey: undefined };
+    const creds = mapSessionToCreds(session);
+    // The provided key (keyId 7) must not be used; initAuthCreds' default is.
+    expect(creds.signedPreKey.keyId).not.toBe(7);
+    expect(creds.signedPreKey.keyPair).toBeDefined();
+  });
+
+  it("maps routingInfo to a Buffer only when present", () => {
+    const withRouting = mapSessionToCreds({
+      ...baseSession(),
+      routingInfo: b64("route"),
+    });
+    expect(withRouting.routingInfo).toEqual(Buffer.from("route"));
+    const withoutRouting = mapSessionToCreds(baseSession());
+    expect(withoutRouting.routingInfo).toBeUndefined();
+  });
+});

--- a/src/baileys/importSession.ts
+++ b/src/baileys/importSession.ts
@@ -76,19 +76,28 @@ export function mapSessionToCreds(
 
   const base = initAuthCreds();
 
-  const signalIdentities: AuthenticationCreds["signalIdentities"] = session.lid
-    ? [
-        {
-          identifier: {
-            name: session.lid.replace("@s.whatsapp.net", "@lid"),
-            deviceId: 0,
+  // The extractor hands the LID over as a `@s.whatsapp.net` JID, but Baileys
+  // addresses linked identities on the `@lid` domain. Normalize once and use
+  // the same value for both signalIdentities and me.lid so downstream identity
+  // and LID lookups stay consistent (they must resolve to the same JID).
+  const normalizedLid = session.lid
+    ? session.lid.replace("@s.whatsapp.net", "@lid")
+    : undefined;
+
+  const signalIdentities: AuthenticationCreds["signalIdentities"] =
+    normalizedLid
+      ? [
+          {
+            identifier: {
+              name: normalizedLid,
+              deviceId: 0,
+            },
+            identifierKey: toSignalIdentityKey(
+              session.account.accountSignatureKey,
+            ),
           },
-          identifierKey: toSignalIdentityKey(
-            session.account.accountSignatureKey,
-          ),
-        },
-      ]
-    : [];
+        ]
+      : [];
 
   return {
     ...base,
@@ -112,7 +121,7 @@ export function mapSessionToCreds(
     me: {
       id: session.id,
       name: session.pushName ?? undefined,
-      lid: session.lid ?? undefined,
+      lid: normalizedLid,
     },
     signalIdentities,
     platform: session.platform ?? undefined,

--- a/src/baileys/importSession.ts
+++ b/src/baileys/importSession.ts
@@ -1,0 +1,124 @@
+import {
+  type AuthenticationCreds,
+  initAuthCreds,
+} from "@whiskeysockets/baileys";
+
+// Shape produced by the browser extension's WhatsApp Web session extractor
+// (a fork of whatsapp-session-extractor). Every binary field is a base64
+// string. `advSecretKey` is base64 too but stays a string in creds — never a
+// Buffer — matching what initAuthCreds() produces.
+//
+// The Noise keypair cannot be resolved to a single value on the extractor
+// side: the HKDF + IV combinations yield several candidates and only one is
+// the real private->public pair. The client picks the right one by connecting;
+// see the candidate-cycling logic in the connection handler.
+export interface ExtractedSession {
+  noiseCandidates: { private: string; public: string }[];
+  identityKey: { private: string; public: string };
+  registrationId: number;
+  advSecretKey: string;
+  account: {
+    details: string;
+    accountSignatureKey: string;
+    accountSignature: string;
+    deviceSignature: string;
+  };
+  id: string;
+  lid?: string | null;
+  platform?: string | null;
+  signedPreKey?: {
+    keyId: number;
+    private: string;
+    public: string;
+    signature: string;
+  } | null;
+  pushName?: string | null;
+  routingInfo?: string | null;
+}
+
+export class InvalidNoiseCandidateError extends Error {}
+
+const toBuffer = (value: string) => Buffer.from(value, "base64");
+
+const toKeyPair = (kp: { private: string; public: string }) => ({
+  private: toBuffer(kp.private),
+  public: toBuffer(kp.public),
+});
+
+// The Signal wire format prefixes a raw curve25519 public key with the 0x05
+// type byte. `account.accountSignatureKey` is the raw key; the companion's own
+// signalIdentity records it prefixed.
+const toSignalIdentityKey = (accountSignatureKeyB64: string) =>
+  Buffer.concat([Buffer.from([5]), toBuffer(accountSignatureKeyB64)]);
+
+// Maps an extracted WhatsApp Web session to Baileys AuthenticationCreds.
+//
+// Starts from initAuthCreds() so runtime-only fields (pre-key counters,
+// accountSettings, a well-typed pairingEphemeralKeyPair, ...) get valid
+// defaults, then overlays the transplanted identity. Because `me.id` is set
+// and `registered` is true, the socket resumes as an already-linked companion
+// and never emits a QR.
+//
+// The field mapping mirrors the whatsapp-session-extractor reference, which is
+// the empirically-validated shape (notably: advSecretKey <- WANoiseInfo
+// recoveryToken, account <- adv_signed_identity, signedPreKey is a nested
+// SignedKeyPair). Validate end-to-end on a test number before relying on it.
+export function mapSessionToCreds(
+  session: ExtractedSession,
+  candidateIndex = 0,
+): AuthenticationCreds {
+  const candidate = session.noiseCandidates[candidateIndex];
+  if (!candidate) {
+    throw new InvalidNoiseCandidateError(
+      `noise candidate index ${candidateIndex} out of range (have ${session.noiseCandidates.length})`,
+    );
+  }
+
+  const base = initAuthCreds();
+
+  const signalIdentities: AuthenticationCreds["signalIdentities"] = session.lid
+    ? [
+        {
+          identifier: {
+            name: session.lid.replace("@s.whatsapp.net", "@lid"),
+            deviceId: 0,
+          },
+          identifierKey: toSignalIdentityKey(
+            session.account.accountSignatureKey,
+          ),
+        },
+      ]
+    : [];
+
+  return {
+    ...base,
+    noiseKey: toKeyPair(candidate),
+    signedIdentityKey: toKeyPair(session.identityKey),
+    signedPreKey: session.signedPreKey
+      ? {
+          keyId: session.signedPreKey.keyId,
+          keyPair: toKeyPair(session.signedPreKey),
+          signature: toBuffer(session.signedPreKey.signature),
+        }
+      : base.signedPreKey,
+    registrationId: session.registrationId,
+    advSecretKey: session.advSecretKey,
+    account: {
+      details: toBuffer(session.account.details),
+      accountSignatureKey: toBuffer(session.account.accountSignatureKey),
+      accountSignature: toBuffer(session.account.accountSignature),
+      deviceSignature: toBuffer(session.account.deviceSignature),
+    },
+    me: {
+      id: session.id,
+      name: session.pushName ?? undefined,
+      lid: session.lid ?? undefined,
+    },
+    signalIdentities,
+    platform: session.platform ?? undefined,
+    routingInfo: session.routingInfo
+      ? toBuffer(session.routingInfo)
+      : undefined,
+    registered: true,
+  };
+}

--- a/src/baileys/redisAuthState.spec.ts
+++ b/src/baileys/redisAuthState.spec.ts
@@ -327,6 +327,14 @@ describe("import candidate cycling", () => {
     mockRedisData.set(authKey(phone), new Map(Object.entries(fields)));
   };
 
+  const mockStringData = (redis as any).__stringData as Map<string, string>;
+  const setLease = (phone: string, owner: string) => {
+    mockStringData.set(
+      `@baileys-api:cluster:lease:${phone}`,
+      JSON.stringify({ owner, epoch: 1 }),
+    );
+  };
+
   it("advanceImportCandidate swaps the noiseKey and bumps the cursor", async () => {
     setHash("adv-phone", {
       creds: JSON.stringify({ noiseKey: { private: "OLD" }, me: { id: "x" } }),
@@ -364,6 +372,47 @@ describe("import candidate cycling", () => {
     expect(await advanceImportCandidate("no-import-phone")).toBe(false);
   });
 
+  it("advanceImportCandidate writes when this instance owns the lease", async () => {
+    setHash("adv-owned", {
+      creds: JSON.stringify({ noiseKey: { private: "OLD" }, me: { id: "x" } }),
+      "import-candidates": JSON.stringify({
+        candidates: [
+          { private: "p0", public: "q0" },
+          { private: "p1", public: "q1" },
+        ],
+        index: 0,
+      }),
+    });
+    setLease("adv-owned", "test-instance");
+
+    expect(await advanceImportCandidate("adv-owned")).toBe(true);
+    expect(
+      JSON.parse(
+        mockRedisData.get(authKey("adv-owned"))!.get("import-candidates")!,
+      ).index,
+    ).toBe(1);
+  });
+
+  it("advanceImportCandidate is fenced off when another instance owns the lease", async () => {
+    setHash("adv-fenced", {
+      creds: JSON.stringify({ noiseKey: { private: "OLD" }, me: { id: "x" } }),
+      "import-candidates": JSON.stringify({
+        candidates: [
+          { private: "p0", public: "q0" },
+          { private: "p1", public: "q1" },
+        ],
+        index: 0,
+      }),
+    });
+    setLease("adv-fenced", "someone-else");
+
+    expect(await advanceImportCandidate("adv-fenced")).toBe(false);
+    // A fenced-off advance moves neither the cursor nor the noiseKey.
+    const hash = mockRedisData.get(authKey("adv-fenced"))!;
+    expect(JSON.parse(hash.get("import-candidates")!).index).toBe(0);
+    expect(JSON.parse(hash.get("creds")!).noiseKey.private).toBe("OLD");
+  });
+
   it("clearImportCandidates removes the cursor", async () => {
     setHash("clear-phone", {
       creds: JSON.stringify({ noiseKey: {} }),
@@ -375,6 +424,20 @@ describe("import candidate cycling", () => {
     expect(
       mockRedisData.get(authKey("clear-phone"))?.get("import-candidates"),
     ).toBeUndefined();
+  });
+
+  it("clearImportCandidates is fenced off when another instance owns the lease", async () => {
+    setHash("clear-fenced", {
+      creds: JSON.stringify({ noiseKey: {} }),
+      "import-candidates": JSON.stringify({ candidates: [], index: 0 }),
+    });
+    setLease("clear-fenced", "someone-else");
+
+    expect(await clearImportCandidates("clear-fenced")).toBe(false);
+    // The cursor survives a fenced-off clear.
+    expect(
+      mockRedisData.get(authKey("clear-fenced"))?.get("import-candidates"),
+    ).toBeDefined();
   });
 });
 

--- a/src/baileys/redisAuthState.spec.ts
+++ b/src/baileys/redisAuthState.spec.ts
@@ -2,8 +2,12 @@ import { beforeEach, describe, expect, it } from "bun:test";
 import { initAuthCreds } from "@whiskeysockets/baileys";
 import redis from "@/lib/redis";
 import {
+  advanceImportCandidate,
+  clearImportCandidates,
   getRedisSavedAuthStateIds,
   isRedisAuthStatePaired,
+  seedImportCandidates,
+  seedRedisAuthCreds,
   useRedisAuthState,
 } from "./redisAuthState";
 
@@ -247,6 +251,130 @@ describe("useRedisAuthState", () => {
       );
       expect(hash?.get("creds")).toBeDefined();
     });
+  });
+});
+
+describe("seedRedisAuthCreds", () => {
+  const mockStringData = (redis as any).__stringData as Map<string, string>;
+
+  it("writes the creds field when no lease exists", async () => {
+    const ok = await seedRedisAuthCreds("seed-phone", initAuthCreds());
+
+    expect(ok).toBe(true);
+    expect(
+      mockRedisData
+        .get("@baileys-api:connections:seed-phone:authState")
+        ?.get("creds"),
+    ).toBeDefined();
+  });
+
+  it("writes when this instance owns the lease", async () => {
+    mockStringData.set(
+      "@baileys-api:cluster:lease:seed-owned-phone",
+      JSON.stringify({ owner: "test-instance", epoch: 1 }),
+    );
+
+    const ok = await seedRedisAuthCreds("seed-owned-phone", initAuthCreds());
+
+    expect(ok).toBe(true);
+    expect(
+      mockRedisData
+        .get("@baileys-api:connections:seed-owned-phone:authState")
+        ?.get("creds"),
+    ).toBeDefined();
+  });
+
+  it("is fenced off (false, no write) when the lease is owned elsewhere", async () => {
+    mockStringData.set(
+      "@baileys-api:cluster:lease:seed-fenced-phone",
+      JSON.stringify({ owner: "someone-else", epoch: 2 }),
+    );
+
+    const ok = await seedRedisAuthCreds("seed-fenced-phone", initAuthCreds());
+
+    expect(ok).toBe(false);
+    expect(
+      mockRedisData
+        .get("@baileys-api:connections:seed-fenced-phone:authState")
+        ?.get("creds"),
+    ).toBeUndefined();
+  });
+});
+
+describe("import candidate cycling", () => {
+  const authKey = (phone: string) =>
+    `@baileys-api:connections:${phone}:authState`;
+
+  const setHash = (phone: string, fields: Record<string, string>) => {
+    mockRedisData.set(authKey(phone), new Map(Object.entries(fields)));
+  };
+
+  it("seedImportCandidates stores the candidate list and cursor", async () => {
+    const ok = await seedImportCandidates(
+      "cand-phone",
+      [{ private: "a", public: "b" }],
+      0,
+    );
+
+    expect(ok).toBe(true);
+    const stored = mockRedisData
+      .get(authKey("cand-phone"))
+      ?.get("import-candidates");
+    expect(stored).toBeDefined();
+    expect(JSON.parse(stored as string)).toEqual({
+      candidates: [{ private: "a", public: "b" }],
+      index: 0,
+    });
+  });
+
+  it("advanceImportCandidate swaps the noiseKey and bumps the cursor", async () => {
+    setHash("adv-phone", {
+      creds: JSON.stringify({ noiseKey: { private: "OLD" }, me: { id: "x" } }),
+      "import-candidates": JSON.stringify({
+        candidates: [
+          { private: "p0", public: "q0" },
+          { private: "p1", public: "q1" },
+        ],
+        index: 0,
+      }),
+    });
+
+    const advanced = await advanceImportCandidate("adv-phone");
+
+    expect(advanced).toBe(true);
+    const hash = mockRedisData.get(authKey("adv-phone"))!;
+    expect(JSON.parse(hash.get("import-candidates")!).index).toBe(1);
+    // The old candidate's noiseKey must have been replaced.
+    expect(JSON.parse(hash.get("creds")!).noiseKey.private).not.toBe("OLD");
+  });
+
+  it("advanceImportCandidate returns false when the candidates are exhausted", async () => {
+    setHash("exhaust-phone", {
+      creds: JSON.stringify({ noiseKey: {} }),
+      "import-candidates": JSON.stringify({
+        candidates: [{ private: "only", public: "only" }],
+        index: 0,
+      }),
+    });
+
+    expect(await advanceImportCandidate("exhaust-phone")).toBe(false);
+  });
+
+  it("advanceImportCandidate returns false when nothing was seeded", async () => {
+    expect(await advanceImportCandidate("no-import-phone")).toBe(false);
+  });
+
+  it("clearImportCandidates removes the cursor", async () => {
+    setHash("clear-phone", {
+      creds: JSON.stringify({ noiseKey: {} }),
+      "import-candidates": JSON.stringify({ candidates: [], index: 0 }),
+    });
+
+    await clearImportCandidates("clear-phone");
+
+    expect(
+      mockRedisData.get(authKey("clear-phone"))?.get("import-candidates"),
+    ).toBeUndefined();
   });
 });
 

--- a/src/baileys/redisAuthState.spec.ts
+++ b/src/baileys/redisAuthState.spec.ts
@@ -6,8 +6,7 @@ import {
   clearImportCandidates,
   getRedisSavedAuthStateIds,
   isRedisAuthStatePaired,
-  seedImportCandidates,
-  seedRedisAuthCreds,
+  seedImportedSession,
   useRedisAuthState,
 } from "./redisAuthState";
 
@@ -254,18 +253,27 @@ describe("useRedisAuthState", () => {
   });
 });
 
-describe("seedRedisAuthCreds", () => {
+describe("seedImportedSession", () => {
   const mockStringData = (redis as any).__stringData as Map<string, string>;
+  const candidates = [{ private: "a", public: "b" }];
 
-  it("writes the creds field when no lease exists", async () => {
-    const ok = await seedRedisAuthCreds("seed-phone", initAuthCreds());
+  it("writes creds + candidate cursor together when no lease exists", async () => {
+    const ok = await seedImportedSession(
+      "seed-phone",
+      initAuthCreds(),
+      candidates,
+      0,
+    );
 
     expect(ok).toBe(true);
-    expect(
-      mockRedisData
-        .get("@baileys-api:connections:seed-phone:authState")
-        ?.get("creds"),
-    ).toBeDefined();
+    const hash = mockRedisData.get(
+      "@baileys-api:connections:seed-phone:authState",
+    );
+    expect(hash?.get("creds")).toBeDefined();
+    expect(JSON.parse(hash?.get("import-candidates") as string)).toEqual({
+      candidates,
+      index: 0,
+    });
   });
 
   it("writes when this instance owns the lease", async () => {
@@ -274,7 +282,12 @@ describe("seedRedisAuthCreds", () => {
       JSON.stringify({ owner: "test-instance", epoch: 1 }),
     );
 
-    const ok = await seedRedisAuthCreds("seed-owned-phone", initAuthCreds());
+    const ok = await seedImportedSession(
+      "seed-owned-phone",
+      initAuthCreds(),
+      candidates,
+      0,
+    );
 
     expect(ok).toBe(true);
     expect(
@@ -290,7 +303,12 @@ describe("seedRedisAuthCreds", () => {
       JSON.stringify({ owner: "someone-else", epoch: 2 }),
     );
 
-    const ok = await seedRedisAuthCreds("seed-fenced-phone", initAuthCreds());
+    const ok = await seedImportedSession(
+      "seed-fenced-phone",
+      initAuthCreds(),
+      candidates,
+      0,
+    );
 
     expect(ok).toBe(false);
     expect(
@@ -308,24 +326,6 @@ describe("import candidate cycling", () => {
   const setHash = (phone: string, fields: Record<string, string>) => {
     mockRedisData.set(authKey(phone), new Map(Object.entries(fields)));
   };
-
-  it("seedImportCandidates stores the candidate list and cursor", async () => {
-    const ok = await seedImportCandidates(
-      "cand-phone",
-      [{ private: "a", public: "b" }],
-      0,
-    );
-
-    expect(ok).toBe(true);
-    const stored = mockRedisData
-      .get(authKey("cand-phone"))
-      ?.get("import-candidates");
-    expect(stored).toBeDefined();
-    expect(JSON.parse(stored as string)).toEqual({
-      candidates: [{ private: "a", public: "b" }],
-      index: 0,
-    });
-  });
 
   it("advanceImportCandidate swaps the noiseKey and bumps the cursor", async () => {
     setHash("adv-phone", {

--- a/src/baileys/redisAuthState.spec.ts
+++ b/src/baileys/redisAuthState.spec.ts
@@ -290,11 +290,15 @@ describe("seedImportedSession", () => {
     );
 
     expect(ok).toBe(true);
-    expect(
-      mockRedisData
-        .get("@baileys-api:connections:seed-owned-phone:authState")
-        ?.get("creds"),
-    ).toBeDefined();
+    const hash = mockRedisData.get(
+      "@baileys-api:connections:seed-owned-phone:authState",
+    );
+    expect(hash?.get("creds")).toBeDefined();
+    // The candidate cursor is part of the same atomic write, not just creds.
+    expect(JSON.parse(hash?.get("import-candidates") as string)).toEqual({
+      candidates,
+      index: 0,
+    });
   });
 
   it("is fenced off (false, no write) when the lease is owned elsewhere", async () => {

--- a/src/baileys/redisAuthState.ts
+++ b/src/baileys/redisAuthState.ts
@@ -91,6 +91,89 @@ export async function writeAuthMetadata(
   return fencedAuthWrite(id, ["metadata", JSON.stringify(metadata)]);
 }
 
+// Seeds AuthenticationCreds directly into the auth hash before a connect. Used
+// by the session-import flow to transplant an already-linked WhatsApp Web
+// session so the next connect resumes it (creds.me set -> no QR). Goes through
+// the same owner fence as saveCreds, serialized identically, so useRedisAuthState
+// reads it back verbatim. The caller must hold the lease — the import path runs
+// this right after forceAcquireLease — otherwise the write is fenced off and
+// this returns false (do not connect: the socket would resume stale/empty creds).
+export async function seedRedisAuthCreds(
+  id: string,
+  creds: AuthenticationCreds,
+): Promise<boolean> {
+  return fencedAuthWrite(id, [
+    "creds",
+    JSON.stringify(creds, BufferJSON.replacer),
+  ]);
+}
+
+const IMPORT_CANDIDATES_FIELD = "import-candidates";
+
+interface ImportCandidateState {
+  candidates: { private: string; public: string }[];
+  index: number;
+}
+
+// Stores the extracted Noise key candidates next to the seeded creds. Only one
+// candidate is the real private->public pair; the extractor cannot tell which,
+// so the connection handler advances through them (advanceImportCandidate) when
+// an imported session closes before it ever opens. Fenced like every auth write.
+export async function seedImportCandidates(
+  id: string,
+  candidates: { private: string; public: string }[],
+  index: number,
+): Promise<boolean> {
+  return fencedAuthWrite(id, [
+    IMPORT_CANDIDATES_FIELD,
+    JSON.stringify({ candidates, index } satisfies ImportCandidateState),
+  ]);
+}
+
+// Advances a seeded import to the next Noise candidate: rewrites creds.noiseKey
+// and bumps the stored cursor so the next connect() (which re-reads creds from
+// Redis) resumes with the new key. Returns false when nothing is seeded or the
+// candidates are exhausted — the caller then falls back to the normal reconnect.
+export async function advanceImportCandidate(id: string): Promise<boolean> {
+  const key = `${redisKeyPrefix}:${id}:authState`;
+  const raw = await redis.hGet(key, IMPORT_CANDIDATES_FIELD);
+  if (!raw) {
+    return false;
+  }
+  const state = JSON.parse(raw) as ImportCandidateState;
+  const nextIndex = state.index + 1;
+  const next = state.candidates[nextIndex];
+  if (!next) {
+    return false;
+  }
+
+  const credsRaw = await redis.hGet(key, "creds");
+  if (!credsRaw) {
+    return false;
+  }
+  const creds = JSON.parse(credsRaw, BufferJSON.reviver) as AuthenticationCreds;
+  (creds as { noiseKey: unknown }).noiseKey = {
+    private: Buffer.from(next.private, "base64"),
+    public: Buffer.from(next.public, "base64"),
+  };
+
+  return fencedAuthWrite(id, [
+    "creds",
+    JSON.stringify(creds, BufferJSON.replacer),
+    IMPORT_CANDIDATES_FIELD,
+    JSON.stringify({
+      candidates: state.candidates,
+      index: nextIndex,
+    } satisfies ImportCandidateState),
+  ]);
+}
+
+// Clears the import candidate cursor once the session opens (or on teardown):
+// later reconnects of a healthy session must not cycle its Noise key.
+export async function clearImportCandidates(id: string): Promise<boolean> {
+  return fencedAuthWrite(id, [IMPORT_CANDIDATES_FIELD, DELETE_SENTINEL]);
+}
+
 // NOTE: Inspired by https://github.com/hbinduni/baileys-redis-auth
 export async function useRedisAuthState(
   id: string,

--- a/src/baileys/redisAuthState.ts
+++ b/src/baileys/redisAuthState.ts
@@ -55,6 +55,25 @@ end
 return redis.call('DEL', KEYS[1])
 `;
 
+// Owner-fenced compare-and-swap for advancing an import candidate. The caller
+// mutates creds.noiseKey in JS (BufferJSON, which Redis-side cjson cannot round
+// -trip without corrupting empty arrays like processedHistoryMessages) and then
+// commits here ONLY if the stored creds still byte-match what it read — so a
+// concurrent saveCreds is never clobbered. KEYS=[hash, lease],
+// ARGV=[owner, expectedCreds, newCreds, newCursor].
+// Returns: 0 fenced off, 1 written, 2 creds changed under us (caller retries).
+const ADVANCE_CANDIDATE_CAS_SCRIPT = `
+-- advance-candidate-cas
+local raw = redis.call('GET', KEYS[2])
+if raw then
+  local lease = cjson.decode(raw)
+  if lease.owner ~= ARGV[1] then return 0 end
+end
+if redis.call('HGET', KEYS[1], 'creds') ~= ARGV[2] then return 2 end
+redis.call('HSET', KEYS[1], 'creds', ARGV[3], 'import-candidates', ARGV[4])
+return 1
+`;
+
 // `pairs` alternates field, value (value = DELETE_SENTINEL deletes the field).
 // Returns false when the write was fenced off (lease owned by someone else).
 async function fencedAuthWrite(id: string, pairs: string[]): Promise<boolean> {
@@ -127,38 +146,72 @@ export async function seedImportedSession(
 // and bumps the stored cursor so the next connect() (which re-reads creds from
 // Redis) resumes with the new key. Returns false when nothing is seeded or the
 // candidates are exhausted — the caller then falls back to the normal reconnect.
+//
+// The read-modify-write of creds is committed via an owner-fenced compare-and
+// -swap: the noiseKey mutation happens in JS (BufferJSON), then the write lands
+// only if the stored creds still match what we read. This keeps a concurrent
+// saveCreds (which also writes the creds field) from being clobbered by our
+// stale-but-for-noiseKey copy; on a mismatch we re-read and recompute. A few
+// attempts is ample — the only writer that can race here is this connection's
+// own saveCreds during a pre-open reconnect, not a hot loop.
 export async function advanceImportCandidate(id: string): Promise<boolean> {
   const key = `${redisKeyPrefix}:${id}:authState`;
-  const raw = await redis.hGet(key, IMPORT_CANDIDATES_FIELD);
-  if (!raw) {
-    return false;
-  }
-  const state = JSON.parse(raw) as ImportCandidateState;
-  const nextIndex = state.index + 1;
-  const next = state.candidates[nextIndex];
-  if (!next) {
-    return false;
-  }
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    const raw = await redis.hGet(key, IMPORT_CANDIDATES_FIELD);
+    if (!raw) {
+      return false;
+    }
+    const state = JSON.parse(raw) as ImportCandidateState;
+    const nextIndex = state.index + 1;
+    const next = state.candidates[nextIndex];
+    if (!next) {
+      return false;
+    }
 
-  const credsRaw = await redis.hGet(key, "creds");
-  if (!credsRaw) {
-    return false;
-  }
-  const creds = JSON.parse(credsRaw, BufferJSON.reviver) as AuthenticationCreds;
-  (creds as { noiseKey: unknown }).noiseKey = {
-    private: Buffer.from(next.private, "base64"),
-    public: Buffer.from(next.public, "base64"),
-  };
+    const credsRaw = await redis.hGet(key, "creds");
+    if (!credsRaw) {
+      return false;
+    }
+    const creds = JSON.parse(
+      credsRaw,
+      BufferJSON.reviver,
+    ) as AuthenticationCreds;
+    (creds as { noiseKey: unknown }).noiseKey = {
+      private: Buffer.from(next.private, "base64"),
+      public: Buffer.from(next.public, "base64"),
+    };
 
-  return fencedAuthWrite(id, [
-    "creds",
-    JSON.stringify(creds, BufferJSON.replacer),
-    IMPORT_CANDIDATES_FIELD,
-    JSON.stringify({
-      candidates: state.candidates,
-      index: nextIndex,
-    } satisfies ImportCandidateState),
-  ]);
+    const result = await redis.eval(ADVANCE_CANDIDATE_CAS_SCRIPT, {
+      keys: [key, clusterKeys.lease(id)],
+      arguments: [
+        instanceId,
+        credsRaw,
+        JSON.stringify(creds, BufferJSON.replacer),
+        JSON.stringify({
+          candidates: state.candidates,
+          index: nextIndex,
+        } satisfies ImportCandidateState),
+      ],
+    });
+
+    if (result === 1) {
+      return true;
+    }
+    if (result === 0) {
+      // Fenced off — another instance owns the lease; do not retry.
+      logger.warn(
+        "[%s] [advanceImportCandidate] write rejected — lease is owned by another instance",
+        id,
+      );
+      return false;
+    }
+    // result === 2: creds changed under us (concurrent saveCreds) — re-read.
+  }
+  logger.warn(
+    "[%s] [advanceImportCandidate] creds kept changing under the compare-and-swap; skipping candidate advance this cycle",
+    id,
+  );
+  return false;
 }
 
 // Clears the import candidate cursor once the session opens (or on teardown):

--- a/src/baileys/redisAuthState.ts
+++ b/src/baileys/redisAuthState.ts
@@ -91,23 +91,6 @@ export async function writeAuthMetadata(
   return fencedAuthWrite(id, ["metadata", JSON.stringify(metadata)]);
 }
 
-// Seeds AuthenticationCreds directly into the auth hash before a connect. Used
-// by the session-import flow to transplant an already-linked WhatsApp Web
-// session so the next connect resumes it (creds.me set -> no QR). Goes through
-// the same owner fence as saveCreds, serialized identically, so useRedisAuthState
-// reads it back verbatim. The caller must hold the lease — the import path runs
-// this right after forceAcquireLease — otherwise the write is fenced off and
-// this returns false (do not connect: the socket would resume stale/empty creds).
-export async function seedRedisAuthCreds(
-  id: string,
-  creds: AuthenticationCreds,
-): Promise<boolean> {
-  return fencedAuthWrite(id, [
-    "creds",
-    JSON.stringify(creds, BufferJSON.replacer),
-  ]);
-}
-
 const IMPORT_CANDIDATES_FIELD = "import-candidates";
 
 interface ImportCandidateState {
@@ -115,16 +98,26 @@ interface ImportCandidateState {
   index: number;
 }
 
-// Stores the extracted Noise key candidates next to the seeded creds. Only one
-// candidate is the real private->public pair; the extractor cannot tell which,
-// so the connection handler advances through them (advanceImportCandidate) when
-// an imported session closes before it ever opens. Fenced like every auth write.
-export async function seedImportCandidates(
+// Transplants an already-linked WhatsApp Web session before a connect: writes
+// the mapped creds AND the Noise-candidate cursor in a SINGLE fenced write, so
+// an import can never land with creds persisted but no candidates (or vice
+// versa) if the process dies between two writes. The next connect resumes the
+// session (creds.me set -> no QR) and can cycle candidates if the seeded Noise
+// key is the wrong one (only one candidate is the real private->public pair;
+// the extractor cannot tell which). Serialized identically to saveCreds so
+// useRedisAuthState reads it back verbatim. The caller must hold the lease —
+// the import path runs this right after forceAcquireLease — otherwise the write
+// is fenced off and this returns false (do not connect: the socket would resume
+// stale/empty creds).
+export async function seedImportedSession(
   id: string,
+  creds: AuthenticationCreds,
   candidates: { private: string; public: string }[],
   index: number,
 ): Promise<boolean> {
   return fencedAuthWrite(id, [
+    "creds",
+    JSON.stringify(creds, BufferJSON.replacer),
     IMPORT_CANDIDATES_FIELD,
     JSON.stringify({ candidates, index } satisfies ImportCandidateState),
   ]);

--- a/src/baileys/types.ts
+++ b/src/baileys/types.ts
@@ -14,6 +14,11 @@ export interface BaileysConnectionOptions {
   autoPresenceSubscribe?: boolean;
   apiKeyHash?: string;
   isReconnect?: boolean;
+  // Import/takeover: discard any live socket and spawn a fresh one so the newly
+  // seeded creds are actually loaded. A reused in-memory socket (e.g. one still
+  // emitting QRs) would otherwise ignore the transplanted session. Transient —
+  // stripped in connect() and never persisted onto the connection.
+  forceRestart?: boolean;
   // Epoch of the lease under which this connection was claimed. Stamped onto
   // connection.update webhooks so the client can discard late events from a
   // previous owner. Threaded in by the coordinator's lease-claim path; never

--- a/src/cluster/coordinator.spec.ts
+++ b/src/cluster/coordinator.spec.ts
@@ -817,6 +817,7 @@ describe("ClusterCoordinator", () => {
       expect(handler.connect).toHaveBeenCalledWith("+5511999", {
         ...options,
         leaseEpoch: 1,
+        forceRestart: true,
       });
     });
 
@@ -862,6 +863,27 @@ describe("ClusterCoordinator", () => {
 
       expect(handler.connect).not.toHaveBeenCalled();
       expect(releaseLease).toHaveBeenCalledWith("+5511999", 9);
+    });
+
+    it("releases the lease and does not connect when the candidate seed is fenced off", async () => {
+      const handler = makeHandlerMock();
+      const coordinator = makeCoordinator(handler);
+      forceAcquireLease.mockResolvedValue({ owner: "test-instance", epoch: 7 });
+      seedRedisAuthCreds.mockResolvedValue(true);
+      seedImportCandidates.mockResolvedValue(false);
+
+      await expect(
+        coordinator.importSessionWithLease(
+          "+5511999",
+          creds,
+          candidates,
+          0,
+          options,
+        ),
+      ).rejects.toThrow(/candidates/i);
+
+      expect(handler.connect).not.toHaveBeenCalled();
+      expect(releaseLease).toHaveBeenCalledWith("+5511999", 7);
     });
 
     it("refuses to steal a live instance's lease in worker role", async () => {

--- a/src/cluster/coordinator.spec.ts
+++ b/src/cluster/coordinator.spec.ts
@@ -24,6 +24,8 @@ const getRedisSavedAuthStateIds = spyOn(
   "getRedisSavedAuthStateIds",
 );
 const isRedisAuthStatePaired = spyOn(redisAuthState, "isRedisAuthStatePaired");
+const seedRedisAuthCreds = spyOn(redisAuthState, "seedRedisAuthCreds");
+const seedImportCandidates = spyOn(redisAuthState, "seedImportCandidates");
 const listLiveInstances = spyOn(registry, "listLiveInstances");
 const heartbeat = spyOn(registry, "heartbeat");
 const deregister = spyOn(registry, "deregister");
@@ -41,6 +43,8 @@ const getHandoffTarget = spyOn(leaseStore, "getHandoffTarget");
 afterAll(() => {
   getRedisSavedAuthStateIds.mockRestore();
   isRedisAuthStatePaired.mockRestore();
+  seedRedisAuthCreds.mockRestore();
+  seedImportCandidates.mockRestore();
   listLiveInstances.mockRestore();
   heartbeat.mockRestore();
   deregister.mockRestore();
@@ -117,6 +121,8 @@ describe("ClusterCoordinator", () => {
   beforeEach(() => {
     getRedisSavedAuthStateIds.mockReset();
     isRedisAuthStatePaired.mockReset();
+    seedRedisAuthCreds.mockReset();
+    seedImportCandidates.mockReset();
     listLiveInstances.mockReset();
     heartbeat.mockReset();
     deregister.mockReset();
@@ -133,6 +139,8 @@ describe("ClusterCoordinator", () => {
 
     getRedisSavedAuthStateIds.mockResolvedValue([]);
     isRedisAuthStatePaired.mockResolvedValue(true);
+    seedRedisAuthCreds.mockResolvedValue(true);
+    seedImportCandidates.mockResolvedValue(true);
     listLiveInstances.mockResolvedValue([instanceEntry("test-instance")]);
     heartbeat.mockResolvedValue(undefined);
     deregister.mockResolvedValue(undefined);
@@ -776,6 +784,109 @@ describe("ClusterCoordinator", () => {
           expect(handler.connect).toHaveBeenCalled();
         });
       });
+    });
+  });
+
+  describe("#importSessionWithLease", () => {
+    const creds = { me: { id: "5511999:1@s.whatsapp.net" } } as never;
+    const candidates = [
+      { private: "np0", public: "nb0" },
+      { private: "np1", public: "nb1" },
+    ];
+    const options = { webhookUrl: "https://h.com", webhookVerifyToken: "t" };
+
+    it("acquires the lease, seeds creds + candidates, then connects", async () => {
+      const handler = makeHandlerMock();
+      const coordinator = makeCoordinator(handler);
+
+      await coordinator.importSessionWithLease(
+        "+5511999",
+        creds,
+        candidates,
+        0,
+        options,
+      );
+
+      expect(forceAcquireLease).toHaveBeenCalledWith("+5511999");
+      expect(seedRedisAuthCreds).toHaveBeenCalledWith("+5511999", creds);
+      expect(seedImportCandidates).toHaveBeenCalledWith(
+        "+5511999",
+        candidates,
+        0,
+      );
+      expect(handler.connect).toHaveBeenCalledWith("+5511999", {
+        ...options,
+        leaseEpoch: 1,
+      });
+    });
+
+    it("seeds only after acquiring the lease (fence needs ownership)", async () => {
+      const handler = makeHandlerMock();
+      const coordinator = makeCoordinator(handler);
+      const order: string[] = [];
+      forceAcquireLease.mockImplementation(async () => {
+        order.push("acquire");
+        return { owner: "test-instance", epoch: 1 };
+      });
+      seedRedisAuthCreds.mockImplementation(async () => {
+        order.push("seed");
+        return true;
+      });
+
+      await coordinator.importSessionWithLease(
+        "+5511999",
+        creds,
+        candidates,
+        0,
+        options,
+      );
+
+      expect(order).toEqual(["acquire", "seed"]);
+    });
+
+    it("releases the lease and does not connect when the seed is fenced off", async () => {
+      const handler = makeHandlerMock();
+      const coordinator = makeCoordinator(handler);
+      forceAcquireLease.mockResolvedValue({ owner: "test-instance", epoch: 9 });
+      seedRedisAuthCreds.mockResolvedValue(false);
+
+      await expect(
+        coordinator.importSessionWithLease(
+          "+5511999",
+          creds,
+          candidates,
+          0,
+          options,
+        ),
+      ).rejects.toThrow(/seed/i);
+
+      expect(handler.connect).not.toHaveBeenCalled();
+      expect(releaseLease).toHaveBeenCalledWith("+5511999", 9);
+    });
+
+    it("refuses to steal a live instance's lease in worker role", async () => {
+      config.cluster.role = "worker";
+      try {
+        const handler = makeHandlerMock();
+        const coordinator = makeCoordinator(handler);
+        getLease.mockResolvedValue({ owner: "peer-instance", epoch: 3 });
+        isInstanceAlive.mockResolvedValue(true);
+
+        await expect(
+          coordinator.importSessionWithLease(
+            "+5511999",
+            creds,
+            candidates,
+            0,
+            options,
+          ),
+        ).rejects.toThrow(BaileysConnectionOwnedElsewhereError);
+
+        expect(forceAcquireLease).not.toHaveBeenCalled();
+        expect(seedRedisAuthCreds).not.toHaveBeenCalled();
+      } finally {
+        config.cluster.role = "standalone";
+      }
     });
   });
 

--- a/src/cluster/coordinator.spec.ts
+++ b/src/cluster/coordinator.spec.ts
@@ -24,8 +24,7 @@ const getRedisSavedAuthStateIds = spyOn(
   "getRedisSavedAuthStateIds",
 );
 const isRedisAuthStatePaired = spyOn(redisAuthState, "isRedisAuthStatePaired");
-const seedRedisAuthCreds = spyOn(redisAuthState, "seedRedisAuthCreds");
-const seedImportCandidates = spyOn(redisAuthState, "seedImportCandidates");
+const seedImportedSession = spyOn(redisAuthState, "seedImportedSession");
 const listLiveInstances = spyOn(registry, "listLiveInstances");
 const heartbeat = spyOn(registry, "heartbeat");
 const deregister = spyOn(registry, "deregister");
@@ -43,8 +42,7 @@ const getHandoffTarget = spyOn(leaseStore, "getHandoffTarget");
 afterAll(() => {
   getRedisSavedAuthStateIds.mockRestore();
   isRedisAuthStatePaired.mockRestore();
-  seedRedisAuthCreds.mockRestore();
-  seedImportCandidates.mockRestore();
+  seedImportedSession.mockRestore();
   listLiveInstances.mockRestore();
   heartbeat.mockRestore();
   deregister.mockRestore();
@@ -121,8 +119,7 @@ describe("ClusterCoordinator", () => {
   beforeEach(() => {
     getRedisSavedAuthStateIds.mockReset();
     isRedisAuthStatePaired.mockReset();
-    seedRedisAuthCreds.mockReset();
-    seedImportCandidates.mockReset();
+    seedImportedSession.mockReset();
     listLiveInstances.mockReset();
     heartbeat.mockReset();
     deregister.mockReset();
@@ -139,8 +136,7 @@ describe("ClusterCoordinator", () => {
 
     getRedisSavedAuthStateIds.mockResolvedValue([]);
     isRedisAuthStatePaired.mockResolvedValue(true);
-    seedRedisAuthCreds.mockResolvedValue(true);
-    seedImportCandidates.mockResolvedValue(true);
+    seedImportedSession.mockResolvedValue(true);
     listLiveInstances.mockResolvedValue([instanceEntry("test-instance")]);
     heartbeat.mockResolvedValue(undefined);
     deregister.mockResolvedValue(undefined);
@@ -795,7 +791,7 @@ describe("ClusterCoordinator", () => {
     ];
     const options = { webhookUrl: "https://h.com", webhookVerifyToken: "t" };
 
-    it("acquires the lease, seeds creds + candidates, then connects", async () => {
+    it("acquires the lease, seeds the imported session, then connects", async () => {
       const handler = makeHandlerMock();
       const coordinator = makeCoordinator(handler);
 
@@ -808,9 +804,9 @@ describe("ClusterCoordinator", () => {
       );
 
       expect(forceAcquireLease).toHaveBeenCalledWith("+5511999");
-      expect(seedRedisAuthCreds).toHaveBeenCalledWith("+5511999", creds);
-      expect(seedImportCandidates).toHaveBeenCalledWith(
+      expect(seedImportedSession).toHaveBeenCalledWith(
         "+5511999",
+        creds,
         candidates,
         0,
       );
@@ -829,7 +825,7 @@ describe("ClusterCoordinator", () => {
         order.push("acquire");
         return { owner: "test-instance", epoch: 1 };
       });
-      seedRedisAuthCreds.mockImplementation(async () => {
+      seedImportedSession.mockImplementation(async () => {
         order.push("seed");
         return true;
       });
@@ -849,7 +845,7 @@ describe("ClusterCoordinator", () => {
       const handler = makeHandlerMock();
       const coordinator = makeCoordinator(handler);
       forceAcquireLease.mockResolvedValue({ owner: "test-instance", epoch: 9 });
-      seedRedisAuthCreds.mockResolvedValue(false);
+      seedImportedSession.mockResolvedValue(false);
 
       await expect(
         coordinator.importSessionWithLease(
@@ -865,12 +861,11 @@ describe("ClusterCoordinator", () => {
       expect(releaseLease).toHaveBeenCalledWith("+5511999", 9);
     });
 
-    it("releases the lease and does not connect when the candidate seed is fenced off", async () => {
+    it("releases the lease when connect throws after a successful seed", async () => {
       const handler = makeHandlerMock();
       const coordinator = makeCoordinator(handler);
-      forceAcquireLease.mockResolvedValue({ owner: "test-instance", epoch: 7 });
-      seedRedisAuthCreds.mockResolvedValue(true);
-      seedImportCandidates.mockResolvedValue(false);
+      forceAcquireLease.mockResolvedValue({ owner: "test-instance", epoch: 4 });
+      handler.connect.mockRejectedValueOnce(new Error("connect boom"));
 
       await expect(
         coordinator.importSessionWithLease(
@@ -880,10 +875,12 @@ describe("ClusterCoordinator", () => {
           0,
           options,
         ),
-      ).rejects.toThrow(/candidates/i);
+      ).rejects.toThrow("connect boom");
 
-      expect(handler.connect).not.toHaveBeenCalled();
-      expect(releaseLease).toHaveBeenCalledWith("+5511999", 7);
+      // The release-on-failure rollback holds even after the lease AND the seed
+      // both succeed, not just on the pre-connect fencing paths.
+      expect(seedImportedSession).toHaveBeenCalled();
+      expect(releaseLease).toHaveBeenCalledWith("+5511999", 4);
     });
 
     it("refuses to steal a live instance's lease in worker role", async () => {
@@ -905,7 +902,7 @@ describe("ClusterCoordinator", () => {
         ).rejects.toThrow(BaileysConnectionOwnedElsewhereError);
 
         expect(forceAcquireLease).not.toHaveBeenCalled();
-        expect(seedRedisAuthCreds).not.toHaveBeenCalled();
+        expect(seedImportedSession).not.toHaveBeenCalled();
       } finally {
         config.cluster.role = "standalone";
       }

--- a/src/cluster/coordinator.ts
+++ b/src/cluster/coordinator.ts
@@ -1,7 +1,10 @@
+import type { AuthenticationCreds } from "@whiskeysockets/baileys";
 import type { BaileysConnectionsHandler } from "@/baileys/connectionsHandler";
 import {
   getRedisSavedAuthStateIds,
   isRedisAuthStatePaired,
+  seedImportCandidates,
+  seedRedisAuthCreds,
 } from "@/baileys/redisAuthState";
 import type { BaileysConnectionOptions } from "@/baileys/types";
 import { instanceId } from "@/cluster/identity";
@@ -673,6 +676,53 @@ export class ClusterCoordinator {
     } catch (error) {
       // A lease held without a socket would keep routing 421s here until the
       // TTL expires; release it so a retry can land anywhere.
+      await this.releaseHeldLease(phoneNumber).catch(() => {});
+      void registry.publishOwnershipChanged(phoneNumber);
+      throw error;
+    }
+  }
+
+  // Session import: same explicit-takeover semantics as connectWithLease, but
+  // seeds transplanted creds into the auth hash BETWEEN acquiring the lease and
+  // connecting. Ordering matters: seedRedisAuthCreds is owner-fenced, so it must
+  // run after forceAcquireLease (we now own the lease) or the write would be a
+  // silent no-op and connect() would resume empty creds and fall back to a QR.
+  async importSessionWithLease(
+    phoneNumber: string,
+    creds: AuthenticationCreds,
+    noiseCandidates: { private: string; public: string }[],
+    candidateIndex: number,
+    options: BaileysConnectionOptions,
+  ) {
+    if (config.cluster.role === "worker") {
+      const lease = await leaseStore.getLease(phoneNumber);
+      if (
+        lease &&
+        lease.owner !== instanceId &&
+        (await registry.isInstanceAlive(lease.owner))
+      ) {
+        throw new BaileysConnectionOwnedElsewhereError(lease.owner);
+      }
+    }
+    const acquired = await leaseStore.forceAcquireLease(phoneNumber);
+    this.heldLeaseEpochs.set(phoneNumber, acquired.epoch);
+    this.claimedAt.set(phoneNumber, this.now());
+    void registry.publishOwnershipChanged(phoneNumber);
+    try {
+      const seeded = await seedRedisAuthCreds(phoneNumber, creds);
+      if (!seeded) {
+        throw new Error(
+          "failed to seed imported creds (auth write fenced off)",
+        );
+      }
+      // Store the candidate cursor so the connection handler can cycle to the
+      // next Noise key if this one fails the handshake (closes before opening).
+      await seedImportCandidates(phoneNumber, noiseCandidates, candidateIndex);
+      await this.handler.connect(phoneNumber, {
+        ...options,
+        leaseEpoch: acquired.epoch,
+      });
+    } catch (error) {
       await this.releaseHeldLease(phoneNumber).catch(() => {});
       void registry.publishOwnershipChanged(phoneNumber);
       throw error;

--- a/src/cluster/coordinator.ts
+++ b/src/cluster/coordinator.ts
@@ -717,10 +717,26 @@ export class ClusterCoordinator {
       }
       // Store the candidate cursor so the connection handler can cycle to the
       // next Noise key if this one fails the handshake (closes before opening).
-      await seedImportCandidates(phoneNumber, noiseCandidates, candidateIndex);
+      // Checked like seedRedisAuthCreds above: a fenced-off write means another
+      // instance grabbed the lease between forceAcquireLease and here, so the
+      // cursor never persists and candidate cycling would silently no-op. Bail
+      // and release the lease instead of connecting on a half-seeded import.
+      const candidatesSeeded = await seedImportCandidates(
+        phoneNumber,
+        noiseCandidates,
+        candidateIndex,
+      );
+      if (!candidatesSeeded) {
+        throw new Error(
+          "failed to seed import candidates (auth write fenced off)",
+        );
+      }
       await this.handler.connect(phoneNumber, {
         ...options,
         leaseEpoch: acquired.epoch,
+        // Replace any live socket (e.g. an in-progress QR pairing) so the seeded
+        // import creds are loaded on a fresh connection instead of ignored.
+        forceRestart: true,
       });
     } catch (error) {
       await this.releaseHeldLease(phoneNumber).catch(() => {});

--- a/src/cluster/coordinator.ts
+++ b/src/cluster/coordinator.ts
@@ -3,8 +3,7 @@ import type { BaileysConnectionsHandler } from "@/baileys/connectionsHandler";
 import {
   getRedisSavedAuthStateIds,
   isRedisAuthStatePaired,
-  seedImportCandidates,
-  seedRedisAuthCreds,
+  seedImportedSession,
 } from "@/baileys/redisAuthState";
 import type { BaileysConnectionOptions } from "@/baileys/types";
 import { instanceId } from "@/cluster/identity";
@@ -643,17 +642,16 @@ export class ClusterCoordinator {
     }
   }
 
-  // Explicit user intent (POST /connections) — takes the identity over even
-  // if a lease exists. In standalone this matches today's single-instance
-  // semantics (the request is authoritative). In worker role, a lease held
-  // by another LIVE instance is not stolen: the caller gets
-  // BaileysConnectionOwnedElsewhereError and the proxy re-routes the request
-  // to the owner. A dead owner's lease is force-taken immediately instead of
-  // waiting for the TTL.
-  async connectWithLease(
+  // Shared lease-takeover setup for the explicit-intent paths
+  // (connectWithLease / importSessionWithLease): the worker-role live-owner
+  // guard, the force-acquire, and the in-memory bookkeeping. Kept in one place
+  // so the two callers cannot drift apart. In worker role, a lease held by
+  // another LIVE instance is not stolen — the caller gets
+  // BaileysConnectionOwnedElsewhereError and the proxy re-routes to the owner;
+  // a dead owner's lease is force-taken immediately instead of waiting for TTL.
+  private async acquireExplicitLease(
     phoneNumber: string,
-    options: BaileysConnectionOptions,
-  ) {
+  ): Promise<{ epoch: number }> {
     if (config.cluster.role === "worker") {
       const lease = await leaseStore.getLease(phoneNumber);
       if (
@@ -668,25 +666,47 @@ export class ClusterCoordinator {
     this.heldLeaseEpochs.set(phoneNumber, acquired.epoch);
     this.claimedAt.set(phoneNumber, this.now());
     void registry.publishOwnershipChanged(phoneNumber);
+    return acquired;
+  }
+
+  // Runs work under a just-acquired explicit lease, releasing it if the work
+  // throws. A lease held without a live socket would keep routing 421s here
+  // until the TTL expires; releasing lets a retry land anywhere.
+  private async runUnderExplicitLease<T>(
+    phoneNumber: string,
+    work: () => Promise<T>,
+  ): Promise<T> {
     try {
-      await this.handler.connect(phoneNumber, {
-        ...options,
-        leaseEpoch: acquired.epoch,
-      });
+      return await work();
     } catch (error) {
-      // A lease held without a socket would keep routing 421s here until the
-      // TTL expires; release it so a retry can land anywhere.
       await this.releaseHeldLease(phoneNumber).catch(() => {});
       void registry.publishOwnershipChanged(phoneNumber);
       throw error;
     }
   }
 
+  // Explicit user intent (POST /connections) — takes the identity over even if
+  // a lease exists. In standalone this matches today's single-instance
+  // semantics (the request is authoritative).
+  async connectWithLease(
+    phoneNumber: string,
+    options: BaileysConnectionOptions,
+  ) {
+    const acquired = await this.acquireExplicitLease(phoneNumber);
+    await this.runUnderExplicitLease(phoneNumber, () =>
+      this.handler.connect(phoneNumber, {
+        ...options,
+        leaseEpoch: acquired.epoch,
+      }),
+    );
+  }
+
   // Session import: same explicit-takeover semantics as connectWithLease, but
-  // seeds transplanted creds into the auth hash BETWEEN acquiring the lease and
-  // connecting. Ordering matters: seedRedisAuthCreds is owner-fenced, so it must
-  // run after forceAcquireLease (we now own the lease) or the write would be a
-  // silent no-op and connect() would resume empty creds and fall back to a QR.
+  // seeds the transplanted creds + Noise-candidate cursor into the auth hash
+  // BETWEEN acquiring the lease and connecting. Ordering matters:
+  // seedImportedSession is owner-fenced, so it must run after acquiring the
+  // lease (we now own it) or the write would be a silent no-op and connect()
+  // would resume empty creds and fall back to a QR.
   async importSessionWithLease(
     phoneNumber: string,
     creds: AuthenticationCreds,
@@ -694,41 +714,21 @@ export class ClusterCoordinator {
     candidateIndex: number,
     options: BaileysConnectionOptions,
   ) {
-    if (config.cluster.role === "worker") {
-      const lease = await leaseStore.getLease(phoneNumber);
-      if (
-        lease &&
-        lease.owner !== instanceId &&
-        (await registry.isInstanceAlive(lease.owner))
-      ) {
-        throw new BaileysConnectionOwnedElsewhereError(lease.owner);
-      }
-    }
-    const acquired = await leaseStore.forceAcquireLease(phoneNumber);
-    this.heldLeaseEpochs.set(phoneNumber, acquired.epoch);
-    this.claimedAt.set(phoneNumber, this.now());
-    void registry.publishOwnershipChanged(phoneNumber);
-    try {
-      const seeded = await seedRedisAuthCreds(phoneNumber, creds);
-      if (!seeded) {
-        throw new Error(
-          "failed to seed imported creds (auth write fenced off)",
-        );
-      }
-      // Store the candidate cursor so the connection handler can cycle to the
-      // next Noise key if this one fails the handshake (closes before opening).
-      // Checked like seedRedisAuthCreds above: a fenced-off write means another
-      // instance grabbed the lease between forceAcquireLease and here, so the
-      // cursor never persists and candidate cycling would silently no-op. Bail
-      // and release the lease instead of connecting on a half-seeded import.
-      const candidatesSeeded = await seedImportCandidates(
+    const acquired = await this.acquireExplicitLease(phoneNumber);
+    await this.runUnderExplicitLease(phoneNumber, async () => {
+      // Creds and the candidate cursor are written together (single fenced
+      // write), so an import never lands with one persisted but not the other.
+      // A fenced-off write means another instance grabbed the lease between
+      // acquiring it and here; bail and release instead of connecting empty.
+      const seeded = await seedImportedSession(
         phoneNumber,
+        creds,
         noiseCandidates,
         candidateIndex,
       );
-      if (!candidatesSeeded) {
+      if (!seeded) {
         throw new Error(
-          "failed to seed import candidates (auth write fenced off)",
+          "failed to seed imported session (auth write fenced off)",
         );
       }
       await this.handler.connect(phoneNumber, {
@@ -738,11 +738,7 @@ export class ClusterCoordinator {
         // import creds are loaded on a fresh connection instead of ignored.
         forceRestart: true,
       });
-    } catch (error) {
-      await this.releaseHeldLease(phoneNumber).catch(() => {});
-      void registry.publishOwnershipChanged(phoneNumber);
-      throw error;
-    }
+    });
   }
 
   get isDraining(): boolean {

--- a/src/controllers/connections/index.spec.ts
+++ b/src/controllers/connections/index.spec.ts
@@ -1,6 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
 import Elysia from "elysia";
 import baileys from "@/baileys";
+import coordinator from "@/cluster";
+import { BaileysConnectionOwnedElsewhereError } from "@/cluster/coordinator";
 import config from "@/config";
 import connectionsController from "./index";
 
@@ -143,5 +145,122 @@ describe("connectionsController restriction diagnostics", () => {
 
       expect(res.status).toBe(404);
     });
+  });
+});
+
+describe("connectionsController import-session", () => {
+  let prevEnv: typeof config.env;
+  let prevRole: typeof config.cluster.role;
+
+  beforeEach(() => {
+    prevEnv = config.env;
+    prevRole = config.cluster.role;
+    config.env = "development";
+    config.cluster.role = "standalone";
+  });
+
+  afterEach(() => {
+    config.env = prevEnv;
+    config.cluster.role = prevRole;
+  });
+
+  const b64 = (s: string) => Buffer.from(s).toString("base64");
+
+  const validSession = () => ({
+    noiseCandidates: [
+      { private: b64("np0"), public: b64("nb0") },
+      { private: b64("np1"), public: b64("nb1") },
+    ],
+    identityKey: { private: b64("ip"), public: b64("ib") },
+    registrationId: 42,
+    advSecretKey: b64("adv"),
+    account: {
+      details: b64("d"),
+      accountSignatureKey: b64("ask"),
+      accountSignature: b64("as"),
+      deviceSignature: b64("ds"),
+    },
+    id: "551101234567:12@s.whatsapp.net",
+    lid: "551101234567@s.whatsapp.net",
+  });
+
+  const validBody = () => ({
+    session: validSession(),
+    webhookUrl: "http://localhost:3026/whatsapp/+551234567890",
+    webhookVerifyToken: "verify",
+  });
+
+  const importRequest = (phone: string, body: unknown) =>
+    new Request(`http://localhost/connections/${phone}/import-session`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    });
+
+  it("maps the session and hands off to the coordinator (202)", async () => {
+    const spy = spyOn(coordinator, "importSessionWithLease").mockResolvedValue(
+      undefined,
+    );
+    try {
+      const app = new Elysia().use(connectionsController);
+      const res = await app.handle(importRequest("+551234567890", validBody()));
+
+      expect(res.status).toBe(202);
+      expect(spy).toHaveBeenCalledWith(
+        "+551234567890",
+        expect.objectContaining({ registered: true }),
+        expect.arrayContaining([
+          expect.objectContaining({ private: expect.any(String) }),
+        ]),
+        0,
+        expect.objectContaining({
+          webhookUrl: "http://localhost:3026/whatsapp/+551234567890",
+          webhookVerifyToken: "verify",
+        }),
+      );
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("returns 422 when the noise candidate index is out of range", async () => {
+    const spy = spyOn(coordinator, "importSessionWithLease");
+    try {
+      const app = new Elysia().use(connectionsController);
+      const res = await app.handle(
+        importRequest("+551234567890", { ...validBody(), candidateIndex: 9 }),
+      );
+
+      expect(res.status).toBe(422);
+      expect(spy).not.toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("surfaces a live owner elsewhere as 409 with x-baileys-owner", async () => {
+    const spy = spyOn(coordinator, "importSessionWithLease").mockImplementation(
+      async () => {
+        throw new BaileysConnectionOwnedElsewhereError("owner-2");
+      },
+    );
+    try {
+      const app = new Elysia().use(connectionsController);
+      const res = await app.handle(importRequest("+551234567890", validBody()));
+
+      expect(res.status).toBe(409);
+      expect(res.headers.get("x-baileys-owner")).toBe("owner-2");
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("rejects a body missing the webhook fields", async () => {
+    const app = new Elysia().use(connectionsController);
+    const res = await app.handle(
+      importRequest("+551234567890", { session: validSession() }),
+    );
+
+    expect(res.status).toBe(422);
   });
 });

--- a/src/controllers/connections/index.ts
+++ b/src/controllers/connections/index.ts
@@ -21,6 +21,7 @@ import {
   anyJid,
   anyMessageContent,
   chatModification,
+  connectionOptionsSchema,
   editableMessageContent,
   extractedSession,
   groupJid,
@@ -123,50 +124,7 @@ const connectionsController = new Elysia({
     {
       params: phoneNumberParams,
       body: t.Object({
-        clientName: t.Optional(
-          t.String({
-            description: "Name of the client to be used on WhatsApp connection",
-            example: "My WhatsApp Client",
-          }),
-        ),
-        webhookUrl: t.String({
-          format: "uri",
-          description: "URL for receiving updates",
-          example: "http://localhost:3026/whatsapp/+1234567890",
-        }),
-        webhookVerifyToken: t.String({
-          minLength: 6,
-          description: "Token for verifying webhook",
-          example: "a3f4b2",
-        }),
-        includeMedia: t.Optional(
-          t.Boolean({
-            description:
-              "Include media in messages.upsert event payload as base64 string",
-            // TODO(v2): Change default to false.
-            default: true,
-          }),
-        ),
-        syncFullHistory: t.Optional(
-          t.Boolean({
-            description: "Sync full history of messages on connection.",
-            default: false,
-          }),
-        ),
-        groupsEnabled: t.Optional(
-          t.Boolean({
-            description:
-              "Enable full group message processing. When false, group messages are accumulated and sent as activity summaries.",
-            default: true,
-          }),
-        ),
-        autoPresenceSubscribe: t.Optional(
-          t.Boolean({
-            description:
-              "Automatically subscribe to presence updates when sending/receiving messages or typing status to/from a contact. Subscriptions are ephemeral and re-established automatically.",
-            default: false,
-          }),
-        ),
+        ...connectionOptionsSchema,
       }),
       detail: {
         responses: {
@@ -236,17 +194,7 @@ const connectionsController = new Elysia({
               "Index into session.noiseCandidates to try first (only one candidate is the real pair).",
           }),
         ),
-        clientName: t.Optional(t.String()),
-        webhookUrl: t.String({
-          format: "uri",
-          description: "URL for receiving updates",
-          example: "http://localhost:3026/whatsapp/+1234567890",
-        }),
-        webhookVerifyToken: t.String({ minLength: 6 }),
-        includeMedia: t.Optional(t.Boolean({ default: true })),
-        syncFullHistory: t.Optional(t.Boolean({ default: false })),
-        groupsEnabled: t.Optional(t.Boolean({ default: true })),
-        autoPresenceSubscribe: t.Optional(t.Boolean({ default: false })),
+        ...connectionOptionsSchema,
       }),
       detail: {
         summary: "Import an extracted WhatsApp Web session (no QR)",

--- a/src/controllers/connections/index.ts
+++ b/src/controllers/connections/index.ts
@@ -4,6 +4,10 @@ import {
   BaileysConnectionForbiddenError,
   BaileysNotConnectedError,
 } from "@/baileys/connection";
+import {
+  InvalidNoiseCandidateError,
+  mapSessionToCreds,
+} from "@/baileys/importSession";
 import coordinator from "@/cluster";
 import { BaileysConnectionOwnedElsewhereError } from "@/cluster/coordinator";
 import { resolveMisdirectedRequest } from "@/cluster/workerRouting";
@@ -18,6 +22,7 @@ import {
   anyMessageContent,
   chatModification,
   editableMessageContent,
+  extractedSession,
   groupJid,
   iMessageKey,
   iMessageKeyWithId,
@@ -61,11 +66,14 @@ const connectionsController = new Elysia({
     // lease transition the local metadata (apiKeyHash) can lag the new
     // owner's writes, and answering 403 off that stale copy would mask the
     // misdirect the proxy knows how to recover from.
-    // POST /connections/:phone is exempt — it is an explicit takeover and
-    // resolves ownership in connectWithLease (409 when the owner is alive).
+    // POST /connections/:phone and .../import-session are exempt — both are
+    // explicit takeovers and resolve ownership in the coordinator (409 when the
+    // owner is alive).
+    const decodedPath = decodeURIComponent(path);
     const isConnectTakeover =
       request.method === "POST" &&
-      decodeURIComponent(path) === `/connections/${phoneNumber}`;
+      (decodedPath === `/connections/${phoneNumber}` ||
+        decodedPath === `/connections/${phoneNumber}/import-session`);
     if (!isConnectTakeover) {
       const owner = await resolveMisdirectedRequest(phoneNumber);
       if (owner) {
@@ -174,6 +182,89 @@ const connectionsController = new Elysia({
                 schema: { type: "string" },
               },
             },
+          },
+        },
+      },
+    },
+  )
+  .post(
+    "/:phoneNumber/import-session",
+    async ({ params, body, apiKeyHash, set }) => {
+      const { phoneNumber } = params;
+      const { session, candidateIndex, ...options } = body;
+
+      // Transplant an already-linked WhatsApp Web session: map the extracted
+      // creds, seed them under the lease, and connect — the socket resumes as a
+      // registered companion (no QR). Like POST /:phoneNumber it is an explicit
+      // takeover, so a live owner elsewhere surfaces as 409.
+      try {
+        const index = candidateIndex ?? 0;
+        const creds = mapSessionToCreds(session, index);
+        await coordinator.importSessionWithLease(
+          phoneNumber,
+          creds,
+          session.noiseCandidates,
+          index,
+          { ...options, apiKeyHash: apiKeyHash ?? undefined },
+        );
+      } catch (e) {
+        if (e instanceof InvalidNoiseCandidateError) {
+          set.status = 422;
+          return { error: "Unprocessable Entity", message: e.message };
+        }
+        if (e instanceof BaileysConnectionOwnedElsewhereError) {
+          set.status = 409;
+          set.headers["x-baileys-owner"] = e.ownerInstanceId;
+          return {
+            error: "Conflict",
+            message: "Connection is owned by another live instance",
+          };
+        }
+        throw e;
+      }
+      set.status = 202;
+    },
+    {
+      params: phoneNumberParams,
+      body: t.Object({
+        session: extractedSession,
+        candidateIndex: t.Optional(
+          t.Number({
+            minimum: 0,
+            default: 0,
+            description:
+              "Index into session.noiseCandidates to try first (only one candidate is the real pair).",
+          }),
+        ),
+        clientName: t.Optional(t.String()),
+        webhookUrl: t.String({
+          format: "uri",
+          description: "URL for receiving updates",
+          example: "http://localhost:3026/whatsapp/+1234567890",
+        }),
+        webhookVerifyToken: t.String({ minLength: 6 }),
+        includeMedia: t.Optional(t.Boolean({ default: true })),
+        syncFullHistory: t.Optional(t.Boolean({ default: false })),
+        groupsEnabled: t.Optional(t.Boolean({ default: true })),
+        autoPresenceSubscribe: t.Optional(t.Boolean({ default: false })),
+      }),
+      detail: {
+        summary: "Import an extracted WhatsApp Web session (no QR)",
+        responses: {
+          202: { description: "Session import accepted; connecting" },
+          409: {
+            description:
+              "Conflict — in cluster mode, the connection is owned by another live instance (id in the x-baileys-owner header).",
+            headers: {
+              "x-baileys-owner": {
+                description: "Instance id of the connection owner",
+                schema: { type: "string" },
+              },
+            },
+          },
+          422: {
+            description:
+              "Unprocessable Entity — the requested noise candidate index is out of range.",
           },
         },
       },

--- a/src/controllers/connections/types.ts
+++ b/src/controllers/connections/types.ts
@@ -1,5 +1,15 @@
 import { t } from "elysia";
 
+// Base64-encoded binary field. importSession.ts decodes these via
+// Buffer.from(..., "base64"); validating the shape at the schema turns
+// malformed input into a clear 422 instead of silently corrupted creds that
+// only surface later as a failed handshake.
+const base64String = (description?: string) =>
+  t.String({
+    pattern: "^[A-Za-z0-9+/]+={0,2}$",
+    ...(description ? { description } : {}),
+  });
+
 export const userJid = (moreInfo?: string) =>
   t.String({
     description: `User JID${moreInfo ? ` [${moreInfo}]` : ""}`,
@@ -35,21 +45,24 @@ export const phoneNumberParams = t.Object({
 export const extractedSession = t.Object(
   {
     noiseCandidates: t.Array(
-      t.Object({ private: t.String(), public: t.String() }),
+      t.Object({ private: base64String(), public: base64String() }),
       {
         minItems: 1,
         description:
           "Noise keypair candidates (base64). Only one is the real pair; the server cycles them until the socket opens.",
       },
     ),
-    identityKey: t.Object({ private: t.String(), public: t.String() }),
+    identityKey: t.Object({
+      private: base64String(),
+      public: base64String(),
+    }),
     registrationId: t.Number(),
-    advSecretKey: t.String({ description: "ADV secret key (base64)" }),
+    advSecretKey: base64String("ADV secret key (base64)"),
     account: t.Object({
-      details: t.String(),
-      accountSignatureKey: t.String(),
-      accountSignature: t.String(),
-      deviceSignature: t.String(),
+      details: base64String(),
+      accountSignatureKey: base64String(),
+      accountSignature: base64String(),
+      deviceSignature: base64String(),
     }),
     id: t.String({
       description: "Companion device JID",
@@ -60,13 +73,13 @@ export const extractedSession = t.Object(
     signedPreKey: t.Optional(
       t.Object({
         keyId: t.Number(),
-        private: t.String(),
-        public: t.String(),
-        signature: t.String(),
+        private: base64String(),
+        public: base64String(),
+        signature: base64String(),
       }),
     ),
     pushName: t.Optional(t.String()),
-    routingInfo: t.Optional(t.String()),
+    routingInfo: t.Optional(base64String()),
   },
   {
     description:

--- a/src/controllers/connections/types.ts
+++ b/src/controllers/connections/types.ts
@@ -3,10 +3,13 @@ import { t } from "elysia";
 // Base64-encoded binary field. importSession.ts decodes these via
 // Buffer.from(..., "base64"); validating the shape at the schema turns
 // malformed input into a clear 422 instead of silently corrupted creds that
-// only surface later as a failed handshake.
+// only surface later as a failed handshake. The pattern enforces canonical
+// base64: non-empty, length a multiple of 4, with correct `=` padding only in
+// the final quad — not just an allowed-character check.
 const base64String = (description?: string) =>
   t.String({
-    pattern: "^[A-Za-z0-9+/]+={0,2}$",
+    pattern:
+      "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})$",
     ...(description ? { description } : {}),
   });
 

--- a/src/controllers/connections/types.ts
+++ b/src/controllers/connections/types.ts
@@ -94,6 +94,56 @@ export const extractedSession = t.Object(
   },
 );
 
+// Shared connection-options request fields. Spread into both POST /:phoneNumber
+// and POST /:phoneNumber/import-session so the two bodies cannot drift apart as
+// options are added or their descriptions/defaults change.
+export const connectionOptionsSchema = {
+  clientName: t.Optional(
+    t.String({
+      description: "Name of the client to be used on WhatsApp connection",
+      example: "My WhatsApp Client",
+    }),
+  ),
+  webhookUrl: t.String({
+    format: "uri",
+    description: "URL for receiving updates",
+    example: "http://localhost:3026/whatsapp/+1234567890",
+  }),
+  webhookVerifyToken: t.String({
+    minLength: 6,
+    description: "Token for verifying webhook",
+    example: "a3f4b2",
+  }),
+  includeMedia: t.Optional(
+    t.Boolean({
+      description:
+        "Include media in messages.upsert event payload as base64 string",
+      // TODO(v2): Change default to false.
+      default: true,
+    }),
+  ),
+  syncFullHistory: t.Optional(
+    t.Boolean({
+      description: "Sync full history of messages on connection.",
+      default: false,
+    }),
+  ),
+  groupsEnabled: t.Optional(
+    t.Boolean({
+      description:
+        "Enable full group message processing. When false, group messages are accumulated and sent as activity summaries.",
+      default: true,
+    }),
+  ),
+  autoPresenceSubscribe: t.Optional(
+    t.Boolean({
+      description:
+        "Automatically subscribe to presence updates when sending/receiving messages or typing status to/from a contact. Subscriptions are ephemeral and re-established automatically.",
+      default: false,
+    }),
+  ),
+} as const;
+
 export const iMessageKey = t.Object({
   id: t.Optional(t.String()),
   remoteJid: t.Optional(t.String()),

--- a/src/controllers/connections/types.ts
+++ b/src/controllers/connections/types.ts
@@ -28,6 +28,52 @@ export const phoneNumberParams = t.Object({
   }),
 });
 
+// Session extracted from an already-linked WhatsApp Web tab by the browser
+// extension. All binary fields are base64 strings. Optional fields must be
+// omitted when absent (not sent as null). Mirrors ExtractedSession in
+// src/baileys/importSession.ts.
+export const extractedSession = t.Object(
+  {
+    noiseCandidates: t.Array(
+      t.Object({ private: t.String(), public: t.String() }),
+      {
+        minItems: 1,
+        description:
+          "Noise keypair candidates (base64). Only one is the real pair; the server cycles them until the socket opens.",
+      },
+    ),
+    identityKey: t.Object({ private: t.String(), public: t.String() }),
+    registrationId: t.Number(),
+    advSecretKey: t.String({ description: "ADV secret key (base64)" }),
+    account: t.Object({
+      details: t.String(),
+      accountSignatureKey: t.String(),
+      accountSignature: t.String(),
+      deviceSignature: t.String(),
+    }),
+    id: t.String({
+      description: "Companion device JID",
+      example: "551101234567:12@s.whatsapp.net",
+    }),
+    lid: t.Optional(t.String()),
+    platform: t.Optional(t.String()),
+    signedPreKey: t.Optional(
+      t.Object({
+        keyId: t.Number(),
+        private: t.String(),
+        public: t.String(),
+        signature: t.String(),
+      }),
+    ),
+    pushName: t.Optional(t.String()),
+    routingInfo: t.Optional(t.String()),
+  },
+  {
+    description:
+      "Impersonation credentials — never log this object. Transported over HTTPS only.",
+  },
+);
+
 export const iMessageKey = t.Object({
   id: t.Optional(t.String()),
   remoteJid: t.Optional(t.String()),

--- a/src/controllers/connections/types.ts
+++ b/src/controllers/connections/types.ts
@@ -48,6 +48,10 @@ export const extractedSession = t.Object(
       t.Object({ private: base64String(), public: base64String() }),
       {
         minItems: 1,
+        // Bounded like the other array bodies in this controller: the list is
+        // persisted to Redis and iterated during candidate cycling, so an
+        // unbounded array is needless load. The extractor yields a handful.
+        maxItems: 20,
         description:
           "Noise keypair candidates (base64). Only one is the real pair; the server cycles them until the socket opens.",
       },

--- a/src/helpers/errorForLog.spec.ts
+++ b/src/helpers/errorForLog.spec.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "bun:test";
+import { errorForLog } from "@/helpers/errorForLog";
+
+describe("errorForLog", () => {
+  it("stringifies non-VALIDATION errors as usual", () => {
+    const out = errorForLog("INTERNAL_SERVER_ERROR", new Error("boom"));
+    expect(out).toContain("boom");
+  });
+
+  it("redacts a VALIDATION error to field paths + schema reasons, never the value", () => {
+    const error = {
+      all: [
+        {
+          path: "/session/advSecretKey",
+          message: "Expected string",
+          value: "super-secret-impersonation-credential",
+        },
+      ],
+    };
+
+    const out = errorForLog("VALIDATION", error);
+
+    expect(out).toBe(
+      "Validation failed: /session/advSecretKey (Expected string)",
+    );
+    // The rejected value (impersonation credentials) must never reach the log.
+    expect(out).not.toContain("super-secret-impersonation-credential");
+  });
+
+  it("falls back to a generic message for a VALIDATION error with no failures", () => {
+    expect(errorForLog("VALIDATION", { all: [] })).toBe("Validation failed");
+  });
+
+  it("stringifies a VALIDATION code that is not a validation-shaped error", () => {
+    const out = errorForLog("VALIDATION", new Error("weird"));
+    expect(out).toContain("weird");
+  });
+});

--- a/src/helpers/errorForLog.ts
+++ b/src/helpers/errorForLog.ts
@@ -1,0 +1,34 @@
+import { errorToString } from "@/helpers/errorToString";
+
+interface ValidationValueError {
+  path?: string;
+  message?: string;
+}
+
+// Structural check for an Elysia ValidationError's `.all` failures. A type
+// guard (not a bare cast) so accessing the failures stays type-safe, and it
+// keeps errorForLog unit-testable without constructing a real ValidationError.
+function hasValidationFailures(
+  error: unknown,
+): error is { all: ValidationValueError[] } {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    Array.isArray((error as { all?: unknown }).all)
+  );
+}
+
+// Renders an error for logging, redacting VALIDATION errors. Elysia surfaces the
+// rejected request value in a validation error's message/stack; for
+// POST /connections/:phone/import-session that value is impersonation
+// credentials, so for a VALIDATION code we emit only which fields failed and the
+// schema-derived reason (never `.value`). All other codes stringify as usual.
+export function errorForLog(code: string | number, error: unknown): string {
+  if (code !== "VALIDATION" || !hasValidationFailures(error)) {
+    return errorToString(error);
+  }
+  const details = error.all
+    .map((e) => `${e.path ?? "?"} (${e.message ?? "invalid"})`)
+    .join("; ");
+  return details ? `Validation failed: ${details}` : "Validation failed";
+}

--- a/src/test/preload.ts
+++ b/src/test/preload.ts
@@ -125,6 +125,21 @@ const mockRedis = {
         return 0;
       }
 
+      // advance-candidate-cas (owner-fenced compare-and-swap on creds):
+      // KEYS=[hash, lease], ARGV=[owner, expectedCreds, newCreds, newCursor].
+      // Checked before the generic HSET branch because this script also HSETs.
+      if (script.includes("advance-candidate-cas")) {
+        const [hashKey, leaseKey] = keys;
+        const [owner, expectedCreds, newCreds, newCursor] = args;
+        const rawLease = stringData.get(leaseKey);
+        if (rawLease && JSON.parse(rawLease).owner !== owner) return 0;
+        if (hashData.get(hashKey)?.get("creds") !== expectedCreds) return 2;
+        if (!hashData.has(hashKey)) hashData.set(hashKey, new Map());
+        hashData.get(hashKey)!.set("creds", newCreds);
+        hashData.get(hashKey)!.set("import-candidates", newCursor);
+        return 1;
+      }
+
       // write-if-owner (auth state fencing): KEYS=[hash, lease], ARGV=[owner, ...pairs]
       if (script.includes("HSET")) {
         const [hashKey, leaseKey] = keys;


### PR DESCRIPTION
## Summary

Adds `POST /connections/:phoneNumber/import-session` to transplant an already-linked WhatsApp Web session (extracted by a browser extension) into the Baileys auth state and connect as a registered companion, **bypassing QR/pairing entirely**.

This works around the **June 2026 WhatsApp passkey wall** that breaks device linking for unofficial libraries (Baileys, whatsmeow, whatsapp-web.js, etc.): the QR/pairing code is accepted but the connection never reaches `open`. The passkey ceremony is resolved once in a real browser + phone during a normal WhatsApp Web login; the resulting session is extracted and transplanted here, making the passkey a one-time onboarding cost.

## What's included

- **`mapSessionToCreds`** (`src/baileys/importSession.ts`) — maps the extracted session shape to Baileys `AuthenticationCreds`, starting from `initAuthCreds()` so runtime-only fields get valid defaults, then overlaying the transplanted identity.
- **Noise candidate cycling** — the extractor cannot resolve the Noise keypair to a single value (HKDF + IV combinations yield several candidates). The session carries all candidates; the connection cycles through them on handshake failure (close-before-open) until one opens or the list is exhausted, then clears the list on a healthy `open`.
- **Redis auth state** (`src/baileys/redisAuthState.ts`) — seeds / advances / clears import candidates under the lease.
- **Coordinator** (`src/cluster/coordinator.ts`) — `importSessionWithLease` performs an explicit takeover (409 when another live instance owns the identity).
- **Controller** (`src/controllers/connections`) — new endpoint with validation, 202/409/422 responses, and misdirect exemption for the takeover.
- **`docs/whatsapp-passkey-2026.md`** — investigation and rationale.

## Testing

`bun test` on the changed files: **192 pass, 0 fail**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/baileys-api/354)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `POST /connections/:phoneNumber/import-session` to import an extracted WhatsApp Web session (no QR) with optional candidate selection, plus OpenAPI docs and correct `202/409/422` responses.
  * Added explicit-lease session import with seeded credentials and owner-fenced progression/clearing of imported Noise candidates.
  * Added `forceRestart` to discard any live socket and spawn a fresh connection for immediate credential reload.
* **Bug Fixes**
  * Prevented reconnect-loop webhook spam during candidate cycling; advancement failures now safely fall back to normal reconnect.
  * Ensured candidate cycling does not occur when another instance owns the lease or the socket already opened.
  * Improved validation error logging to avoid exposing rejected payload details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->