### PR TITLE
feat: accept a caller-reserved messageId on send-message

### DIFF
--- a/.codex-review-waived
+++ b/.codex-review-waived
@@ -1,0 +1,10 @@
+# Pre-existing swagger generator defect, not something this PR introduced.
+# The controller declares shared `responses` (403/421) in the Elysia constructor's
+# `detail`, and every route's own `detail.responses` is merged into that same shared
+# object — so all 40 routes end up with the union, last writer per status code wins.
+# It is already visible on main: send-message's 200 reads "Disconnected" and its 500
+# reads "Message not edited", both from other routes. Regenerating the committed spec
+# only changed which description wins for 409. Fixing it means reworking how the
+# shared detail is declared, which rewrites the whole spec and belongs in its own PR:
+# https://github.com/fazer-ai/baileys-api/issues/374
+swagger.json: Restore the actual send-message conflict response

--- a/src/baileys/connection.spec.ts
+++ b/src/baileys/connection.spec.ts
@@ -993,6 +993,31 @@ describe("BaileysConnection", () => {
       await connection.sendMessage("jid@s.whatsapp.net", { text: "hi" });
       expect(mockSocket.sendMessage).toHaveBeenCalled();
     });
+
+    it("forwards a caller-provided messageId to the socket", async () => {
+      await connection.connect();
+      mockSocket.sendMessage.mockClear();
+      await connection.sendMessage(
+        "jid@s.whatsapp.net",
+        { text: "hi" },
+        { messageId: "3EB0RESERVED" },
+      );
+      expect(mockSocket.sendMessage).toHaveBeenCalledWith(
+        "jid@s.whatsapp.net",
+        { text: "hi" },
+        expect.objectContaining({ messageId: "3EB0RESERVED" }),
+      );
+    });
+
+    // Baileys spreads our options over its own `messageId` default, so passing
+    // the key as undefined would silently downgrade that default.
+    it("omits messageId entirely when the caller did not reserve one", async () => {
+      await connection.connect();
+      mockSocket.sendMessage.mockClear();
+      await connection.sendMessage("jid@s.whatsapp.net", { text: "hi" });
+      const options = mockSocket.sendMessage.mock.calls[0]?.[2];
+      expect(Object.keys(options as object)).not.toContain("messageId");
+    });
   });
 
   describe("#sendPresenceUpdate", () => {

--- a/src/baileys/connection.ts
+++ b/src/baileys/connection.ts
@@ -509,7 +509,7 @@ export class BaileysConnection {
   async sendMessage(
     jid: string,
     messageContent: AnyMessageContent,
-    options?: { quoted?: WAMessage },
+    options?: { quoted?: WAMessage; messageId?: string },
   ) {
     this.safeSocket();
     this.markTraffic();
@@ -541,9 +541,17 @@ export class BaileysConnection {
       );
     }
 
+    // NOTE: `messageId` overrides the id Baileys would generate for the WhatsApp
+    // message key. The caller reserves it before the send so it can match the
+    // `messages.upsert` echo of its own message even when this response never
+    // reaches it (and so a resend of the same message reuses the same id).
+    // Spread it only when set: Baileys spreads our options over its own
+    // `messageId: generateMessageIDV2(user)` default, so an explicit
+    // `undefined` would downgrade that default to the user-less fallback.
     return this.safeSocket().sendMessage(jid, messageContent, {
       waveformProxy,
       quoted: options?.quoted,
+      ...(options?.messageId ? { messageId: options.messageId } : {}),
     });
   }
 

--- a/src/baileys/connectionsHandler.ts
+++ b/src/baileys/connectionsHandler.ts
@@ -299,14 +299,17 @@ export class BaileysConnectionsHandler {
       jid,
       messageContent,
       quoted,
+      messageId,
     }: {
       jid: string;
       messageContent: AnyMessageContent;
       quoted?: WAMessage;
+      messageId?: string;
     },
   ) {
     return this.getConnection(phoneNumber).sendMessage(jid, messageContent, {
       quoted,
+      messageId,
     });
   }
 

--- a/src/controllers/connections/index.spec.ts
+++ b/src/controllers/connections/index.spec.ts
@@ -71,6 +71,17 @@ describe("connectionsController send-message", () => {
     }
   });
 
+  // An empty string would pass through as falsy and let Baileys generate an id
+  // the caller never learns about, so it is rejected instead.
+  it("rejects an empty messageId", async () => {
+    const app = new Elysia().use(connectionsController);
+    const res = await app.handle(
+      sendMessageRequest("+551234567890", { messageId: "" }),
+    );
+
+    expect(res.status).toBe(422);
+  });
+
   it("does not mask a generic send failure as 404", async () => {
     const spy = spyOn(baileys, "sendMessage").mockImplementation(async () => {
       throw new Error("unexpected boom");

--- a/src/controllers/connections/index.spec.ts
+++ b/src/controllers/connections/index.spec.ts
@@ -26,13 +26,14 @@ describe("connectionsController send-message", () => {
     config.cluster.role = prevRole;
   });
 
-  const sendMessageRequest = (phone: string) =>
+  const sendMessageRequest = (phone: string, extraBody: object = {}) =>
     new Request(`http://localhost/connections/${phone}/send-message`, {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({
         jid: "551101234567@s.whatsapp.net",
         messageContent: { text: "hello" },
+        ...extraBody,
       }),
     });
 
@@ -44,6 +45,30 @@ describe("connectionsController send-message", () => {
     const res = await app.handle(sendMessageRequest("+551234567890"));
 
     expect(res.status).toBe(404);
+  });
+
+  // The caller reserves the WhatsApp message id before the send so it can match
+  // the `messages.upsert` echo of its own message even if this response is lost.
+  it("forwards the reserved messageId to the send", async () => {
+    const spy = spyOn(baileys, "sendMessage").mockResolvedValue({
+      key: { id: "3EB0RESERVED" },
+      messageTimestamp: 1,
+    } as any);
+
+    try {
+      const app = new Elysia().use(connectionsController);
+      const res = await app.handle(
+        sendMessageRequest("+551234567890", { messageId: "3EB0RESERVED" }),
+      );
+
+      expect(res.status).toBe(200);
+      expect(spy).toHaveBeenCalledWith(
+        "+551234567890",
+        expect.objectContaining({ messageId: "3EB0RESERVED" }),
+      );
+    } finally {
+      spy.mockRestore();
+    }
   });
 
   it("does not mask a generic send failure as 404", async () => {

--- a/src/controllers/connections/index.ts
+++ b/src/controllers/connections/index.ts
@@ -352,8 +352,10 @@ const connectionsController = new Elysia({
         // the request. It comes back as `data.key.id` and on the
         // `messages.upsert` echo, so the caller can match its own message even
         // if this response is lost — and a resend reuses the same id instead of
-        // creating a second WhatsApp message. Omit to let Baileys generate one.
-        messageId: t.Optional(t.String()),
+        // creating a second WhatsApp message. Omit to let Baileys generate one;
+        // an empty string is rejected rather than silently falling back to a
+        // generated id the caller does not know about.
+        messageId: t.Optional(t.String({ minLength: 1 })),
       }),
       detail: {
         responses: {

--- a/src/controllers/connections/index.ts
+++ b/src/controllers/connections/index.ts
@@ -291,7 +291,7 @@ const connectionsController = new Elysia({
     "/:phoneNumber/send-message",
     async ({ params, body }) => {
       const { phoneNumber } = params;
-      const { jid, messageContent, chatwootMessageId } = body;
+      const { jid, messageContent, chatwootMessageId, messageId } = body;
 
       const idempotencyKey =
         chatwootMessageId !== undefined && chatwootMessageId !== null
@@ -308,6 +308,7 @@ const connectionsController = new Elysia({
             jid,
             messageContent: builtContent,
             quoted,
+            messageId,
           });
 
           if (!response) return null;
@@ -347,6 +348,12 @@ const connectionsController = new Elysia({
         jid: anyJid(),
         messageContent: anyMessageContent,
         chatwootMessageId: t.Optional(t.Union([t.String(), t.Number()])),
+        // The WhatsApp message id to send under, reserved by the caller before
+        // the request. It comes back as `data.key.id` and on the
+        // `messages.upsert` echo, so the caller can match its own message even
+        // if this response is lost — and a resend reuses the same id instead of
+        // creating a second WhatsApp message. Omit to let Baileys generate one.
+        messageId: t.Optional(t.String()),
       }),
       detail: {
         responses: {

--- a/swagger.json
+++ b/swagger.json
@@ -3947,6 +3947,9 @@
                   "chatwootMessageId": {
                     "type": "string",
                     "enum": []
+                  },
+                  "messageId": {
+                    "type": "string"
                   }
                 },
                 "required": [
@@ -4320,6 +4323,9 @@
                   "chatwootMessageId": {
                     "type": "string",
                     "enum": []
+                  },
+                  "messageId": {
+                    "type": "string"
                   }
                 },
                 "required": [
@@ -4693,6 +4699,9 @@
                   "chatwootMessageId": {
                     "type": "string",
                     "enum": []
+                  },
+                  "messageId": {
+                    "type": "string"
                   }
                 },
                 "required": [

--- a/swagger.json
+++ b/swagger.json
@@ -3949,6 +3949,7 @@
                     "enum": []
                   },
                   "messageId": {
+                    "minLength": 1,
                     "type": "string"
                   }
                 },
@@ -4325,6 +4326,7 @@
                     "enum": []
                   },
                   "messageId": {
+                    "minLength": 1,
                     "type": "string"
                   }
                 },
@@ -4701,6 +4703,7 @@
                     "enum": []
                   },
                   "messageId": {
+                    "minLength": 1,
                     "type": "string"
                   }
                 },

--- a/swagger.json
+++ b/swagger.json
@@ -289,7 +289,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Disconnected",
+            "description": "Disconnected (auth state cleared)",
             "content": {
               "application/json": {
                 "schema": {
@@ -626,14 +626,17 @@
               }
             }
           },
+          "202": {
+            "description": "Session import accepted; connecting"
+          },
           "403": {
             "description": "Forbidden — the API key does not own this connection. Returned when a connection is bound to a different API key."
           },
           "404": {
-            "description": "Phone number not found"
+            "description": "Phone number not connected"
           },
           "409": {
-            "description": "Message is already being processed",
+            "description": "Owned by another live instance (worker role)",
             "headers": {
               "x-baileys-owner": {
                 "description": "Instance id of the connection owner",
@@ -653,6 +656,9 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable Entity — the requested noise candidate index is out of range."
           },
           "500": {
             "description": "Message not edited"
@@ -835,7 +841,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Disconnected",
+            "description": "Disconnected (auth state cleared)",
             "content": {
               "application/json": {
                 "schema": {
@@ -1172,14 +1178,17 @@
               }
             }
           },
+          "202": {
+            "description": "Session import accepted; connecting"
+          },
           "403": {
             "description": "Forbidden — the API key does not own this connection. Returned when a connection is bound to a different API key."
           },
           "404": {
-            "description": "Phone number not found"
+            "description": "Phone number not connected"
           },
           "409": {
-            "description": "Message is already being processed",
+            "description": "Owned by another live instance (worker role)",
             "headers": {
               "x-baileys-owner": {
                 "description": "Instance id of the connection owner",
@@ -1200,8 +1209,986 @@
               }
             }
           },
+          "422": {
+            "description": "Unprocessable Entity — the requested noise candidate index is out of range."
+          },
           "500": {
             "description": "Message not edited"
+          }
+        }
+      }
+    },
+    "/connections/{phoneNumber}/import-session": {
+      "post": {
+        "parameters": [
+          {
+            "description": "Phone number for connection. Must have + prefix.",
+            "schema": {
+              "type": "string",
+              "minLength": 6,
+              "maxLength": 16,
+              "pattern": "^\\+\\d{5,15}$",
+              "example": "+551234567890"
+            },
+            "in": "path",
+            "name": "phoneNumber",
+            "required": true
+          }
+        ],
+        "operationId": "postConnectionsByPhoneNumberImport-session",
+        "tags": [
+          "Connections"
+        ],
+        "security": [
+          {
+            "xApiKey": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Disconnected (auth state cleared)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "key": {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "string"
+                            },
+                            "remoteJid": {
+                              "type": "string"
+                            },
+                            "fromMe": {
+                              "type": "boolean"
+                            },
+                            "participant": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "messageTimestamp": {
+                          "type": "string"
+                        },
+                        "jid": {
+                          "type": "string",
+                          "description": "WhatsApp JID of the phone number",
+                          "example": "551234567890@s.whatsapp.net"
+                        },
+                        "profilePictureUrl": {
+                          "type": "string",
+                          "nullable": true,
+                          "example": "https://pps.whatsapp.net/v/t61.24694-24/..."
+                        },
+                        "isActive": {
+                          "type": "boolean",
+                          "description": "Whether the reach-out time-lock is currently enforced",
+                          "example": false
+                        },
+                        "timeEnforcementEnds": {
+                          "type": "string",
+                          "format": "date-time",
+                          "nullable": true,
+                          "description": "When the current enforcement window ends"
+                        },
+                        "enforcementType": {
+                          "type": "string",
+                          "description": "Reason/type of enforcement. 'DEFAULT' means no restriction.",
+                          "example": "DEFAULT"
+                        },
+                        "total_quota": {
+                          "type": "number",
+                          "description": "Total new-chat messages allowed in the current cycle",
+                          "example": 100
+                        },
+                        "used_quota": {
+                          "type": "number",
+                          "description": "New-chat messages already used in the current cycle",
+                          "example": 0
+                        },
+                        "cycle_start_timestamp": {
+                          "type": "string",
+                          "nullable": true,
+                          "description": "Unix timestamp of the cycle start"
+                        },
+                        "cycle_end_timestamp": {
+                          "type": "string",
+                          "nullable": true,
+                          "description": "Unix timestamp of the cycle end"
+                        },
+                        "server_sent_timestamp": {
+                          "type": "string",
+                          "nullable": true,
+                          "description": "Unix timestamp when WhatsApp produced this snapshot"
+                        },
+                        "ote_status": {
+                          "type": "string",
+                          "nullable": true,
+                          "description": "One-time-engagement cap status (NOT_ELIGIBLE, ELIGIBLE, ACTIVE_IN_CURRENT_CYCLE, EXHAUSTED)"
+                        },
+                        "mv_status": {
+                          "type": "string",
+                          "nullable": true,
+                          "description": "Multi-vertical cap status (NOT_ELIGIBLE, NOT_ACTIVE, ACTIVE, ACTIVE_UPGRADE_AVAILABLE)"
+                        },
+                        "capping_status": {
+                          "type": "string",
+                          "nullable": true,
+                          "description": "Overall capping status (NONE, FIRST_WARNING, SECOND_WARNING, CAPPED)",
+                          "example": "NONE"
+                        },
+                        "inviteCode": {
+                          "type": "string",
+                          "nullable": true
+                        },
+                        "groupJid": {
+                          "type": "string",
+                          "nullable": true
+                        },
+                        "revoked": {
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key",
+                        "messageTimestamp"
+                      ],
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "jid": {
+                            "type": "string",
+                            "description": "WhatsApp JID of the phone number",
+                            "example": "551234567890@s.whatsapp.net"
+                          },
+                          "exists": {
+                            "type": "boolean",
+                            "description": "Whether the phone number is registered on WhatsApp"
+                          }
+                        }
+                      }
+                    },
+                    "wid": {
+                      "type": "string",
+                      "description": "WhatsApp ID of the business",
+                      "example": "551234567890@s.whatsapp.net"
+                    },
+                    "description": {
+                      "type": "string",
+                      "description": "Business description",
+                      "example": "We are a company that sells products"
+                    },
+                    "email": {
+                      "type": "string",
+                      "nullable": true,
+                      "description": "Business email",
+                      "example": "contact@business.com"
+                    },
+                    "website": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "description": "Business websites",
+                      "example": [
+                        "https://business.com"
+                      ]
+                    },
+                    "category": {
+                      "type": "string",
+                      "nullable": true,
+                      "description": "Business category",
+                      "example": "Retail"
+                    },
+                    "address": {
+                      "type": "string",
+                      "nullable": true,
+                      "description": "Business address",
+                      "example": "123 Main St, City"
+                    },
+                    "business_hours": {
+                      "type": "object",
+                      "description": "Business hours configuration",
+                      "properties": {
+                        "timezone": {
+                          "type": "string",
+                          "description": "Timezone of the business",
+                          "example": "America/Sao_Paulo"
+                        },
+                        "config": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "day_of_week": {
+                                "type": "string"
+                              },
+                              "mode": {
+                                "type": "string"
+                              },
+                              "open_time": {
+                                "type": "number"
+                              },
+                              "close_time": {
+                                "type": "number"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "id": {
+                      "type": "string",
+                      "description": "Group JID",
+                      "example": "120363425378794738@g.us"
+                    },
+                    "addressingMode": {
+                      "type": "string",
+                      "description": "Addressing mode of the group",
+                      "example": "lid"
+                    },
+                    "subject": {
+                      "type": "string",
+                      "description": "Group name/subject",
+                      "example": "My Group"
+                    },
+                    "subjectOwner": {
+                      "type": "string",
+                      "description": "JID of the user who set the subject",
+                      "example": "12345678901234@lid"
+                    },
+                    "subjectOwnerPn": {
+                      "type": "string",
+                      "description": "Phone number JID of the subject owner",
+                      "example": "551234567890@s.whatsapp.net"
+                    },
+                    "subjectTime": {
+                      "type": "number",
+                      "description": "Timestamp when subject was set"
+                    },
+                    "size": {
+                      "type": "number",
+                      "description": "Number of participants in the group"
+                    },
+                    "creation": {
+                      "type": "number",
+                      "description": "Timestamp when the group was created"
+                    },
+                    "owner": {
+                      "type": "string",
+                      "description": "JID of the group owner",
+                      "example": "12345678901234@lid"
+                    },
+                    "ownerPn": {
+                      "type": "string",
+                      "description": "Phone number JID of the group owner",
+                      "example": "551234567890@s.whatsapp.net"
+                    },
+                    "owner_country_code": {
+                      "type": "string",
+                      "description": "Country code of the group owner",
+                      "example": "BR"
+                    },
+                    "desc": {
+                      "type": "string",
+                      "nullable": true,
+                      "description": "Group description"
+                    },
+                    "descId": {
+                      "type": "string",
+                      "nullable": true,
+                      "description": "Description ID"
+                    },
+                    "descOwner": {
+                      "type": "string",
+                      "nullable": true,
+                      "description": "JID of the user who set the description"
+                    },
+                    "descTime": {
+                      "type": "number",
+                      "nullable": true,
+                      "description": "Timestamp when description was set"
+                    },
+                    "restrict": {
+                      "type": "boolean",
+                      "description": "Whether only admins can change group settings",
+                      "example": false
+                    },
+                    "announce": {
+                      "type": "boolean",
+                      "description": "Whether only admins can send messages",
+                      "example": false
+                    },
+                    "isCommunity": {
+                      "type": "boolean",
+                      "description": "Whether the group is a community",
+                      "example": false
+                    },
+                    "isCommunityAnnounce": {
+                      "type": "boolean",
+                      "description": "Whether the group is a community announcement group",
+                      "example": false
+                    },
+                    "joinApprovalMode": {
+                      "type": "boolean",
+                      "description": "Whether join requests require admin approval",
+                      "example": false
+                    },
+                    "memberAddMode": {
+                      "type": "boolean",
+                      "description": "Whether members can add other members",
+                      "example": true
+                    },
+                    "participants": {
+                      "type": "array",
+                      "description": "List of group participants",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "description": "Participant JID",
+                            "example": "12345678901234@lid"
+                          },
+                          "phoneNumber": {
+                            "type": "string",
+                            "description": "Participant phone number JID",
+                            "example": "551234567890@s.whatsapp.net"
+                          },
+                          "admin": {
+                            "type": "string",
+                            "nullable": true,
+                            "description": "Admin status: 'superadmin', 'admin', or null",
+                            "example": "superadmin"
+                          }
+                        }
+                      }
+                    },
+                    "ephemeralDuration": {
+                      "type": "number",
+                      "nullable": true,
+                      "description": "Duration in seconds for disappearing messages",
+                      "example": 604800
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ]
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Session import accepted; connecting"
+          },
+          "403": {
+            "description": "Forbidden — the API key does not own this connection. Returned when a connection is bound to a different API key."
+          },
+          "404": {
+            "description": "Phone number not connected"
+          },
+          "409": {
+            "description": "Owned by another live instance (worker role)",
+            "headers": {
+              "x-baileys-owner": {
+                "description": "Instance id of the connection owner",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "421": {
+            "description": "Misdirected Request — in cluster mode, this instance does not own the connection. The owning instance id is in the x-baileys-owner header; a proxy re-routes the request there. Not returned for POST /connections/{phoneNumber} (explicit takeover).",
+            "headers": {
+              "x-baileys-owner": {
+                "description": "Instance id of the connection owner",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity — the requested noise candidate index is out of range."
+          },
+          "500": {
+            "description": "Message not edited"
+          }
+        },
+        "summary": "Import an extracted WhatsApp Web session (no QR)",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "session": {
+                    "description": "Impersonation credentials — never log this object. Transported over HTTPS only.",
+                    "type": "object",
+                    "properties": {
+                      "noiseCandidates": {
+                        "minItems": 1,
+                        "maxItems": 20,
+                        "description": "Noise keypair candidates (base64). Only one is the real pair; the server cycles them until the socket opens.",
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "private": {
+                              "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})$",
+                              "type": "string"
+                            },
+                            "public": {
+                              "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})$",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "private",
+                            "public"
+                          ]
+                        }
+                      },
+                      "identityKey": {
+                        "type": "object",
+                        "properties": {
+                          "private": {
+                            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})$",
+                            "type": "string"
+                          },
+                          "public": {
+                            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})$",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "private",
+                          "public"
+                        ]
+                      },
+                      "registrationId": {
+                        "type": "number"
+                      },
+                      "advSecretKey": {
+                        "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})$",
+                        "description": "ADV secret key (base64)",
+                        "type": "string"
+                      },
+                      "account": {
+                        "type": "object",
+                        "properties": {
+                          "details": {
+                            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})$",
+                            "type": "string"
+                          },
+                          "accountSignatureKey": {
+                            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})$",
+                            "type": "string"
+                          },
+                          "accountSignature": {
+                            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})$",
+                            "type": "string"
+                          },
+                          "deviceSignature": {
+                            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})$",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "details",
+                          "accountSignatureKey",
+                          "accountSignature",
+                          "deviceSignature"
+                        ]
+                      },
+                      "id": {
+                        "description": "Companion device JID",
+                        "example": "551101234567:12@s.whatsapp.net",
+                        "type": "string"
+                      },
+                      "lid": {
+                        "type": "string"
+                      },
+                      "platform": {
+                        "type": "string"
+                      },
+                      "signedPreKey": {
+                        "type": "object",
+                        "properties": {
+                          "keyId": {
+                            "type": "number"
+                          },
+                          "private": {
+                            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})$",
+                            "type": "string"
+                          },
+                          "public": {
+                            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})$",
+                            "type": "string"
+                          },
+                          "signature": {
+                            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})$",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "keyId",
+                          "private",
+                          "public",
+                          "signature"
+                        ]
+                      },
+                      "pushName": {
+                        "type": "string"
+                      },
+                      "routingInfo": {
+                        "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})$",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "noiseCandidates",
+                      "identityKey",
+                      "registrationId",
+                      "advSecretKey",
+                      "account",
+                      "id"
+                    ]
+                  },
+                  "candidateIndex": {
+                    "minimum": 0,
+                    "default": 0,
+                    "description": "Index into session.noiseCandidates to try first (only one candidate is the real pair).",
+                    "type": "number"
+                  },
+                  "clientName": {
+                    "description": "Name of the client to be used on WhatsApp connection",
+                    "example": "My WhatsApp Client",
+                    "type": "string"
+                  },
+                  "webhookUrl": {
+                    "format": "uri",
+                    "description": "URL for receiving updates",
+                    "example": "http://localhost:3026/whatsapp/+1234567890",
+                    "type": "string"
+                  },
+                  "webhookVerifyToken": {
+                    "minLength": 6,
+                    "description": "Token for verifying webhook",
+                    "example": "a3f4b2",
+                    "type": "string"
+                  },
+                  "includeMedia": {
+                    "description": "Include media in messages.upsert event payload as base64 string",
+                    "default": true,
+                    "type": "boolean"
+                  },
+                  "syncFullHistory": {
+                    "description": "Sync full history of messages on connection.",
+                    "default": false,
+                    "type": "boolean"
+                  },
+                  "groupsEnabled": {
+                    "description": "Enable full group message processing. When false, group messages are accumulated and sent as activity summaries.",
+                    "default": true,
+                    "type": "boolean"
+                  },
+                  "autoPresenceSubscribe": {
+                    "description": "Automatically subscribe to presence updates when sending/receiving messages or typing status to/from a contact. Subscriptions are ephemeral and re-established automatically.",
+                    "default": false,
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "session",
+                  "webhookUrl",
+                  "webhookVerifyToken"
+                ]
+              }
+            },
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "session": {
+                    "description": "Impersonation credentials — never log this object. Transported over HTTPS only.",
+                    "type": "object",
+                    "properties": {
+                      "noiseCandidates": {
+                        "minItems": 1,
+                        "maxItems": 20,
+                        "description": "Noise keypair candidates (base64). Only one is the real pair; the server cycles them until the socket opens.",
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "private": {
+                              "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})$",
+                              "type": "string"
+                            },
+                            "public": {
+                              "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})$",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "private",
+                            "public"
+                          ]
+                        }
+                      },
+                      "identityKey": {
+                        "type": "object",
+                        "properties": {
+                          "private": {
+                            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})$",
+                            "type": "string"
+                          },
+                          "public": {
+                            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})$",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "private",
+                          "public"
+                        ]
+                      },
+                      "registrationId": {
+                        "type": "number"
+                      },
+                      "advSecretKey": {
+                        "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})$",
+                        "description": "ADV secret key (base64)",
+                        "type": "string"
+                      },
+                      "account": {
+                        "type": "object",
+                        "properties": {
+                          "details": {
+                            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})$",
+                            "type": "string"
+                          },
+                          "accountSignatureKey": {
+                            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})$",
+                            "type": "string"
+                          },
+                          "accountSignature": {
+                            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})$",
+                            "type": "string"
+                          },
+                          "deviceSignature": {
+                            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})$",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "details",
+                          "accountSignatureKey",
+                          "accountSignature",
+                          "deviceSignature"
+                        ]
+                      },
+                      "id": {
+                        "description": "Companion device JID",
+                        "example": "551101234567:12@s.whatsapp.net",
+                        "type": "string"
+                      },
+                      "lid": {
+                        "type": "string"
+                      },
+                      "platform": {
+                        "type": "string"
+                      },
+                      "signedPreKey": {
+                        "type": "object",
+                        "properties": {
+                          "keyId": {
+                            "type": "number"
+                          },
+                          "private": {
+                            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})$",
+                            "type": "string"
+                          },
+                          "public": {
+                            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})$",
+                            "type": "string"
+                          },
+                          "signature": {
+                            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})$",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "keyId",
+                          "private",
+                          "public",
+                          "signature"
+                        ]
+                      },
+                      "pushName": {
+                        "type": "string"
+                      },
+                      "routingInfo": {
+                        "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})$",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "noiseCandidates",
+                      "identityKey",
+                      "registrationId",
+                      "advSecretKey",
+                      "account",
+                      "id"
+                    ]
+                  },
+                  "candidateIndex": {
+                    "minimum": 0,
+                    "default": 0,
+                    "description": "Index into session.noiseCandidates to try first (only one candidate is the real pair).",
+                    "type": "number"
+                  },
+                  "clientName": {
+                    "description": "Name of the client to be used on WhatsApp connection",
+                    "example": "My WhatsApp Client",
+                    "type": "string"
+                  },
+                  "webhookUrl": {
+                    "format": "uri",
+                    "description": "URL for receiving updates",
+                    "example": "http://localhost:3026/whatsapp/+1234567890",
+                    "type": "string"
+                  },
+                  "webhookVerifyToken": {
+                    "minLength": 6,
+                    "description": "Token for verifying webhook",
+                    "example": "a3f4b2",
+                    "type": "string"
+                  },
+                  "includeMedia": {
+                    "description": "Include media in messages.upsert event payload as base64 string",
+                    "default": true,
+                    "type": "boolean"
+                  },
+                  "syncFullHistory": {
+                    "description": "Sync full history of messages on connection.",
+                    "default": false,
+                    "type": "boolean"
+                  },
+                  "groupsEnabled": {
+                    "description": "Enable full group message processing. When false, group messages are accumulated and sent as activity summaries.",
+                    "default": true,
+                    "type": "boolean"
+                  },
+                  "autoPresenceSubscribe": {
+                    "description": "Automatically subscribe to presence updates when sending/receiving messages or typing status to/from a contact. Subscriptions are ephemeral and re-established automatically.",
+                    "default": false,
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "session",
+                  "webhookUrl",
+                  "webhookVerifyToken"
+                ]
+              }
+            },
+            "text/plain": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "session": {
+                    "description": "Impersonation credentials — never log this object. Transported over HTTPS only.",
+                    "type": "object",
+                    "properties": {
+                      "noiseCandidates": {
+                        "minItems": 1,
+                        "maxItems": 20,
+                        "description": "Noise keypair candidates (base64). Only one is the real pair; the server cycles them until the socket opens.",
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "private": {
+                              "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})$",
+                              "type": "string"
+                            },
+                            "public": {
+                              "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})$",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "private",
+                            "public"
+                          ]
+                        }
+                      },
+                      "identityKey": {
+                        "type": "object",
+                        "properties": {
+                          "private": {
+                            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})$",
+                            "type": "string"
+                          },
+                          "public": {
+                            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})$",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "private",
+                          "public"
+                        ]
+                      },
+                      "registrationId": {
+                        "type": "number"
+                      },
+                      "advSecretKey": {
+                        "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})$",
+                        "description": "ADV secret key (base64)",
+                        "type": "string"
+                      },
+                      "account": {
+                        "type": "object",
+                        "properties": {
+                          "details": {
+                            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})$",
+                            "type": "string"
+                          },
+                          "accountSignatureKey": {
+                            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})$",
+                            "type": "string"
+                          },
+                          "accountSignature": {
+                            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})$",
+                            "type": "string"
+                          },
+                          "deviceSignature": {
+                            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})$",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "details",
+                          "accountSignatureKey",
+                          "accountSignature",
+                          "deviceSignature"
+                        ]
+                      },
+                      "id": {
+                        "description": "Companion device JID",
+                        "example": "551101234567:12@s.whatsapp.net",
+                        "type": "string"
+                      },
+                      "lid": {
+                        "type": "string"
+                      },
+                      "platform": {
+                        "type": "string"
+                      },
+                      "signedPreKey": {
+                        "type": "object",
+                        "properties": {
+                          "keyId": {
+                            "type": "number"
+                          },
+                          "private": {
+                            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})$",
+                            "type": "string"
+                          },
+                          "public": {
+                            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})$",
+                            "type": "string"
+                          },
+                          "signature": {
+                            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})$",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "keyId",
+                          "private",
+                          "public",
+                          "signature"
+                        ]
+                      },
+                      "pushName": {
+                        "type": "string"
+                      },
+                      "routingInfo": {
+                        "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})$",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "noiseCandidates",
+                      "identityKey",
+                      "registrationId",
+                      "advSecretKey",
+                      "account",
+                      "id"
+                    ]
+                  },
+                  "candidateIndex": {
+                    "minimum": 0,
+                    "default": 0,
+                    "description": "Index into session.noiseCandidates to try first (only one candidate is the real pair).",
+                    "type": "number"
+                  },
+                  "clientName": {
+                    "description": "Name of the client to be used on WhatsApp connection",
+                    "example": "My WhatsApp Client",
+                    "type": "string"
+                  },
+                  "webhookUrl": {
+                    "format": "uri",
+                    "description": "URL for receiving updates",
+                    "example": "http://localhost:3026/whatsapp/+1234567890",
+                    "type": "string"
+                  },
+                  "webhookVerifyToken": {
+                    "minLength": 6,
+                    "description": "Token for verifying webhook",
+                    "example": "a3f4b2",
+                    "type": "string"
+                  },
+                  "includeMedia": {
+                    "description": "Include media in messages.upsert event payload as base64 string",
+                    "default": true,
+                    "type": "boolean"
+                  },
+                  "syncFullHistory": {
+                    "description": "Sync full history of messages on connection.",
+                    "default": false,
+                    "type": "boolean"
+                  },
+                  "groupsEnabled": {
+                    "description": "Enable full group message processing. When false, group messages are accumulated and sent as activity summaries.",
+                    "default": true,
+                    "type": "boolean"
+                  },
+                  "autoPresenceSubscribe": {
+                    "description": "Automatically subscribe to presence updates when sending/receiving messages or typing status to/from a contact. Subscriptions are ephemeral and re-established automatically.",
+                    "default": false,
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "session",
+                  "webhookUrl",
+                  "webhookVerifyToken"
+                ]
+              }
+            }
           }
         }
       }
@@ -1234,7 +2221,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Disconnected",
+            "description": "Disconnected (auth state cleared)",
             "content": {
               "application/json": {
                 "schema": {
@@ -1571,14 +2558,17 @@
               }
             }
           },
+          "202": {
+            "description": "Session import accepted; connecting"
+          },
           "403": {
             "description": "Forbidden — the API key does not own this connection. Returned when a connection is bound to a different API key."
           },
           "404": {
-            "description": "Phone number not found"
+            "description": "Phone number not connected"
           },
           "409": {
-            "description": "Message is already being processed",
+            "description": "Owned by another live instance (worker role)",
             "headers": {
               "x-baileys-owner": {
                 "description": "Instance id of the connection owner",
@@ -1598,6 +2588,9 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable Entity — the requested noise candidate index is out of range."
           },
           "500": {
             "description": "Message not edited"
@@ -1728,7 +2721,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Disconnected",
+            "description": "Disconnected (auth state cleared)",
             "content": {
               "application/json": {
                 "schema": {
@@ -2065,14 +3058,17 @@
               }
             }
           },
+          "202": {
+            "description": "Session import accepted; connecting"
+          },
           "403": {
             "description": "Forbidden — the API key does not own this connection. Returned when a connection is bound to a different API key."
           },
           "404": {
-            "description": "Phone number not found"
+            "description": "Phone number not connected"
           },
           "409": {
-            "description": "Message is already being processed",
+            "description": "Owned by another live instance (worker role)",
             "headers": {
               "x-baileys-owner": {
                 "description": "Instance id of the connection owner",
@@ -2092,6 +3088,9 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable Entity — the requested noise candidate index is out of range."
           },
           "500": {
             "description": "Message not edited"
@@ -2205,7 +3204,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Disconnected",
+            "description": "Disconnected (auth state cleared)",
             "content": {
               "application/json": {
                 "schema": {
@@ -2542,14 +3541,17 @@
               }
             }
           },
+          "202": {
+            "description": "Session import accepted; connecting"
+          },
           "403": {
             "description": "Forbidden — the API key does not own this connection. Returned when a connection is bound to a different API key."
           },
           "404": {
-            "description": "Phone number not found"
+            "description": "Phone number not connected"
           },
           "409": {
-            "description": "Message is already being processed",
+            "description": "Owned by another live instance (worker role)",
             "headers": {
               "x-baileys-owner": {
                 "description": "Instance id of the connection owner",
@@ -2569,6 +3571,9 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable Entity — the requested noise candidate index is out of range."
           },
           "500": {
             "description": "Message not edited"
@@ -3728,7 +4733,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Disconnected",
+            "description": "Disconnected (auth state cleared)",
             "content": {
               "application/json": {
                 "schema": {
@@ -4065,14 +5070,17 @@
               }
             }
           },
+          "202": {
+            "description": "Session import accepted; connecting"
+          },
           "403": {
             "description": "Forbidden — the API key does not own this connection. Returned when a connection is bound to a different API key."
           },
           "404": {
-            "description": "Phone number not found"
+            "description": "Phone number not connected"
           },
           "409": {
-            "description": "Message is already being processed",
+            "description": "Owned by another live instance (worker role)",
             "headers": {
               "x-baileys-owner": {
                 "description": "Instance id of the connection owner",
@@ -4092,6 +5100,9 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable Entity — the requested noise candidate index is out of range."
           },
           "500": {
             "description": "Message not edited"
@@ -4222,7 +5233,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Disconnected",
+            "description": "Disconnected (auth state cleared)",
             "content": {
               "application/json": {
                 "schema": {
@@ -4559,14 +5570,17 @@
               }
             }
           },
+          "202": {
+            "description": "Session import accepted; connecting"
+          },
           "403": {
             "description": "Forbidden — the API key does not own this connection. Returned when a connection is bound to a different API key."
           },
           "404": {
-            "description": "Phone number not found"
+            "description": "Phone number not connected"
           },
           "409": {
-            "description": "Message is already being processed",
+            "description": "Owned by another live instance (worker role)",
             "headers": {
               "x-baileys-owner": {
                 "description": "Instance id of the connection owner",
@@ -4586,6 +5600,9 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable Entity — the requested noise candidate index is out of range."
           },
           "500": {
             "description": "Message not edited"
@@ -4819,7 +5836,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Disconnected",
+            "description": "Disconnected (auth state cleared)",
             "content": {
               "application/json": {
                 "schema": {
@@ -5156,14 +6173,17 @@
               }
             }
           },
+          "202": {
+            "description": "Session import accepted; connecting"
+          },
           "403": {
             "description": "Forbidden — the API key does not own this connection. Returned when a connection is bound to a different API key."
           },
           "404": {
-            "description": "Phone number not found"
+            "description": "Phone number not connected"
           },
           "409": {
-            "description": "Message is already being processed",
+            "description": "Owned by another live instance (worker role)",
             "headers": {
               "x-baileys-owner": {
                 "description": "Instance id of the connection owner",
@@ -5183,6 +6203,9 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable Entity — the requested noise candidate index is out of range."
           },
           "500": {
             "description": "Message not edited"
@@ -5340,7 +6363,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Disconnected",
+            "description": "Disconnected (auth state cleared)",
             "content": {
               "application/json": {
                 "schema": {
@@ -5677,14 +6700,17 @@
               }
             }
           },
+          "202": {
+            "description": "Session import accepted; connecting"
+          },
           "403": {
             "description": "Forbidden — the API key does not own this connection. Returned when a connection is bound to a different API key."
           },
           "404": {
-            "description": "Phone number not found"
+            "description": "Phone number not connected"
           },
           "409": {
-            "description": "Message is already being processed",
+            "description": "Owned by another live instance (worker role)",
             "headers": {
               "x-baileys-owner": {
                 "description": "Instance id of the connection owner",
@@ -5704,6 +6730,9 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable Entity — the requested noise candidate index is out of range."
           },
           "500": {
             "description": "Message not edited"
@@ -5835,7 +6864,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Disconnected",
+            "description": "Disconnected (auth state cleared)",
             "content": {
               "application/json": {
                 "schema": {
@@ -6172,14 +7201,17 @@
               }
             }
           },
+          "202": {
+            "description": "Session import accepted; connecting"
+          },
           "403": {
             "description": "Forbidden — the API key does not own this connection. Returned when a connection is bound to a different API key."
           },
           "404": {
-            "description": "Phone number not found"
+            "description": "Phone number not connected"
           },
           "409": {
-            "description": "Message is already being processed",
+            "description": "Owned by another live instance (worker role)",
             "headers": {
               "x-baileys-owner": {
                 "description": "Instance id of the connection owner",
@@ -6199,6 +7231,9 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable Entity — the requested noise candidate index is out of range."
           },
           "500": {
             "description": "Message not edited"
@@ -6358,7 +7393,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Disconnected",
+            "description": "Disconnected (auth state cleared)",
             "content": {
               "application/json": {
                 "schema": {
@@ -6695,14 +7730,17 @@
               }
             }
           },
+          "202": {
+            "description": "Session import accepted; connecting"
+          },
           "403": {
             "description": "Forbidden — the API key does not own this connection. Returned when a connection is bound to a different API key."
           },
           "404": {
-            "description": "Phone number not found"
+            "description": "Phone number not connected"
           },
           "409": {
-            "description": "Message is already being processed",
+            "description": "Owned by another live instance (worker role)",
             "headers": {
               "x-baileys-owner": {
                 "description": "Instance id of the connection owner",
@@ -6722,6 +7760,9 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable Entity — the requested noise candidate index is out of range."
           },
           "500": {
             "description": "Message not edited"
@@ -6989,7 +8030,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Disconnected",
+            "description": "Disconnected (auth state cleared)",
             "content": {
               "application/json": {
                 "schema": {
@@ -7326,14 +8367,17 @@
               }
             }
           },
+          "202": {
+            "description": "Session import accepted; connecting"
+          },
           "403": {
             "description": "Forbidden — the API key does not own this connection. Returned when a connection is bound to a different API key."
           },
           "404": {
-            "description": "Phone number not found"
+            "description": "Phone number not connected"
           },
           "409": {
-            "description": "Message is already being processed",
+            "description": "Owned by another live instance (worker role)",
             "headers": {
               "x-baileys-owner": {
                 "description": "Instance id of the connection owner",
@@ -7353,6 +8397,9 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable Entity — the requested noise candidate index is out of range."
           },
           "500": {
             "description": "Message not edited"
@@ -7388,7 +8435,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Disconnected",
+            "description": "Disconnected (auth state cleared)",
             "content": {
               "application/json": {
                 "schema": {
@@ -7725,14 +8772,17 @@
               }
             }
           },
+          "202": {
+            "description": "Session import accepted; connecting"
+          },
           "403": {
             "description": "Forbidden — the API key does not own this connection. Returned when a connection is bound to a different API key."
           },
           "404": {
-            "description": "Phone number not found"
+            "description": "Phone number not connected"
           },
           "409": {
-            "description": "Message is already being processed",
+            "description": "Owned by another live instance (worker role)",
             "headers": {
               "x-baileys-owner": {
                 "description": "Instance id of the connection owner",
@@ -7752,6 +8802,9 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable Entity — the requested noise candidate index is out of range."
           },
           "500": {
             "description": "Message not edited"
@@ -7788,7 +8841,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Disconnected",
+            "description": "Disconnected (auth state cleared)",
             "content": {
               "application/json": {
                 "schema": {
@@ -8125,14 +9178,17 @@
               }
             }
           },
+          "202": {
+            "description": "Session import accepted; connecting"
+          },
           "403": {
             "description": "Forbidden — the API key does not own this connection. Returned when a connection is bound to a different API key."
           },
           "404": {
-            "description": "Phone number not found"
+            "description": "Phone number not connected"
           },
           "409": {
-            "description": "Message is already being processed",
+            "description": "Owned by another live instance (worker role)",
             "headers": {
               "x-baileys-owner": {
                 "description": "Instance id of the connection owner",
@@ -8152,6 +9208,9 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable Entity — the requested noise candidate index is out of range."
           },
           "500": {
             "description": "Message not edited"
@@ -8188,7 +9247,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Disconnected",
+            "description": "Disconnected (auth state cleared)",
             "content": {
               "application/json": {
                 "schema": {
@@ -8525,14 +9584,17 @@
               }
             }
           },
+          "202": {
+            "description": "Session import accepted; connecting"
+          },
           "403": {
             "description": "Forbidden — the API key does not own this connection. Returned when a connection is bound to a different API key."
           },
           "404": {
-            "description": "Phone number not found"
+            "description": "Phone number not connected"
           },
           "409": {
-            "description": "Message is already being processed",
+            "description": "Owned by another live instance (worker role)",
             "headers": {
               "x-baileys-owner": {
                 "description": "Instance id of the connection owner",
@@ -8552,6 +9614,9 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable Entity — the requested noise candidate index is out of range."
           },
           "500": {
             "description": "Message not edited"
@@ -8669,7 +9734,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Disconnected",
+            "description": "Disconnected (auth state cleared)",
             "content": {
               "application/json": {
                 "schema": {
@@ -9006,14 +10071,17 @@
               }
             }
           },
+          "202": {
+            "description": "Session import accepted; connecting"
+          },
           "403": {
             "description": "Forbidden — the API key does not own this connection. Returned when a connection is bound to a different API key."
           },
           "404": {
-            "description": "Phone number not found"
+            "description": "Phone number not connected"
           },
           "409": {
-            "description": "Message is already being processed",
+            "description": "Owned by another live instance (worker role)",
             "headers": {
               "x-baileys-owner": {
                 "description": "Instance id of the connection owner",
@@ -9033,6 +10101,9 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable Entity — the requested noise candidate index is out of range."
           },
           "500": {
             "description": "Message not edited"
@@ -9079,7 +10150,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Disconnected",
+            "description": "Disconnected (auth state cleared)",
             "content": {
               "application/json": {
                 "schema": {
@@ -9416,14 +10487,17 @@
               }
             }
           },
+          "202": {
+            "description": "Session import accepted; connecting"
+          },
           "403": {
             "description": "Forbidden — the API key does not own this connection. Returned when a connection is bound to a different API key."
           },
           "404": {
-            "description": "Phone number not found"
+            "description": "Phone number not connected"
           },
           "409": {
-            "description": "Message is already being processed",
+            "description": "Owned by another live instance (worker role)",
             "headers": {
               "x-baileys-owner": {
                 "description": "Instance id of the connection owner",
@@ -9443,6 +10517,9 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable Entity — the requested noise candidate index is out of range."
           },
           "500": {
             "description": "Message not edited"
@@ -9478,7 +10555,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Disconnected",
+            "description": "Disconnected (auth state cleared)",
             "content": {
               "application/json": {
                 "schema": {
@@ -9815,14 +10892,17 @@
               }
             }
           },
+          "202": {
+            "description": "Session import accepted; connecting"
+          },
           "403": {
             "description": "Forbidden — the API key does not own this connection. Returned when a connection is bound to a different API key."
           },
           "404": {
-            "description": "Phone number not found"
+            "description": "Phone number not connected"
           },
           "409": {
-            "description": "Message is already being processed",
+            "description": "Owned by another live instance (worker role)",
             "headers": {
               "x-baileys-owner": {
                 "description": "Instance id of the connection owner",
@@ -9842,6 +10922,9 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable Entity — the requested noise candidate index is out of range."
           },
           "500": {
             "description": "Message not edited"
@@ -9982,7 +11065,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Disconnected",
+            "description": "Disconnected (auth state cleared)",
             "content": {
               "application/json": {
                 "schema": {
@@ -10319,14 +11402,17 @@
               }
             }
           },
+          "202": {
+            "description": "Session import accepted; connecting"
+          },
           "403": {
             "description": "Forbidden — the API key does not own this connection. Returned when a connection is bound to a different API key."
           },
           "404": {
-            "description": "Phone number not found"
+            "description": "Phone number not connected"
           },
           "409": {
-            "description": "Message is already being processed",
+            "description": "Owned by another live instance (worker role)",
             "headers": {
               "x-baileys-owner": {
                 "description": "Instance id of the connection owner",
@@ -10346,6 +11432,9 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable Entity — the requested noise candidate index is out of range."
           },
           "500": {
             "description": "Message not edited"
@@ -10456,7 +11545,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Disconnected",
+            "description": "Disconnected (auth state cleared)",
             "content": {
               "application/json": {
                 "schema": {
@@ -10793,14 +11882,17 @@
               }
             }
           },
+          "202": {
+            "description": "Session import accepted; connecting"
+          },
           "403": {
             "description": "Forbidden — the API key does not own this connection. Returned when a connection is bound to a different API key."
           },
           "404": {
-            "description": "Phone number not found"
+            "description": "Phone number not connected"
           },
           "409": {
-            "description": "Message is already being processed",
+            "description": "Owned by another live instance (worker role)",
             "headers": {
               "x-baileys-owner": {
                 "description": "Instance id of the connection owner",
@@ -10820,6 +11912,9 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable Entity — the requested noise candidate index is out of range."
           },
           "500": {
             "description": "Message not edited"
@@ -10924,7 +12019,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Disconnected",
+            "description": "Disconnected (auth state cleared)",
             "content": {
               "application/json": {
                 "schema": {
@@ -11261,14 +12356,17 @@
               }
             }
           },
+          "202": {
+            "description": "Session import accepted; connecting"
+          },
           "403": {
             "description": "Forbidden — the API key does not own this connection. Returned when a connection is bound to a different API key."
           },
           "404": {
-            "description": "Phone number not found"
+            "description": "Phone number not connected"
           },
           "409": {
-            "description": "Message is already being processed",
+            "description": "Owned by another live instance (worker role)",
             "headers": {
               "x-baileys-owner": {
                 "description": "Instance id of the connection owner",
@@ -11288,6 +12386,9 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable Entity — the requested noise candidate index is out of range."
           },
           "500": {
             "description": "Message not edited"
@@ -11398,7 +12499,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Disconnected",
+            "description": "Disconnected (auth state cleared)",
             "content": {
               "application/json": {
                 "schema": {
@@ -11735,14 +12836,17 @@
               }
             }
           },
+          "202": {
+            "description": "Session import accepted; connecting"
+          },
           "403": {
             "description": "Forbidden — the API key does not own this connection. Returned when a connection is bound to a different API key."
           },
           "404": {
-            "description": "Phone number not found"
+            "description": "Phone number not connected"
           },
           "409": {
-            "description": "Message is already being processed",
+            "description": "Owned by another live instance (worker role)",
             "headers": {
               "x-baileys-owner": {
                 "description": "Instance id of the connection owner",
@@ -11762,6 +12866,9 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable Entity — the requested noise candidate index is out of range."
           },
           "500": {
             "description": "Message not edited"
@@ -11887,7 +12994,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Disconnected",
+            "description": "Disconnected (auth state cleared)",
             "content": {
               "application/json": {
                 "schema": {
@@ -12224,14 +13331,17 @@
               }
             }
           },
+          "202": {
+            "description": "Session import accepted; connecting"
+          },
           "403": {
             "description": "Forbidden — the API key does not own this connection. Returned when a connection is bound to a different API key."
           },
           "404": {
-            "description": "Phone number not found"
+            "description": "Phone number not connected"
           },
           "409": {
-            "description": "Message is already being processed",
+            "description": "Owned by another live instance (worker role)",
             "headers": {
               "x-baileys-owner": {
                 "description": "Instance id of the connection owner",
@@ -12251,6 +13361,9 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable Entity — the requested noise candidate index is out of range."
           },
           "500": {
             "description": "Message not edited"
@@ -12347,7 +13460,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Disconnected",
+            "description": "Disconnected (auth state cleared)",
             "content": {
               "application/json": {
                 "schema": {
@@ -12684,14 +13797,17 @@
               }
             }
           },
+          "202": {
+            "description": "Session import accepted; connecting"
+          },
           "403": {
             "description": "Forbidden — the API key does not own this connection. Returned when a connection is bound to a different API key."
           },
           "404": {
-            "description": "Phone number not found"
+            "description": "Phone number not connected"
           },
           "409": {
-            "description": "Message is already being processed",
+            "description": "Owned by another live instance (worker role)",
             "headers": {
               "x-baileys-owner": {
                 "description": "Instance id of the connection owner",
@@ -12711,6 +13827,9 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable Entity — the requested noise candidate index is out of range."
           },
           "500": {
             "description": "Message not edited"
@@ -12747,7 +13866,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Disconnected",
+            "description": "Disconnected (auth state cleared)",
             "content": {
               "application/json": {
                 "schema": {
@@ -13084,14 +14203,17 @@
               }
             }
           },
+          "202": {
+            "description": "Session import accepted; connecting"
+          },
           "403": {
             "description": "Forbidden — the API key does not own this connection. Returned when a connection is bound to a different API key."
           },
           "404": {
-            "description": "Phone number not found"
+            "description": "Phone number not connected"
           },
           "409": {
-            "description": "Message is already being processed",
+            "description": "Owned by another live instance (worker role)",
             "headers": {
               "x-baileys-owner": {
                 "description": "Instance id of the connection owner",
@@ -13111,6 +14233,9 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable Entity — the requested noise candidate index is out of range."
           },
           "500": {
             "description": "Message not edited"
@@ -13270,7 +14395,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Disconnected",
+            "description": "Disconnected (auth state cleared)",
             "content": {
               "application/json": {
                 "schema": {
@@ -13607,14 +14732,17 @@
               }
             }
           },
+          "202": {
+            "description": "Session import accepted; connecting"
+          },
           "403": {
             "description": "Forbidden — the API key does not own this connection. Returned when a connection is bound to a different API key."
           },
           "404": {
-            "description": "Phone number not found"
+            "description": "Phone number not connected"
           },
           "409": {
-            "description": "Message is already being processed",
+            "description": "Owned by another live instance (worker role)",
             "headers": {
               "x-baileys-owner": {
                 "description": "Instance id of the connection owner",
@@ -13634,6 +14762,9 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable Entity — the requested noise candidate index is out of range."
           },
           "500": {
             "description": "Message not edited"
@@ -13670,7 +14801,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Disconnected",
+            "description": "Disconnected (auth state cleared)",
             "content": {
               "application/json": {
                 "schema": {
@@ -14007,14 +15138,17 @@
               }
             }
           },
+          "202": {
+            "description": "Session import accepted; connecting"
+          },
           "403": {
             "description": "Forbidden — the API key does not own this connection. Returned when a connection is bound to a different API key."
           },
           "404": {
-            "description": "Phone number not found"
+            "description": "Phone number not connected"
           },
           "409": {
-            "description": "Message is already being processed",
+            "description": "Owned by another live instance (worker role)",
             "headers": {
               "x-baileys-owner": {
                 "description": "Instance id of the connection owner",
@@ -14034,6 +15168,9 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable Entity — the requested noise candidate index is out of range."
           },
           "500": {
             "description": "Message not edited"
@@ -14120,7 +15257,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Disconnected",
+            "description": "Disconnected (auth state cleared)",
             "content": {
               "application/json": {
                 "schema": {
@@ -14457,14 +15594,17 @@
               }
             }
           },
+          "202": {
+            "description": "Session import accepted; connecting"
+          },
           "403": {
             "description": "Forbidden — the API key does not own this connection. Returned when a connection is bound to a different API key."
           },
           "404": {
-            "description": "Phone number not found"
+            "description": "Phone number not connected"
           },
           "409": {
-            "description": "Message is already being processed",
+            "description": "Owned by another live instance (worker role)",
             "headers": {
               "x-baileys-owner": {
                 "description": "Instance id of the connection owner",
@@ -14484,6 +15624,9 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable Entity — the requested noise candidate index is out of range."
           },
           "500": {
             "description": "Message not edited"
@@ -14570,7 +15713,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Disconnected",
+            "description": "Disconnected (auth state cleared)",
             "content": {
               "application/json": {
                 "schema": {
@@ -14907,14 +16050,17 @@
               }
             }
           },
+          "202": {
+            "description": "Session import accepted; connecting"
+          },
           "403": {
             "description": "Forbidden — the API key does not own this connection. Returned when a connection is bound to a different API key."
           },
           "404": {
-            "description": "Phone number not found"
+            "description": "Phone number not connected"
           },
           "409": {
-            "description": "Message is already being processed",
+            "description": "Owned by another live instance (worker role)",
             "headers": {
               "x-baileys-owner": {
                 "description": "Instance id of the connection owner",
@@ -14934,6 +16080,9 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable Entity — the requested noise candidate index is out of range."
           },
           "500": {
             "description": "Message not edited"
@@ -15038,7 +16187,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Disconnected",
+            "description": "Disconnected (auth state cleared)",
             "content": {
               "application/json": {
                 "schema": {
@@ -15375,14 +16524,17 @@
               }
             }
           },
+          "202": {
+            "description": "Session import accepted; connecting"
+          },
           "403": {
             "description": "Forbidden — the API key does not own this connection. Returned when a connection is bound to a different API key."
           },
           "404": {
-            "description": "Phone number not found"
+            "description": "Phone number not connected"
           },
           "409": {
-            "description": "Message is already being processed",
+            "description": "Owned by another live instance (worker role)",
             "headers": {
               "x-baileys-owner": {
                 "description": "Instance id of the connection owner",
@@ -15402,6 +16554,9 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable Entity — the requested noise candidate index is out of range."
           },
           "500": {
             "description": "Message not edited"
@@ -15582,7 +16737,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Disconnected",
+            "description": "Disconnected (auth state cleared)",
             "content": {
               "application/json": {
                 "schema": {
@@ -15919,14 +17074,17 @@
               }
             }
           },
+          "202": {
+            "description": "Session import accepted; connecting"
+          },
           "403": {
             "description": "Forbidden — the API key does not own this connection. Returned when a connection is bound to a different API key."
           },
           "404": {
-            "description": "Phone number not found"
+            "description": "Phone number not connected"
           },
           "409": {
-            "description": "Message is already being processed",
+            "description": "Owned by another live instance (worker role)",
             "headers": {
               "x-baileys-owner": {
                 "description": "Instance id of the connection owner",
@@ -15946,6 +17104,9 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable Entity — the requested noise candidate index is out of range."
           },
           "500": {
             "description": "Message not edited"
@@ -15982,7 +17143,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Disconnected",
+            "description": "Disconnected (auth state cleared)",
             "content": {
               "application/json": {
                 "schema": {
@@ -16319,14 +17480,17 @@
               }
             }
           },
+          "202": {
+            "description": "Session import accepted; connecting"
+          },
           "403": {
             "description": "Forbidden — the API key does not own this connection. Returned when a connection is bound to a different API key."
           },
           "404": {
-            "description": "Phone number not found"
+            "description": "Phone number not connected"
           },
           "409": {
-            "description": "Message is already being processed",
+            "description": "Owned by another live instance (worker role)",
             "headers": {
               "x-baileys-owner": {
                 "description": "Instance id of the connection owner",
@@ -16346,6 +17510,9 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable Entity — the requested noise candidate index is out of range."
           },
           "500": {
             "description": "Message not edited"
@@ -16453,7 +17620,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Disconnected",
+            "description": "Disconnected (auth state cleared)",
             "content": {
               "application/json": {
                 "schema": {
@@ -16790,14 +17957,17 @@
               }
             }
           },
+          "202": {
+            "description": "Session import accepted; connecting"
+          },
           "403": {
             "description": "Forbidden — the API key does not own this connection. Returned when a connection is bound to a different API key."
           },
           "404": {
-            "description": "Phone number not found"
+            "description": "Phone number not connected"
           },
           "409": {
-            "description": "Message is already being processed",
+            "description": "Owned by another live instance (worker role)",
             "headers": {
               "x-baileys-owner": {
                 "description": "Instance id of the connection owner",
@@ -16817,6 +17987,9 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable Entity — the requested noise candidate index is out of range."
           },
           "500": {
             "description": "Message not edited"
@@ -16939,7 +18112,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Disconnected",
+            "description": "Disconnected (auth state cleared)",
             "content": {
               "application/json": {
                 "schema": {
@@ -17276,14 +18449,17 @@
               }
             }
           },
+          "202": {
+            "description": "Session import accepted; connecting"
+          },
           "403": {
             "description": "Forbidden — the API key does not own this connection. Returned when a connection is bound to a different API key."
           },
           "404": {
-            "description": "Phone number not found"
+            "description": "Phone number not connected"
           },
           "409": {
-            "description": "Message is already being processed",
+            "description": "Owned by another live instance (worker role)",
             "headers": {
               "x-baileys-owner": {
                 "description": "Instance id of the connection owner",
@@ -17303,6 +18479,9 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable Entity — the requested noise candidate index is out of range."
           },
           "500": {
             "description": "Message not edited"
@@ -17419,7 +18598,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Disconnected",
+            "description": "Disconnected (auth state cleared)",
             "content": {
               "application/json": {
                 "schema": {
@@ -17756,14 +18935,17 @@
               }
             }
           },
+          "202": {
+            "description": "Session import accepted; connecting"
+          },
           "403": {
             "description": "Forbidden — the API key does not own this connection. Returned when a connection is bound to a different API key."
           },
           "404": {
-            "description": "Phone number not found"
+            "description": "Phone number not connected"
           },
           "409": {
-            "description": "Message is already being processed",
+            "description": "Owned by another live instance (worker role)",
             "headers": {
               "x-baileys-owner": {
                 "description": "Instance id of the connection owner",
@@ -17783,6 +18965,9 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable Entity — the requested noise candidate index is out of range."
           },
           "500": {
             "description": "Message not edited"
@@ -17899,7 +19084,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Disconnected",
+            "description": "Disconnected (auth state cleared)",
             "content": {
               "application/json": {
                 "schema": {
@@ -18236,14 +19421,17 @@
               }
             }
           },
+          "202": {
+            "description": "Session import accepted; connecting"
+          },
           "403": {
             "description": "Forbidden — the API key does not own this connection. Returned when a connection is bound to a different API key."
           },
           "404": {
-            "description": "Phone number not found"
+            "description": "Phone number not connected"
           },
           "409": {
-            "description": "Message is already being processed",
+            "description": "Owned by another live instance (worker role)",
             "headers": {
               "x-baileys-owner": {
                 "description": "Instance id of the connection owner",
@@ -18263,6 +19451,9 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable Entity — the requested noise candidate index is out of range."
           },
           "500": {
             "description": "Message not edited"


### PR DESCRIPTION
`POST /connections/:phoneNumber/send-message` passa a aceitar um `messageId` opcional, usado como id da mensagem no WhatsApp. Quem envia pode reservar o id antes da requisição e, com isso, reconhecer o eco de `messages.upsert` da própria mensagem mesmo que a resposta se perca. Um reenvio com o mesmo id também deixa de virar uma segunda mensagem no WhatsApp.

## Closes

- Habilita fazer-ai/chatwoot#338 (fazer-ai/chatwoot#362)

## How to test

1. `POST /connections/<phone>/send-message` com `messageId: "3EB0..."` no body.
2. A resposta traz `data.key.id` igual ao id enviado, e o webhook `messages.upsert` do eco carrega o mesmo id.
3. Sem `messageId` no body, nada muda: Baileys gera o id como antes.

## What changed

- `messageId` opcional no schema do endpoint, repassado por `connectionsHandler.sendMessage` até `sock.sendMessage`, onde vira o `key.id`.
- A chave só entra no objeto de opções quando definida: Baileys aplica o spread das nossas options sobre o próprio `messageId: generateMessageIDV2(user)`, então um `undefined` explícito rebaixaria esse default para a variante sem user.
- Primeiro commit regenera o `swagger.json`, que estava com drift de PRs anteriores (respostas 202/422 do import-session, descrições reescritas, schemas de participantes de grupo). Assim o commit da feature mostra só o campo novo.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/baileys-api/373)
<!-- Reviewable:end -->
