### PR TITLE
fix(media): pre-download media inside wrapper messages

### DIFF
--- a/src/baileys/helpers/downloadMediaFromMessages.spec.ts
+++ b/src/baileys/helpers/downloadMediaFromMessages.spec.ts
@@ -172,6 +172,74 @@ describe("downloadMediaFromMessages", () => {
     expect(downloadContentFromMessage).toHaveBeenCalledTimes(1);
   });
 
+  it("extracts media from an album child message", async () => {
+    const messages = [
+      {
+        key: { id: "msg-album-child" },
+        message: {
+          associatedChildMessage: {
+            message: {
+              imageMessage: { url: "https://example.com/album-1.jpg" },
+            },
+          },
+        },
+      },
+    ] as any;
+
+    await downloadMediaFromMessages(messages);
+    expect(downloadContentFromMessage).toHaveBeenCalledTimes(1);
+    expect(downloadContentFromMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ url: "https://example.com/album-1.jpg" }),
+      "image",
+    );
+  });
+
+  it("extracts media from a lottie sticker message", async () => {
+    const messages = [
+      {
+        key: { id: "msg-lottie" },
+        message: {
+          lottieStickerMessage: {
+            message: {
+              stickerMessage: { url: "https://example.com/sticker.was" },
+            },
+          },
+        },
+      },
+    ] as any;
+
+    await downloadMediaFromMessages(messages);
+    expect(downloadContentFromMessage).toHaveBeenCalledTimes(1);
+    expect(downloadContentFromMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ url: "https://example.com/sticker.was" }),
+      "sticker",
+    );
+  });
+
+  it("preprocesses wrapped (ephemeral) audio and updates the inner mimetype", async () => {
+    const messages = [
+      {
+        key: { id: "msg-ephemeral-audio" },
+        message: {
+          ephemeralMessage: {
+            message: {
+              audioMessage: {
+                url: "https://example.com/audio",
+                mimetype: "audio/mp3",
+              },
+            },
+          },
+        },
+      },
+    ] as any;
+
+    await downloadMediaFromMessages(messages);
+    expect(preprocessAudio).toHaveBeenCalled();
+    expect(
+      messages[0].message.ephemeralMessage.message.audioMessage.mimetype,
+    ).toBe("audio/ogg; codecs=opus");
+  });
+
   it("extracts media from a template message header", async () => {
     const messages = [
       {

--- a/src/baileys/helpers/downloadMediaFromMessages.ts
+++ b/src/baileys/helpers/downloadMediaFromMessages.ts
@@ -4,6 +4,7 @@ import {
   type BaileysEventMap,
   downloadContentFromMessage,
   type MediaType,
+  normalizeMessageContent,
   type proto,
 } from "@whiskeysockets/baileys";
 import { file } from "bun";
@@ -60,9 +61,11 @@ export async function downloadMediaFromMessages(
         );
         let fileBuffer = await streamToBuffer(stream);
 
-        if (message.audioMessage) {
+        if (mediaType === "audio") {
           fileBuffer = await preprocessAudio(fileBuffer, "ogg-low");
-          message.audioMessage.mimetype = "audio/ogg; codecs=opus";
+          // Mutating the extracted node also updates the webhook payload for
+          // wrapped audio (e.g. ephemeral), since it is the same reference.
+          mediaMessage.mimetype = "audio/ogg; codecs=opus";
         }
 
         const filePath = path.join(mediaDir, `${key.id}`);
@@ -128,32 +131,40 @@ export async function downloadMediaFromMessages(
   return Object.keys(downloadedMedia).length > 0 ? downloadedMedia : null;
 }
 
+// normalizeMessageContent unwraps ephemeral, view-once, edited,
+// documentWithCaption and album child (associatedChildMessage) containers.
+// lottieStickerMessage is not in its wrapper list on 7.0.0-rc14, so unwrap
+// it manually afterwards.
+function unwrapMessageContent(message: proto.IMessage): proto.IMessage {
+  const normalized = normalizeMessageContent(message) ?? message;
+  return normalized.lottieStickerMessage?.message ?? normalized;
+}
+
 function extractMediaMessage(message: proto.IMessage): {
   mediaMessage: MediaMessage | null;
   mediaType: MediaType | null;
 } {
+  const content = unwrapMessageContent(message);
+
   const mediaMapping: [keyof proto.IMessage, MediaType][] = [
     ["imageMessage", "image"],
     ["stickerMessage", "sticker"],
     ["videoMessage", "video"],
     ["audioMessage", "audio"],
     ["documentMessage", "document"],
-    ["documentWithCaptionMessage", "document"],
   ];
 
   for (const [field, type] of mediaMapping) {
-    if (message[field]) {
+    if (content[field]) {
       return {
-        mediaMessage: (field === "documentWithCaptionMessage"
-          ? message[field]?.message?.documentMessage
-          : message[field]) as MediaMessage,
+        mediaMessage: content[field] as MediaMessage,
         mediaType: type,
       };
     }
   }
 
   return (
-    extractHeaderMediaMessage(message) ?? {
+    extractHeaderMediaMessage(content) ?? {
       mediaMessage: null,
       mediaType: null,
     }

--- a/src/test/preload.ts
+++ b/src/test/preload.ts
@@ -505,6 +505,27 @@ mock.module("@whiskeysockets/baileys", () => ({
     }
     return generate();
   }),
+  // Faithful reimplementation of 7.0.0-rc14's normalizeMessageContent
+  // (getFutureProofMessage wrapper list, bounded loop).
+  normalizeMessageContent: (content: any) => {
+    let current = content;
+    if (!current) return undefined;
+    for (let i = 0; i < 5; i++) {
+      const inner =
+        current?.ephemeralMessage ||
+        current?.viewOnceMessage ||
+        current?.documentWithCaptionMessage ||
+        current?.viewOnceMessageV2 ||
+        current?.viewOnceMessageV2Extension ||
+        current?.editedMessage ||
+        current?.associatedChildMessage ||
+        current?.groupStatusMessage ||
+        current?.groupStatusMessageV2;
+      if (!inner) break;
+      current = inner.message;
+    }
+    return current;
+  },
   initAuthCreds: mock(() => ({
     noiseKey: { private: "noise-priv", public: "noise-pub" },
     pairingEphemeralKeyPair: { private: "pair-priv", public: "pair-pub" },


### PR DESCRIPTION
Media wrapped in container nodes — album items (`associatedChildMessage`), disappearing-chat messages (`ephemeralMessage`) and animated Lottie stickers (`lottieStickerMessage`) — was never pre-downloaded, because `extractMediaMessage` only inspected top-level fields. Consumers then got a 404 from `GET /media/:messageId` for those messages.

## What changed

- `extractMediaMessage` now normalizes the content first via Baileys' `normalizeMessageContent` (covers ephemeral, view-once, edited, documentWithCaption and album children), plus a manual `lottieStickerMessage` unwrap that 7.0.0-rc14 does not cover.
- The `documentWithCaptionMessage` special-case in the mapping was removed: normalization already unwraps it.
- Audio preprocessing is now keyed on the extracted media type instead of a top-level `audioMessage` check, so wrapped audio is transcoded and its inner mimetype updated in the webhook payload too.
- Test preload gains a faithful `normalizeMessageContent` reimplementation (rc14 wrapper list); new specs for album child, lottie sticker and wrapped audio.

> Companion to fazer-ai/chatwoot#345.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/baileys-api/367)
<!-- Reviewable:end -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved media downloads from album child messages and nested message wrappers.
  * Added support for extracting media from Lottie stickers.
  * Fixed audio media handling when messages are wrapped or ephemeral.
  * Improved document downloads when captions are included.
  * Corrected MIME type detection for nested audio content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->