### PR TITLE
fix: DELETE /connections clears persisted auth state when no socket is live

### DIFF
--- a/src/baileys/redisAuthState.spec.ts
+++ b/src/baileys/redisAuthState.spec.ts
@@ -4,6 +4,7 @@ import redis from "@/lib/redis";
 import {
   advanceImportCandidate,
   clearImportCandidates,
+  clearRedisAuthState,
   getRedisSavedAuthStateIds,
   isRedisAuthStatePaired,
   seedImportedSession,
@@ -512,5 +513,48 @@ describe("getRedisSavedAuthStateIds", () => {
 
     const result = await getRedisSavedAuthStateIds();
     expect(result).toEqual([]);
+  });
+});
+
+describe("clearRedisAuthState", () => {
+  const mockStringData = (redis as any).__stringData as Map<string, string>;
+
+  beforeEach(() => {
+    mockRedisData.clear();
+    mockStringData.clear();
+  });
+
+  it("removes the hash when this instance holds the lease", async () => {
+    const key = "@baileys-api:connections:offline-phone:authState";
+    mockRedisData.set(
+      key,
+      new Map([["creds", JSON.stringify({ registrationId: 1 })]]),
+    );
+    mockStringData.set(
+      "@baileys-api:cluster:lease:offline-phone",
+      JSON.stringify({ owner: "test-instance", epoch: 2 }),
+    );
+
+    expect(await clearRedisAuthState("offline-phone")).toBe(true);
+    expect(mockRedisData.has(key)).toBe(false);
+  });
+
+  it("is fenced off when another instance holds the lease", async () => {
+    const key = "@baileys-api:connections:foreign-phone:authState";
+    mockRedisData.set(
+      key,
+      new Map([["creds", JSON.stringify({ registrationId: 1 })]]),
+    );
+    mockStringData.set(
+      "@baileys-api:cluster:lease:foreign-phone",
+      JSON.stringify({ owner: "someone-else", epoch: 2 }),
+    );
+
+    expect(await clearRedisAuthState("foreign-phone")).toBe(false);
+    expect(mockRedisData.has(key)).toBe(true);
+  });
+
+  it("treats a phone with no stored session as already cleared", async () => {
+    expect(await clearRedisAuthState("ghost-phone")).toBe(true);
   });
 });

--- a/src/baileys/redisAuthState.ts
+++ b/src/baileys/redisAuthState.ts
@@ -110,6 +110,25 @@ export async function writeAuthMetadata(
   return fencedAuthWrite(id, ["metadata", JSON.stringify(metadata)]);
 }
 
+// Offline logout: clears the persisted auth state when there is no live
+// socket to run the logout RPC through — the session is being discarded by
+// explicit intent (DELETE /connections) and must not survive to be resumed
+// by the next connect. Same owner fence as the in-connection clear; the
+// caller must hold the lease (acquireExplicitLease) or the DEL no-ops.
+export async function clearRedisAuthState(id: string): Promise<boolean> {
+  const key = `${redisKeyPrefix}:${id}:authState`;
+  const result = await redis.eval(CLEAR_IF_OWNER_SCRIPT, {
+    keys: [key, clusterKeys.lease(id)],
+    arguments: [instanceId],
+  });
+  if (result !== 0) {
+    return true;
+  }
+  // A 0 is ambiguous: fenced off OR nothing to delete. Only fencing is a
+  // failure — a logout for a phone with no stored session is a no-op.
+  return !(await redis.exists(key));
+}
+
 const IMPORT_CANDIDATES_FIELD = "import-candidates";
 
 interface ImportCandidateState {

--- a/src/cluster/coordinator.spec.ts
+++ b/src/cluster/coordinator.spec.ts
@@ -7,6 +7,7 @@ import {
   mock,
   spyOn,
 } from "bun:test";
+import { BaileysNotConnectedError } from "@/baileys/connection";
 import type { BaileysConnectionsHandler } from "@/baileys/connectionsHandler";
 import * as redisAuthState from "@/baileys/redisAuthState";
 import * as registry from "@/cluster/instanceRegistry";
@@ -26,6 +27,7 @@ const getRedisSavedAuthStateIds = spyOn(
 );
 const isRedisAuthStatePaired = spyOn(redisAuthState, "isRedisAuthStatePaired");
 const seedImportedSession = spyOn(redisAuthState, "seedImportedSession");
+const clearRedisAuthState = spyOn(redisAuthState, "clearRedisAuthState");
 const listLiveInstances = spyOn(registry, "listLiveInstances");
 const heartbeat = spyOn(registry, "heartbeat");
 const deregister = spyOn(registry, "deregister");
@@ -46,6 +48,7 @@ afterAll(() => {
   getRedisSavedAuthStateIds.mockRestore();
   isRedisAuthStatePaired.mockRestore();
   seedImportedSession.mockRestore();
+  clearRedisAuthState.mockRestore();
   listLiveInstances.mockRestore();
   heartbeat.mockRestore();
   deregister.mockRestore();
@@ -140,6 +143,7 @@ describe("ClusterCoordinator", () => {
     getHandoffTarget.mockReset();
     isQuarantined.mockReset();
     clearQuarantine.mockReset();
+    clearRedisAuthState.mockReset();
 
     getRedisSavedAuthStateIds.mockResolvedValue([]);
     isRedisAuthStatePaired.mockResolvedValue(true);
@@ -162,6 +166,7 @@ describe("ClusterCoordinator", () => {
     getHandoffTarget.mockResolvedValue(null);
     isQuarantined.mockResolvedValue(false);
     clearQuarantine.mockResolvedValue(undefined);
+    clearRedisAuthState.mockResolvedValue(true);
   });
 
   describe("#runClaimCycle", () => {
@@ -996,11 +1001,11 @@ describe("ClusterCoordinator", () => {
       expect(releaseLease).toHaveBeenCalledWith("+5511999", 8);
     });
 
-    it("falls back to the stored lease epoch when none is tracked locally", async () => {
+    it("releases under the epoch of the takeover the logout itself acquired", async () => {
       const handler = makeHandlerMock();
       handler.connections.add("+5511999");
       const coordinator = makeCoordinator(handler);
-      getLease.mockResolvedValue({ owner: "test-instance", epoch: 5 });
+      forceAcquireLease.mockResolvedValue({ owner: "test-instance", epoch: 5 });
 
       await coordinator.logoutWithLease("+5511999");
 
@@ -1008,26 +1013,81 @@ describe("ClusterCoordinator", () => {
       expect(releaseLease).toHaveBeenCalledWith("+5511999", 5);
     });
 
-    it("skips the release when the lease belongs to another instance", async () => {
+    it("force-takes a foreign lease in standalone — an explicit DELETE is authoritative", async () => {
       const handler = makeHandlerMock();
       handler.connections.add("+5511999");
       const coordinator = makeCoordinator(handler);
       getLease.mockResolvedValue({ owner: "other-instance", epoch: 5 });
+      forceAcquireLease.mockResolvedValue({ owner: "test-instance", epoch: 6 });
 
       await coordinator.logoutWithLease("+5511999");
 
-      expect(releaseLease).not.toHaveBeenCalled();
+      expect(forceAcquireLease).toHaveBeenCalledWith("+5511999");
+      expect(releaseLease).toHaveBeenCalledWith("+5511999", 6);
     });
 
-    it("releases the lease even when logout throws", async () => {
+    it("refuses to steal a live peer's lease in worker role", async () => {
+      config.cluster.role = "worker";
+      try {
+        const handler = makeHandlerMock();
+        const coordinator = makeCoordinator(handler);
+        getLease.mockResolvedValue({ owner: "peer-instance", epoch: 3 });
+        isInstanceAlive.mockResolvedValue(true);
+
+        await expect(coordinator.logoutWithLease("+5511999")).rejects.toThrow(
+          BaileysConnectionOwnedElsewhereError,
+        );
+        expect(handler.logout).not.toHaveBeenCalled();
+      } finally {
+        config.cluster.role = "standalone";
+      }
+    });
+
+    it("clears the persisted auth state on an offline logout (no live socket)", async () => {
       const handler = makeHandlerMock();
-      handler.logout.mockRejectedValueOnce(new Error("not connected"));
+      handler.logout.mockRejectedValueOnce(new BaileysNotConnectedError());
       const coordinator = makeCoordinator(handler);
-      getLease.mockResolvedValue({ owner: "test-instance", epoch: 5 });
+
+      await coordinator.logoutWithLease("+5511999");
+
+      expect(clearRedisAuthState).toHaveBeenCalledWith("+5511999");
+      expect(clearQuarantine).toHaveBeenCalledWith("+5511999");
+      expect(releaseLease).toHaveBeenCalled();
+    });
+
+    it("throws when the offline clear is fenced off", async () => {
+      const handler = makeHandlerMock();
+      handler.logout.mockRejectedValueOnce(new BaileysNotConnectedError());
+      clearRedisAuthState.mockResolvedValueOnce(false);
+      const coordinator = makeCoordinator(handler);
 
       await expect(coordinator.logoutWithLease("+5511999")).rejects.toThrow(
-        "not connected",
+        "fenced off",
       );
+      expect(releaseLease).toHaveBeenCalled();
+    });
+
+    it("does not touch the persisted auth state on a normal online logout", async () => {
+      const handler = makeHandlerMock();
+      handler.connections.add("+5511999");
+      const coordinator = makeCoordinator(handler);
+
+      await coordinator.logoutWithLease("+5511999");
+
+      expect(clearRedisAuthState).not.toHaveBeenCalled();
+    });
+
+    it("releases the takeover lease even when logout throws a non-offline error", async () => {
+      const handler = makeHandlerMock();
+      handler.logout.mockRejectedValueOnce(new Error("socket exploded"));
+      const coordinator = makeCoordinator(handler);
+      forceAcquireLease.mockResolvedValue({ owner: "test-instance", epoch: 5 });
+
+      await expect(coordinator.logoutWithLease("+5511999")).rejects.toThrow(
+        "socket exploded",
+      );
+      // A plain Error is NOT the offline path — no destructive clear.
+      expect(clearRedisAuthState).not.toHaveBeenCalled();
       expect(releaseLease).toHaveBeenCalledWith("+5511999", 5);
     });
   });

--- a/src/cluster/coordinator.ts
+++ b/src/cluster/coordinator.ts
@@ -1,6 +1,8 @@
 import type { AuthenticationCreds } from "@whiskeysockets/baileys";
+import { BaileysNotConnectedError } from "@/baileys/connection";
 import type { BaileysConnectionsHandler } from "@/baileys/connectionsHandler";
 import {
+  clearRedisAuthState,
   getRedisSavedAuthStateIds,
   isRedisAuthStatePaired,
   seedImportedSession,
@@ -772,10 +774,31 @@ export class ClusterCoordinator {
     return this.draining;
   }
 
+  // Explicit intent like connectWithLease: force-takes the lease so the
+  // fenced clears below are authorized even when no local socket exists.
+  // Worker role keeps the live-owner guard (409 via
+  // BaileysConnectionOwnedElsewhereError) so a proxy can re-route.
   async logoutWithLease(phoneNumber: string) {
+    await this.acquireExplicitLease(phoneNumber);
     try {
       await this.handler.logout(phoneNumber);
+    } catch (error) {
+      if (!(error instanceof BaileysNotConnectedError)) {
+        throw error;
+      }
+      // Offline logout: no live socket to RPC through, but the intent is
+      // still authoritative. Without this, a dead session — the exact state
+      // a DELETE is meant to discard — survives the request and every later
+      // connect resumes it instead of offering a fresh QR.
+      const cleared = await clearRedisAuthState(phoneNumber);
+      if (!cleared) {
+        throw new Error(
+          "failed to clear auth state for offline logout (write fenced off)",
+        );
+      }
     } finally {
+      // A discarded identity must not leave strike state behind.
+      await this.clearQuarantineForExplicitIntent(phoneNumber);
       await this.releaseHeldLease(phoneNumber).catch(() => {});
       void registry.publishOwnershipChanged(phoneNumber);
     }

--- a/src/controllers/connections/index.ts
+++ b/src/controllers/connections/index.ts
@@ -1738,14 +1738,23 @@ const connectionsController = new Elysia({
   )
   .delete(
     "/:phoneNumber",
-    async ({ params }) => {
+    async ({ params, set }) => {
       const { phoneNumber } = params;
 
+      // No 404 for a phone without a live socket: logoutWithLease clears the
+      // persisted auth state on the offline path, so an explicit DELETE is
+      // idempotent — a dead session (the exact state a logout is meant to
+      // discard) must not survive just because no socket was up.
       try {
         await coordinator.logoutWithLease(phoneNumber);
       } catch (e) {
-        if (e instanceof BaileysNotConnectedError) {
-          return new Response("Phone number not found", { status: 404 });
+        if (e instanceof BaileysConnectionOwnedElsewhereError) {
+          set.status = 409;
+          set.headers["x-baileys-owner"] = e.ownerInstanceId;
+          return {
+            error: "Conflict",
+            message: "Connection is owned by another live instance",
+          };
         }
         throw e;
       }
@@ -1755,10 +1764,10 @@ const connectionsController = new Elysia({
       detail: {
         responses: {
           200: {
-            description: "Disconnected",
+            description: "Disconnected (auth state cleared)",
           },
-          404: {
-            description: "Phone number not found",
+          409: {
+            description: "Owned by another live instance (worker role)",
           },
         },
       },


### PR DESCRIPTION
## Contexto

Descoberto ao executar a recuperação de inboxes presas em produção: `POST disconnect_channel_provider` do Chatwoot retornava 200, mas o auth state continuava no Redis. O `DELETE /connections/{phone}` fazia logout via socket; para um número **sem conexão viva em memória** (exatamente o estado de uma sessão morta em reconnect loop), `getConnection` lança `BaileysNotConnectedError`, o controller devolvia 404 e a sessão morta sobrevivia — todo connect posterior a resumia em vez de oferecer QR novo. Ou seja: a única sessão que o DELETE não conseguia descartar era a que mais precisa ser descartada.

## O que muda

- **`logoutWithLease` força o lease** (mesma semântica de intent explícito do `connectWithLease`; worker role mantém o guard de dono vivo → 409 + `x-baileys-owner`) e, em `BaileysNotConnectedError`, **limpa o auth state persistido** via clear owner-fenced. Também limpa a quarentena — identidade descartada não deixa strikes para trás.
- **`clearRedisAuthState` (novo em redisAuthState)**: DEL fenced do hash; chave inexistente conta como sucesso (DELETE idempotente), só o fence rejeitado é falha.
- **Controller DELETE**: sem 404 para número sem socket (agora é um no-op idempotente bem-sucedido); conflito de worker vira 409 como nas demais rotas de intent.

Isso é pré-requisito do reset-on-reconnect no Chatwoot (disconnect + setup automático para sessões em loop confirmado).

## Testes

467 pass. Novos casos: offline logout limpa auth+quarentena; clear fenced → erro; erro não-offline não faz clear destrutivo; takeover standalone vs recusa em worker role; `clearRedisAuthState` (fenced/idempotente) no redisAuthState.spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/baileys-api/366)
<!-- Reviewable:end -->

