### PR TITLE
chore: bump baileys to v7.0.0-rc14

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -9,7 +9,7 @@
         "@elysiajs/swagger": "^1.3.1",
         "@ffmpeg-installer/ffmpeg": "^1.1.0",
         "@hapi/boom": "^10.0.1",
-        "@whiskeysockets/baileys": "7.0.0-rc13",
+        "@whiskeysockets/baileys": "7.0.0-rc14",
         "audio-decode": "^2.2.3",
         "elysia": "^1.4.29",
         "fluent-ffmpeg": "^2.1.3",
@@ -35,7 +35,7 @@
     },
   },
   "patchedDependencies": {
-    "@whiskeysockets/baileys@7.0.0-rc13": "patches/@whiskeysockets%2Fbaileys@7.0.0-rc13.patch",
+    "@whiskeysockets/baileys@7.0.0-rc14": "patches/@whiskeysockets%2Fbaileys@7.0.0-rc14.patch",
   },
   "packages": {
     "@biomejs/biome": ["@biomejs/biome@2.5.2", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.5.2", "@biomejs/cli-darwin-x64": "2.5.2", "@biomejs/cli-linux-arm64": "2.5.2", "@biomejs/cli-linux-arm64-musl": "2.5.2", "@biomejs/cli-linux-x64": "2.5.2", "@biomejs/cli-linux-x64-musl": "2.5.2", "@biomejs/cli-win32-arm64": "2.5.2", "@biomejs/cli-win32-x64": "2.5.2" }, "bin": { "biome": "bin/biome" } }, "sha512-VQ3RCqr7JmDIX+w6stWYl+g/3bYofN3q2wDBHUKKc/c7i5QWrFKFBZYCYPWTE6agsUPMIZZe6/CMmVUfUAhkKA=="],
@@ -212,7 +212,7 @@
 
     "@wasm-audio-decoders/opus-ml": ["@wasm-audio-decoders/opus-ml@0.0.1", "", { "dependencies": { "@wasm-audio-decoders/common": "9.0.7" } }, "sha512-FALuUCz10HS2h8KB4L7wmfXncOuBDFvlKRk6Ga2rw8sr/zNIpwCjhhomxH4JKPhVLOnBjZfrPa8aTFIQq74vzQ=="],
 
-    "@whiskeysockets/baileys": ["@whiskeysockets/baileys@7.0.0-rc13", "", { "dependencies": { "@cacheable/node-cache": "^1.4.0", "@hapi/boom": "^9.1.3", "async-mutex": "^0.5.0", "libsignal": "^6.0.0", "lru-cache": "^11.1.0", "music-metadata": "^11.12.3", "p-queue": "^9.0.0", "pino": "^9.6", "protobufjs": "^7.5.6", "whatsapp-rust-bridge": "0.5.4", "ws": "^8.13.0" }, "peerDependencies": { "audio-decode": "^2.1.3", "jimp": "^1.6.1", "link-preview-js": "^3.0.0", "sharp": "*" }, "optionalPeers": ["audio-decode", "jimp", "link-preview-js"] }, "sha512-8JPc8gaaCRykkjW2jxLGQ7/RZGrc7awO7WU+QJocf58eSUI9jAdcuYLynzhAbyU4UWvJJsHImZ+5E/JaZj5ypA=="],
+    "@whiskeysockets/baileys": ["@whiskeysockets/baileys@7.0.0-rc14", "", { "dependencies": { "@cacheable/node-cache": "^1.4.0", "@hapi/boom": "^9.1.3", "async-mutex": "^0.5.0", "libsignal": "^6.0.0", "lru-cache": "^11.1.0", "music-metadata": "^11.12.3", "p-queue": "^9.0.0", "pino": "^9.6", "protobufjs": "^7.5.6", "whatsapp-rust-bridge": "0.5.4", "ws": "^8.13.0" }, "peerDependencies": { "audio-decode": "^2.1.3", "jimp": "^1.6.1", "link-preview-js": "^3.0.0", "sharp": "*" }, "optionalPeers": ["audio-decode", "jimp", "link-preview-js"] }, "sha512-WK+X8ju8TPGxvWIsP8hrY6JB6FltYuFe+vsqKfjOYX25JObij9qLf2c3ZGdl1Q+vhFwbnT+AZmWAB5pTvzmSiQ=="],
 
     "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
@@ -495,8 +495,6 @@
     "@scalar/themes/@scalar/types": ["@scalar/types@0.1.1", "", { "dependencies": { "@scalar/openapi-types": "0.1.9", "@unhead/schema": "^1.11.11", "zod": "^3.23.8" } }, "sha512-LlUX6AmOOGoRqOMoO835V2FezM1KiO5UlvQC3poT/s7oqD6ranqwRNFxyrPz/IxClPYR+SV1yBUSNKely4ZQhQ=="],
 
     "@whiskeysockets/baileys/@hapi/boom": ["@hapi/boom@9.1.4", "", { "dependencies": { "@hapi/hoek": "9.x.x" } }, "sha512-Ls1oH8jaN1vNsqcaHVYJrKmgMcKsC1wcp8bujvXrHaAqD2iDYq3HoOwsxwo09Cuda5R5nC0o0IxlrlTuvPuzSw=="],
-
-    "@whiskeysockets/baileys/lru-cache": ["lru-cache@11.5.0", "", {}, "sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA=="],
 
     "@whiskeysockets/baileys/pino": ["pino@9.7.0", "", { "dependencies": { "atomic-sleep": "^1.0.0", "fast-redact": "^3.1.1", "on-exit-leak-free": "^2.1.0", "pino-abstract-transport": "^2.0.0", "pino-std-serializers": "^7.0.0", "process-warning": "^5.0.0", "quick-format-unescaped": "^4.0.3", "real-require": "^0.2.0", "safe-stable-stringify": "^2.3.1", "sonic-boom": "^4.0.1", "thread-stream": "^3.0.0" }, "bin": { "pino": "bin.js" } }, "sha512-vnMCM6xZTb1WDmLvtG2lE/2p+t9hDEIvTWJsu6FejkE62vB7gDhvzrpFR4Cw2to+9JNQxVnkAKVPA1KPB98vWg=="],
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@elysiajs/swagger": "^1.3.1",
     "@ffmpeg-installer/ffmpeg": "^1.1.0",
     "@hapi/boom": "^10.0.1",
-    "@whiskeysockets/baileys": "7.0.0-rc13",
+    "@whiskeysockets/baileys": "7.0.0-rc14",
     "audio-decode": "^2.2.3",
     "elysia": "^1.4.29",
     "fluent-ffmpeg": "^2.1.3",
@@ -50,6 +50,6 @@
     "typescript": "^6.0.3"
   },
   "patchedDependencies": {
-    "@whiskeysockets/baileys@7.0.0-rc13": "patches/@whiskeysockets%2Fbaileys@7.0.0-rc13.patch"
+    "@whiskeysockets/baileys@7.0.0-rc14": "patches/@whiskeysockets%2Fbaileys@7.0.0-rc14.patch"
   }
 }

--- a/patches/@whiskeysockets%2Fbaileys@7.0.0-rc14.patch
+++ b/patches/@whiskeysockets%2Fbaileys@7.0.0-rc14.patch
@@ -47,10 +47,10 @@ index 0004fb678bf732ec3fd5ec35ae48594bd5960c43..c0802d9e512724d06ef8f3bdd52f0325
  export type MessageGenerationOptionsFromContent = MiscMessageGenerationOptions & {
      userJid: string;
 diff --git a/lib/Utils/link-preview.js b/lib/Utils/link-preview.js
-index 0f4ff1ce169432faa8b0a7d2e2bca874c1d8092d..840dd0d7e0c78ceab41dfa8e224990730797e136 100644
+index 0f4ff1ce169432faa8b0a7d2e2bca874c1d8092d..740c45d80b39355b4585e2af5f808aaf71e7be00 100644
 --- a/lib/Utils/link-preview.js
 +++ b/lib/Utils/link-preview.js
-@@ -1,6 +1,53 @@
+@@ -1,6 +1,52 @@
  import { prepareWAMessageMedia } from './messages.js';
  import { extractImageThumb, getHttpStream } from './messages-media.js';
  const THUMBNAIL_WIDTH_PX = 192;
@@ -92,11 +92,10 @@ index 0f4ff1ce169432faa8b0a7d2e2bca874c1d8092d..840dd0d7e0c78ceab41dfa8e22499073
 +        description: `${data.author_name}`,
 +        mediaType: 'video.other',
 +        contentType: 'text/html; charset=utf-8',
-+        images: [
-+            `https://img.youtube.com/vi/${videoId}/maxresdefault.jpg`,
-+            `https://img.youtube.com/vi/${videoId}/sddefault.jpg`,
-+            data.thumbnail_url
-+        ],
++        // getUrlInfo reads only images[0] and downscales it to thumbnailWidth
++        // (192px by default), so prefer the variant that always exists over
++        // higher-resolution ones that 404 on older or low-quality uploads.
++        images: [data.thumbnail_url || `https://img.youtube.com/vi/${videoId}/hqdefault.jpg`],
 +        videos: [],
 +        favicons: ['https://www.youtube.com/favicon.ico']
 +    };
@@ -104,7 +103,7 @@ index 0f4ff1ce169432faa8b0a7d2e2bca874c1d8092d..840dd0d7e0c78ceab41dfa8e22499073
  /** Fetches an image and generates a thumbnail for it */
  const getCompressedJpegThumbnail = async (url, { thumbnailWidth, fetchOpts }) => {
      const stream = await getHttpStream(url, fetchOpts);
-@@ -26,27 +73,33 @@ export const getUrlInfo = async (text, opts = {
+@@ -26,27 +72,36 @@ export const getUrlInfo = async (text, opts = {
          if (!text.startsWith('https://') && !text.startsWith('http://')) {
              previewLink = 'https://' + previewLink;
          }
@@ -130,7 +129,10 @@ index 0f4ff1ce169432faa8b0a7d2e2bca874c1d8092d..840dd0d7e0c78ceab41dfa8e22499073
 -            headers: opts.fetchOpts?.headers
 -        });
 +        let info;
-+        if (isYouTubeUrl(previewLink)) {
++        // isYouTubeUrl matches on a substring, so a host like notyoutube.com
++        // passes it. getVideoId validates the hostname; gating on it keeps such
++        // URLs on the generic path instead of throwing 'Invalid YouTube URL'.
++        if (isYouTubeUrl(previewLink) && getVideoId(previewLink)) {
 +            info = await getYouTubeLinkPreview(previewLink, opts.fetchOpts);
 +        }
 +        else {

--- a/patches/@whiskeysockets%2Fbaileys@7.0.0-rc14.patch
+++ b/patches/@whiskeysockets%2Fbaileys@7.0.0-rc14.patch
@@ -12,10 +12,10 @@ index 311fb3ef977e3f8bd091650e2f484ce57f12e91c..b1d29fdf662b7afb2649ff876f359a3d
              this.socket?.on(event, (...args) => this.emit(event, ...args));
          }
 diff --git a/lib/Socket/socket.js b/lib/Socket/socket.js
-index 6357f9ee191bb76873b3c2777d7da1b68dd36fdd..b3f8b0e37eca27925302f3a2b43b4c401d2166ba 100644
+index ae34a8f315a0b9fd101472cc69e59624c6c63861..c4ddb74ddb49d1e161e6746147fca17e949e4b35 100644
 --- a/lib/Socket/socket.js
 +++ b/lib/Socket/socket.js
-@@ -274,6 +274,9 @@ export const makeSocket = (config) => {
+@@ -277,6 +277,9 @@ export const makeSocket = (config) => {
      const socketEndHandlers = [];
      /** log & process any unexpected errors */
      const onUnexpectedError = (err, msg) => {


### PR DESCRIPTION
Bumps `@whiskeysockets/baileys` from `7.0.0-rc13` to `7.0.0-rc14`.

## Upstream changes

No breaking changes. The public type surface only gained additions (`Browsers.android`, `buildProfilePictureQueryContent`); nothing was removed or had its signature changed.

- **`fix: nest profile picture tc token` (#2607)** — the tctoken was sent as a sibling of the `picture` node instead of nested inside it, and without the required `t` timestamp attribute, so the server never responded. This is the one upstream fix that affects us directly, since `profilePictureUrl` is exposed in `src/controllers/connections/index.ts`.
- **`chore: update WhatsApp Web version`** — `2.3000.1035194821` → `2.3000.1043857760`. Low impact here: `fetchBaileysClientVersion` resolves the version at runtime via `fetchLatestWaWebVersion`, so this constant only serves as the fallback when that fetch fails.
- **`feat: add android browser` (#2201)** — additive, see the note below.
- **`fix: add Long type import` (#2586)** — type-only, no runtime effect.

## Patch regenerated

rc14 inserts three lines into `lib/Socket/socket.js` immediately before the `onUnexpectedError` hunk our patch targets. With the hunk shifted, `bun install` applied 4 of 5 hunks and **silently dropped the fifth** — the `if (!ws.isOpen) return;` guard never made it into `node_modules`, which would have brought back `unexpected error in '...'` log noise on normal disconnects.

The patch is regenerated against rc14 with correct blob hashes. Verified on a from-scratch install with an isolated bun cache (mirroring CI/Docker): all 5 hunks apply.

## Verification

- `bun check` (lint + `tsc --noEmit` + tests) passes: 445 tests, 0 failures.
- Runtime smoke test against the patched rc14: all 16 value imports resolve, `initAuthCreds`, `BufferJSON` round-trip and `proto.Message.AppStateSyncKeyData` all work.

## Follow-up worth considering (not in this PR)

rc14 now inspects `config.browser[1]` and, if it contains "android", switches the `ClientPayload` platform to `ANDROID` and omits `webInfo` from the connection handshake. We pass `Browsers.windows(this.clientName)`, which puts `clientName` in exactly that position — and `clientName` is caller-supplied via the request body as an unconstrained `t.String()`. A client naming itself something like "MyApp Android" would silently alter the handshake. Harmless on the default (`"Chrome"`), but it changed from an inert label into a protocol-affecting field. Left out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/baileys-api/363)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebSocket error handling by reducing event forwarding and suppressing “unexpected error” when the socket isn’t open.
  * Enhanced YouTube link previews with richer metadata (title, author/description, and thumbnails).
  * Improved audio waveform generation by supporting an alternate waveform input when available.
* **Improvements**
  * Document media messages can now omit MIME type when it’s unavailable.
* **Chores**
  * Upgraded the underlying WhatsApp/transport library to the newer release candidate version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->