### PR TITLE
fix: quarantine phones whose reconnect cycles keep failing

### DIFF
--- a/src/baileys/connection.spec.ts
+++ b/src/baileys/connection.spec.ts
@@ -683,6 +683,89 @@ describe("BaileysConnection", () => {
       }
     });
 
+    it("records quarantine strikes with doubling backoff and reports them on the webhook", async () => {
+      setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+      try {
+        const quarantineKey = "@baileys-api:cluster:quarantine:+5511999999999";
+        const stringData = (redis as any).__stringData as Map<string, string>;
+
+        await connection.connect();
+        let handler = mockEventHandlers.get("connection.update")!;
+        for (let i = 0; i < 11; i++) {
+          await handler({ isNewLogin: true });
+        }
+
+        // The isNewLogin path fires handleReconnecting without awaiting it,
+        // so the strike lands asynchronously.
+        while (!stringData.has(quarantineKey)) {
+          await new Promise((r) => setImmediate(r));
+        }
+        let stored = JSON.parse(stringData.get(quarantineKey)!) as {
+          strikes: number;
+          nextRetryAt: number;
+        };
+        expect(stored.strikes).toBe(1);
+        expect(stored.nextRetryAt).toBe(
+          Date.parse("2026-01-01T00:00:00.000Z") + 60_000,
+        );
+        // The webhook advertises the quarantine so clients can render the
+        // real state instead of a bare "try reconnecting".
+        while (
+          !fetchCalls.some(
+            (c) =>
+              c.body?.includes('"error":"reconnect_loop_detected"') &&
+              c.body?.includes('"quarantine"') &&
+              c.body?.includes('"strikes":1'),
+          )
+        ) {
+          await new Promise((r) => setImmediate(r));
+        }
+
+        // A second full failed cycle doubles the backoff.
+        connection = new BaileysConnection("+5511999999999", defaultOptions);
+        await connection.connect();
+        handler = mockEventHandlers.get("connection.update")!;
+        for (let i = 0; i < 11; i++) {
+          await handler({ isNewLogin: true });
+        }
+        while (
+          (JSON.parse(stringData.get(quarantineKey)!) as { strikes: number })
+            .strikes < 2
+        ) {
+          await new Promise((r) => setImmediate(r));
+        }
+        stored = JSON.parse(stringData.get(quarantineKey)!) as {
+          strikes: number;
+          nextRetryAt: number;
+        };
+        expect(stored.strikes).toBe(2);
+        expect(stored.nextRetryAt).toBe(
+          Date.parse("2026-01-01T00:00:00.000Z") + 120_000,
+        );
+      } finally {
+        setSystemTime();
+      }
+    });
+
+    it("clears quarantine when the connection opens", async () => {
+      const quarantineKey = "@baileys-api:cluster:quarantine:+5511999999999";
+      const stringData = (redis as any).__stringData as Map<string, string>;
+      stringData.set(
+        quarantineKey,
+        JSON.stringify({ strikes: 3, nextRetryAt: Date.now() + 60_000 }),
+      );
+
+      await connection.connect();
+      const handler = mockEventHandlers.get("connection.update")!;
+      await handler({ connection: "open" });
+
+      // clearQuarantine is fire-and-forget on the open path.
+      while (stringData.has(quarantineKey)) {
+        await new Promise((r) => setImmediate(r));
+      }
+      expect(stringData.has(quarantineKey)).toBe(false);
+    });
+
     it("does not resurrect the socket via the post-close reconnect after aborting", async () => {
       await connection.connect();
       const handler = mockEventHandlers.get("connection.update")!;

--- a/src/baileys/connection.ts
+++ b/src/baileys/connection.ts
@@ -38,6 +38,11 @@ import type {
 } from "@/baileys/types";
 import { instanceId } from "@/cluster/identity";
 import { getLease } from "@/cluster/leaseStore";
+import {
+  clearQuarantine,
+  type QuarantineState,
+  recordStrike,
+} from "@/cluster/quarantineStore";
 import config from "@/config";
 import { asyncSleep } from "@/helpers/asyncSleep";
 import { errorToString } from "@/helpers/errorToString";
@@ -917,10 +922,15 @@ export class BaileysConnection {
           this.abort();
           return;
         }
-        logger.debug(
-          "[%s] [handleConnectionUpdate] Reconnecting (lastDisconnect=%o)",
+        // warn, not debug: production typically runs at LOG_LEVEL=warn and
+        // the close reason is the one datum that explains a reconnect loop
+        // (e.g. the server rejecting every handshake with stream:error 503).
+        logger.warn(
+          "[%s] [handleConnectionUpdate] connection closed (statusCode=%s, message=%s), reconnecting (attempt %d)",
           this.phoneNumber,
-          lastDisconnect ?? {},
+          String(statusCode ?? "unknown"),
+          message ?? "",
+          this.reconnectCount + 1,
         );
         await this.handleReconnecting();
         // NOTE: We don't call `this.close()` here because we want to keep the auth state.
@@ -970,6 +980,16 @@ export class BaileysConnection {
 
     if (data.connection === "open") {
       this.reconnectCount = 0;
+      // Any healthy open wipes the quarantine strike history — the backoff
+      // must reflect CONSECUTIVE failed cycles, not lifetime totals. Not
+      // awaited (the open path must not block on it), rejection logged.
+      clearQuarantine(this.phoneNumber).catch((clearError) => {
+        logger.warn(
+          "[%s] [handleConnectionUpdate] clearQuarantine failed; background claims may skip this phone until the stale entry expires (error=%s)",
+          this.phoneNumber,
+          errorToString(clearError),
+        );
+      });
       const isFirstOpen = !this.hasOpened;
       this.hasOpened = true;
       if (isFirstOpen) {
@@ -1214,15 +1234,42 @@ export class BaileysConnection {
   private async handleReconnecting() {
     this.reconnectCount += 1;
     if (this.reconnectCount > 10) {
+      // abort() first and SYNCHRONOUSLY: with an await between the decision
+      // and the abort, a socket event landing in that window (e.g. a late
+      // "open") races a connection this guard already condemned. The strike
+      // lands after — still ahead of any background re-claim, because the
+      // abort does not release the lease; it only expires by TTL seconds
+      // from now.
+      this.abort();
+      let quarantine: QuarantineState | null = null;
+      try {
+        quarantine = await recordStrike(this.phoneNumber);
+      } catch (error) {
+        logger.warn(
+          "[%s] [handleReconnecting] failed to record quarantine strike: %s",
+          this.phoneNumber,
+          errorToString(error),
+        );
+      }
       logger.warn(
-        "[%s] [handleReconnecting] Reconnect count exceeded 10, aborting reconnection (auth state preserved)",
+        "[%s] [handleReconnecting] Reconnect count exceeded 10, aborting reconnection (auth state preserved)%s",
         this.phoneNumber,
+        quarantine
+          ? `; quarantined until ${new Date(quarantine.nextRetryAt).toISOString()} (strike ${quarantine.strikes})`
+          : "",
       );
       this.sendToWebhook({
         event: "connection.update",
-        data: { error: "reconnect_loop_detected" },
+        data: {
+          error: "reconnect_loop_detected",
+          ...(quarantine && {
+            quarantine: {
+              strikes: quarantine.strikes,
+              until: new Date(quarantine.nextRetryAt).toISOString(),
+            },
+          }),
+        },
       });
-      this.abort();
       return;
     }
     this.sendToWebhook({

--- a/src/baileys/types.ts
+++ b/src/baileys/types.ts
@@ -39,7 +39,13 @@ export interface BaileysConnectionWebhookPayload {
   data:
     | BaileysEventMap[keyof BaileysEventMap]
     | (BaileysEventMap["connection.update"] & { epoch?: number })
-    | { error: string };
+    | {
+        error: string;
+        // Present on reconnect_loop_detected when the phone entered
+        // quarantine: consecutive failed reconnect cycles and when background
+        // claims will retry. Explicit POST /connections retries immediately.
+        quarantine?: { strikes: number; until: string };
+      };
   extra?: unknown;
 }
 

--- a/src/cluster/coordinator.spec.ts
+++ b/src/cluster/coordinator.spec.ts
@@ -11,6 +11,7 @@ import type { BaileysConnectionsHandler } from "@/baileys/connectionsHandler";
 import * as redisAuthState from "@/baileys/redisAuthState";
 import * as registry from "@/cluster/instanceRegistry";
 import * as leaseStore from "@/cluster/leaseStore";
+import * as quarantineStore from "@/cluster/quarantineStore";
 import config from "@/config";
 import {
   BaileysConnectionOwnedElsewhereError,
@@ -38,6 +39,8 @@ const isOnOwnReleaseCooldown = spyOn(leaseStore, "isOnOwnReleaseCooldown");
 const setReleaseCooldown = spyOn(leaseStore, "setReleaseCooldown");
 const setHandoffTarget = spyOn(leaseStore, "setHandoffTarget");
 const getHandoffTarget = spyOn(leaseStore, "getHandoffTarget");
+const isQuarantined = spyOn(quarantineStore, "isQuarantined");
+const clearQuarantine = spyOn(quarantineStore, "clearQuarantine");
 
 afterAll(() => {
   getRedisSavedAuthStateIds.mockRestore();
@@ -56,6 +59,8 @@ afterAll(() => {
   setReleaseCooldown.mockRestore();
   setHandoffTarget.mockRestore();
   getHandoffTarget.mockRestore();
+  isQuarantined.mockRestore();
+  clearQuarantine.mockRestore();
 });
 
 function makeHandlerMock() {
@@ -133,6 +138,8 @@ describe("ClusterCoordinator", () => {
     setReleaseCooldown.mockReset();
     setHandoffTarget.mockReset();
     getHandoffTarget.mockReset();
+    isQuarantined.mockReset();
+    clearQuarantine.mockReset();
 
     getRedisSavedAuthStateIds.mockResolvedValue([]);
     isRedisAuthStatePaired.mockResolvedValue(true);
@@ -153,6 +160,8 @@ describe("ClusterCoordinator", () => {
     setReleaseCooldown.mockResolvedValue(undefined);
     setHandoffTarget.mockResolvedValue(undefined);
     getHandoffTarget.mockResolvedValue(null);
+    isQuarantined.mockResolvedValue(false);
+    clearQuarantine.mockResolvedValue(undefined);
   });
 
   describe("#runClaimCycle", () => {
@@ -176,6 +185,26 @@ describe("ClusterCoordinator", () => {
       expect(options.webhookUrl).toBe("https://h.com");
       // Epoch of the acquireLease that authorized this reconnect.
       expect(options.leaseEpoch).toBe(1);
+    });
+
+    it("skips quarantined phones and claims them again once quarantine lapses", async () => {
+      const handler = makeHandlerMock();
+      const coordinator = makeCoordinator(handler);
+      getRedisSavedAuthStateIds.mockResolvedValue([savedEntry("+5511999")]);
+      isQuarantined.mockResolvedValue(true);
+
+      await coordinator.runClaimCycle();
+
+      // Claiming a quarantined phone would restart the exact reconnect
+      // livelock the quarantine is throttling.
+      expect(acquireLease).not.toHaveBeenCalled();
+      expect(handler.connect).not.toHaveBeenCalled();
+
+      isQuarantined.mockResolvedValue(false);
+      await coordinator.runClaimCycle();
+
+      expect(acquireLease).toHaveBeenCalledTimes(1);
+      expect(handler.connect).toHaveBeenCalledTimes(1);
     });
 
     it("does not touch phones it already holds a connection for", async () => {
@@ -701,6 +730,32 @@ describe("ClusterCoordinator", () => {
       });
     });
 
+    it("clears quarantine — explicit intent must retry immediately", async () => {
+      const handler = makeHandlerMock();
+      const coordinator = makeCoordinator(handler);
+
+      await coordinator.connectWithLease("+5511999", {
+        webhookUrl: "https://h.com",
+        webhookVerifyToken: "t",
+      });
+
+      expect(clearQuarantine).toHaveBeenCalledWith("+5511999");
+      expect(handler.connect).toHaveBeenCalled();
+    });
+
+    it("still connects when the quarantine clear fails", async () => {
+      const handler = makeHandlerMock();
+      const coordinator = makeCoordinator(handler);
+      clearQuarantine.mockRejectedValue(new Error("redis down"));
+
+      await coordinator.connectWithLease("+5511999", {
+        webhookUrl: "https://h.com",
+        webhookVerifyToken: "t",
+      });
+
+      expect(handler.connect).toHaveBeenCalled();
+    });
+
     it("releases the force-acquired lease when connect fails", async () => {
       const handler = makeHandlerMock();
       const coordinator = makeCoordinator(handler);
@@ -815,6 +870,22 @@ describe("ClusterCoordinator", () => {
         leaseEpoch: 1,
         forceRestart: true,
       });
+    });
+
+    it("clears quarantine — a fresh import must not inherit old strikes", async () => {
+      const handler = makeHandlerMock();
+      const coordinator = makeCoordinator(handler);
+
+      await coordinator.importSessionWithLease(
+        "+5511999",
+        creds,
+        candidates,
+        0,
+        options,
+      );
+
+      expect(clearQuarantine).toHaveBeenCalledWith("+5511999");
+      expect(handler.connect).toHaveBeenCalled();
     });
 
     it("seeds only after acquiring the lease (fence needs ownership)", async () => {

--- a/src/cluster/coordinator.ts
+++ b/src/cluster/coordinator.ts
@@ -9,6 +9,7 @@ import type { BaileysConnectionOptions } from "@/baileys/types";
 import { instanceId } from "@/cluster/identity";
 import * as registry from "@/cluster/instanceRegistry";
 import * as leaseStore from "@/cluster/leaseStore";
+import * as quarantineStore from "@/cluster/quarantineStore";
 import config from "@/config";
 import { asyncSleep } from "@/helpers/asyncSleep";
 import { errorToString } from "@/helpers/errorToString";
@@ -291,6 +292,14 @@ export class ClusterCoordinator {
           continue;
         }
         if (!directedAtMe && (await leaseStore.isOnOwnReleaseCooldown(id))) {
+          continue;
+        }
+        // A quarantined phone just burned a full reconnect cycle (10
+        // attempts, abort); claiming it again before its backoff elapses
+        // reproduces the exact livelock quarantine exists to break. Directed
+        // handoffs bypass this like they bypass fair share — rebalance only
+        // moves live sockets, which by definition are not quarantined.
+        if (!directedAtMe && (await quarantineStore.isQuarantined(id))) {
           continue;
         }
         // A phone that never finished pairing has no session to resume; a QR
@@ -685,6 +694,22 @@ export class ClusterCoordinator {
     }
   }
 
+  // Explicit intent overrides quarantine: the operator asked for this phone
+  // NOW. Best-effort — a failed clear must not block the connect; worst case
+  // background claims keep skipping the phone until the stale entry expires,
+  // while this explicit attempt proceeds regardless.
+  private async clearQuarantineForExplicitIntent(phoneNumber: string) {
+    try {
+      await quarantineStore.clearQuarantine(phoneNumber);
+    } catch (error) {
+      logger.warn(
+        "[coordinator] failed to clear quarantine for %s: %s",
+        phoneNumber,
+        errorToString(error),
+      );
+    }
+  }
+
   // Explicit user intent (POST /connections) — takes the identity over even if
   // a lease exists. In standalone this matches today's single-instance
   // semantics (the request is authoritative).
@@ -693,6 +718,7 @@ export class ClusterCoordinator {
     options: BaileysConnectionOptions,
   ) {
     const acquired = await this.acquireExplicitLease(phoneNumber);
+    await this.clearQuarantineForExplicitIntent(phoneNumber);
     await this.runUnderExplicitLease(phoneNumber, () =>
       this.handler.connect(phoneNumber, {
         ...options,
@@ -715,6 +741,7 @@ export class ClusterCoordinator {
     options: BaileysConnectionOptions,
   ) {
     const acquired = await this.acquireExplicitLease(phoneNumber);
+    await this.clearQuarantineForExplicitIntent(phoneNumber);
     await this.runUnderExplicitLease(phoneNumber, async () => {
       // Creds and the candidate cursor are written together (single fenced
       // write), so an import never lands with one persisted but not the other.

--- a/src/cluster/keys.ts
+++ b/src/cluster/keys.ts
@@ -10,6 +10,9 @@ export const clusterKeys = {
   instancePattern: `${prefix}:instance:*`,
   handoff: (phoneNumber: string) => `${prefix}:handoff:${phoneNumber}`,
   cooldown: (phoneNumber: string) => `${prefix}:cooldown:${phoneNumber}`,
+  // Backoff state for phones whose reconnect cycles keep failing — see
+  // cluster/quarantineStore.ts.
+  quarantine: (phoneNumber: string) => `${prefix}:quarantine:${phoneNumber}`,
   eventsChannel: `${prefix}:events`,
 };
 

--- a/src/cluster/quarantineStore.spec.ts
+++ b/src/cluster/quarantineStore.spec.ts
@@ -1,0 +1,141 @@
+import { beforeEach, describe, expect, it, setSystemTime } from "bun:test";
+import config from "@/config";
+import redis from "@/lib/redis";
+import { clusterKeys } from "./keys";
+import {
+  backoffMs,
+  clearQuarantine,
+  isQuarantined,
+  recordStrike,
+} from "./quarantineStore";
+
+const stringData = (redis as any).__stringData as Map<string, string>;
+
+const PHONE = "+5511999999999";
+const KEY = clusterKeys.quarantine(PHONE);
+
+// config is the shared preload mock — restore even if a test throws, or every
+// spec file that runs after this one sees the mutated values.
+const withQuarantineConfig = async (
+  overrides: Partial<{
+    quarantineEnabled: boolean;
+    quarantineBaseMs: number;
+    quarantineMaxMs: number;
+  }>,
+  fn: () => Promise<void>,
+) => {
+  const previous = {
+    quarantineEnabled: config.cluster.quarantineEnabled,
+    quarantineBaseMs: config.cluster.quarantineBaseMs,
+    quarantineMaxMs: config.cluster.quarantineMaxMs,
+  };
+  Object.assign(config.cluster, overrides);
+  try {
+    await fn();
+  } finally {
+    Object.assign(config.cluster, previous);
+  }
+};
+
+describe("quarantineStore", () => {
+  beforeEach(() => {
+    stringData.clear();
+  });
+
+  describe("backoffMs", () => {
+    it("doubles per strike from the base and caps at the max", () => {
+      expect(backoffMs(1)).toBe(60_000);
+      expect(backoffMs(2)).toBe(120_000);
+      expect(backoffMs(3)).toBe(240_000);
+      // 60s * 2^6 = 64min > 1h cap.
+      expect(backoffMs(7)).toBe(3_600_000);
+      // Far past the exponent clamp: still the cap, never Infinity/NaN.
+      expect(backoffMs(10_000)).toBe(3_600_000);
+    });
+  });
+
+  describe("recordStrike", () => {
+    it("starts at one strike and doubles the wait on each further strike", async () => {
+      setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+      try {
+        const now = Date.parse("2026-01-01T00:00:00.000Z");
+
+        const first = await recordStrike(PHONE);
+        expect(first).toEqual({ strikes: 1, nextRetryAt: now + 60_000 });
+
+        const second = await recordStrike(PHONE);
+        expect(second).toEqual({ strikes: 2, nextRetryAt: now + 120_000 });
+
+        const stored = JSON.parse(stringData.get(KEY)!);
+        expect(stored.strikes).toBe(2);
+      } finally {
+        setSystemTime();
+      }
+    });
+
+    it("restarts the count on a corrupted entry instead of failing the abort path", async () => {
+      stringData.set(KEY, "not-json");
+
+      const state = await recordStrike(PHONE);
+
+      expect(state?.strikes).toBe(1);
+    });
+
+    it("is a no-op when quarantine is disabled", async () => {
+      await withQuarantineConfig({ quarantineEnabled: false }, async () => {
+        const state = await recordStrike(PHONE);
+
+        expect(state).toBeNull();
+        expect(stringData.has(KEY)).toBe(false);
+      });
+    });
+  });
+
+  describe("isQuarantined", () => {
+    it("is false with no entry", async () => {
+      expect(await isQuarantined(PHONE)).toBe(false);
+    });
+
+    it("is true until nextRetryAt, false afterwards", async () => {
+      stringData.set(
+        KEY,
+        JSON.stringify({ strikes: 1, nextRetryAt: Date.now() + 60_000 }),
+      );
+      expect(await isQuarantined(PHONE)).toBe(true);
+
+      stringData.set(
+        KEY,
+        JSON.stringify({ strikes: 1, nextRetryAt: Date.now() - 1 }),
+      );
+      expect(await isQuarantined(PHONE)).toBe(false);
+    });
+
+    it("is false on a corrupted entry", async () => {
+      stringData.set(KEY, "not-json");
+      expect(await isQuarantined(PHONE)).toBe(false);
+    });
+
+    it("is false when quarantine is disabled, even with a live entry", async () => {
+      stringData.set(
+        KEY,
+        JSON.stringify({ strikes: 1, nextRetryAt: Date.now() + 60_000 }),
+      );
+      await withQuarantineConfig({ quarantineEnabled: false }, async () => {
+        expect(await isQuarantined(PHONE)).toBe(false);
+      });
+    });
+  });
+
+  describe("clearQuarantine", () => {
+    it("removes the entry", async () => {
+      stringData.set(
+        KEY,
+        JSON.stringify({ strikes: 5, nextRetryAt: Date.now() + 60_000 }),
+      );
+
+      await clearQuarantine(PHONE);
+
+      expect(stringData.has(KEY)).toBe(false);
+    });
+  });
+});

--- a/src/cluster/quarantineStore.ts
+++ b/src/cluster/quarantineStore.ts
@@ -1,0 +1,83 @@
+import { clusterKeys } from "@/cluster/keys";
+import config from "@/config";
+import redis from "@/lib/redis";
+
+// Breaks the claim/abort/re-claim livelock: without it, a phone whose session
+// the server rejects on every handshake (observed in production as
+// stream:error 503 for weeks straight) is re-claimed by the coordinator every
+// claim tick, burning thousands of reconnect cycles a day and hammering
+// WhatsApp from the same IP. A strike is one FULL failed reconnect cycle (10
+// attempts ending in abort), not one dropped socket.
+//
+// Lifecycle: recordStrike on every aborted cycle (backoff doubles per
+// strike), isQuarantined consulted by background claims only, cleared by a
+// healthy open or by explicit user intent (POST /connections, import-session)
+// — a human asking for the phone always wins immediately.
+export interface QuarantineState {
+  strikes: number;
+  nextRetryAt: number;
+}
+
+// Key lifetime, not the backoff cap: keeps the strike history inspectable for
+// a while after the phone recovers or is abandoned, then self-cleans.
+const QUARANTINE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+// Exponent clamp so a long-running strike streak cannot overflow the double
+// (2 ** 1024 === Infinity); past this the cap has long taken over anyway.
+const MAX_BACKOFF_EXPONENT = 25;
+
+export function backoffMs(strikes: number): number {
+  const { quarantineBaseMs, quarantineMaxMs } = config.cluster;
+  const exponent = Math.min(Math.max(strikes - 1, 0), MAX_BACKOFF_EXPONENT);
+  return Math.min(quarantineBaseMs * 2 ** exponent, quarantineMaxMs);
+}
+
+// Plain read-modify-write, no CAS: the only writer is the instance whose
+// socket just aborted, and two instances can only race here across an
+// ownership change mid-cycle — worst case one strike is lost, which merely
+// shortens the backoff by one doubling.
+export async function recordStrike(
+  phoneNumber: string,
+): Promise<QuarantineState | null> {
+  if (!config.cluster.quarantineEnabled) {
+    return null;
+  }
+  const key = clusterKeys.quarantine(phoneNumber);
+  const raw = await redis.get(key);
+  let strikes = 1;
+  if (raw) {
+    try {
+      strikes = (JSON.parse(raw) as QuarantineState).strikes + 1;
+    } catch {
+      // Corrupted entry: restart the strike count rather than fail the abort
+      // path that records it.
+    }
+  }
+  const state: QuarantineState = {
+    strikes,
+    nextRetryAt: Date.now() + backoffMs(strikes),
+  };
+  await redis.set(key, JSON.stringify(state), {
+    expiration: { type: "PX", value: QUARANTINE_TTL_MS },
+  });
+  return state;
+}
+
+export async function isQuarantined(phoneNumber: string): Promise<boolean> {
+  if (!config.cluster.quarantineEnabled) {
+    return false;
+  }
+  const raw = await redis.get(clusterKeys.quarantine(phoneNumber));
+  if (!raw) {
+    return false;
+  }
+  try {
+    return (JSON.parse(raw) as QuarantineState).nextRetryAt > Date.now();
+  } catch {
+    return false;
+  }
+}
+
+export async function clearQuarantine(phoneNumber: string): Promise<void> {
+  await redis.del(clusterKeys.quarantine(phoneNumber));
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -41,6 +41,9 @@ const {
   CLUSTER_HEARTBEAT_INTERVAL_MS,
   CLUSTER_INSTANCE_TTL_MS,
   CLUSTER_SHUTDOWN_TIMEOUT_MS,
+  CLUSTER_QUARANTINE_ENABLED,
+  CLUSTER_QUARANTINE_BASE_MS,
+  CLUSTER_QUARANTINE_MAX_MS,
   PROXY_ROUTE_CACHE_TTL_MS,
   PROXY_REQUEST_TIMEOUT_MS,
   PROXY_MAX_BODY_BYTES,
@@ -219,6 +222,25 @@ const config = {
       30_000,
       { min: 0 },
     ),
+    // Backoff for phones whose reconnect cycles keep failing (see
+    // cluster/quarantineStore.ts): first failed cycle waits quarantineBaseMs
+    // before background claims retry, doubling per failed cycle up to
+    // quarantineMaxMs.
+    quarantineEnabled: boolFromEnv(
+      "CLUSTER_QUARANTINE_ENABLED",
+      CLUSTER_QUARANTINE_ENABLED,
+      true,
+    ),
+    quarantineBaseMs: intFromEnv(
+      "CLUSTER_QUARANTINE_BASE_MS",
+      CLUSTER_QUARANTINE_BASE_MS,
+      60_000,
+    ),
+    quarantineMaxMs: intFromEnv(
+      "CLUSTER_QUARANTINE_MAX_MS",
+      CLUSTER_QUARANTINE_MAX_MS,
+      3_600_000,
+    ),
   },
   proxy: {
     routeCacheTtlMs: intFromEnv(
@@ -267,6 +289,11 @@ if (config.cluster.leaseRenewIntervalMs > config.cluster.leaseTtlMs / 2) {
 if (config.cluster.heartbeatIntervalMs > config.cluster.instanceTtlMs / 2) {
   throw new Error(
     "CLUSTER_HEARTBEAT_INTERVAL_MS must be at most half of CLUSTER_INSTANCE_TTL_MS",
+  );
+}
+if (config.cluster.quarantineBaseMs > config.cluster.quarantineMaxMs) {
+  throw new Error(
+    "CLUSTER_QUARANTINE_BASE_MS must be at most CLUSTER_QUARANTINE_MAX_MS",
   );
 }
 

--- a/src/test/preload.ts
+++ b/src/test/preload.ts
@@ -368,6 +368,9 @@ mock.module("@/config", () => ({
       heartbeatIntervalMs: 5_000,
       instanceTtlMs: 15_000,
       shutdownTimeoutMs: 30_000,
+      quarantineEnabled: true,
+      quarantineBaseMs: 60_000,
+      quarantineMaxMs: 3_600_000,
     },
     proxy: {
       routeCacheTtlMs: 50,


### PR DESCRIPTION
## Contexto

Em produção 5 números cujas sessões o WhatsApp rejeita a cada handshake (`stream:error 503`) ficaram **26 dias** num livelock: o coordinator re-clama a conexão a cada claim tick, o socket cai, 10 tentativas, `abort()`, lease expira, re-claim — ~2 mil ciclos/dia por número contra o WhatsApp a partir do mesmo IP (lease-epochs chegaram a ~33k). O webhook `reconnect_loop_detected` só diz ao cliente "try reconnecting", que resume as mesmas creds rejeitadas e recomeça o loop.

## O que muda

- **`cluster/quarantineStore` (novo)**: 1 strike por ciclo completo de reconexão falho (10 tentativas → abort), persistido no Redis (`@baileys-api:cluster:quarantine:{phone}`, TTL 7d). Backoff dobra a partir de `CLUSTER_QUARANTINE_BASE_MS` (60s) até `CLUSTER_QUARANTINE_MAX_MS` (1h). O claim loop pula números em quarentena (handoff dirigido de rebalance não é afetado). `CLUSTER_QUARANTINE_ENABLED=false` restaura o comportamento antigo.
- **Intenção explícita vence sempre**: `POST /connections` e `POST /import-session` limpam a quarentena e tentam na hora; um `open` saudável zera os strikes (backoff mede falhas *consecutivas*).
- **Webhook mais honesto**: `reconnect_loop_detected` agora carrega `quarantine: { strikes, until }`, permitindo ao cliente (Chatwoot) mostrar o estado real em vez de sugerir um reconnect que não resolve.
- **Motivo do disconnect visível**: o close reason (statusCode/message) sobe de `debug` para `warn` — produção roda com `LOG_LEVEL=warn` e esse é o único dado que explica um reconnect loop (o 503 ficou invisível por semanas).

## O que NÃO muda

- Nada limpa creds/auth state automaticamente: uma sessão rejeitada continua exigindo ação explícita (logout + novo QR, ou import). Auto-limpar seria perigoso num outage do WhatsApp.
- O abort continua síncrono na decisão do estouro (o strike é gravado logo após; o lease sobrevive ao abort por TTL, então a quarentena é observada muito antes de qualquer re-claim).

## Testes

- `quarantineStore.spec.ts`: progressão/cap do backoff, entrada corrompida, flag de disable, expiração, clear.
- `coordinator.spec.ts`: claim pula quarentenado e volta quando expira; connect/import explícitos limpam; clear falhando não bloqueia o connect.
- `connection.spec.ts`: strikes dobram e vão no payload do webhook; open limpa a quarentena; casos existentes de abort preservados (460 pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/baileys-api/365)
<!-- Reviewable:end -->
