### PR TITLE
fix: stop a wedged keystore mutex from silently muting a connection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,25 @@ PORT=3025
 LOG_LEVEL=debug
 
 BAILEYS_LOG_LEVEL=debug
+# Deadline for the Baileys library's own HTTP downloads. Guards against a
+# parked download wedging the per-connection keystore transaction, which mutes
+# every send on that connection.
+BAILEYS_HTTP_TIMEOUT_MS=120000
+# Reject after waiting this long for the keystore transaction mutex. Six
+# operations share one mutex per connection, so a wedged one blocks all sends.
+# The default is the conservative rollout value: high enough to be
+# diagnosis-only. Lower to 90000 once the stall reports name the culprit.
+# 0 disables.
+BAILEYS_TX_ACQUIRE_TIMEOUT_MS=300000
+# Report a transaction still holding the mutex after this long. Must be lower
+# than BAILEYS_TX_ACQUIRE_TIMEOUT_MS. 0 disables.
+BAILEYS_TX_HOLD_WARN_MS=30000
+# Deadline on a single send. Must be lower than PROXY_REQUEST_TIMEOUT_MS.
+BAILEYS_SEND_TIMEOUT_MS=45000
+# Allow a connection whose sends keep timing out to recreate its own socket.
+# Off by default: turn it on after watching the detector fire only on the real
+# pattern. Detection, logging and the webhook run either way.
+BAILEYS_SEND_STALL_RESTART_ENABLED=false
 BAILEYS_CLIENT_VERSION=default
 BAILEYS_OVERRIDE_CLIENT_VERSION=false
 # Can be used to send Baileys events that are currently not handled by the API to the webhook.

--- a/README-pt.md
+++ b/README-pt.md
@@ -189,7 +189,7 @@ Exemplo: um proxy no host A (`WORKER_BASE_URL` não usado), workers nos hosts B 
 | `BAILEYS_HTTP_TIMEOUT_MS`             | Prazo para os downloads HTTP da própria biblioteca Baileys. Impede que um download travado prenda os envios da conexão. | `120000`                 |
 | `BAILEYS_TX_ACQUIRE_TIMEOUT_MS`       | Falha após esperar esse tempo pelo mutex de transação do keystore. `0` desativa. Veja "Conexões mudas" abaixo.          | `300000`                 |
 | `BAILEYS_TX_HOLD_WARN_MS`             | Reporta uma transação que ainda segura o mutex após esse tempo. Deve ser menor que o timeout de aquisição. `0` desativa. | `30000`                 |
-| `BAILEYS_SEND_TIMEOUT_MS`             | Prazo de um envio. Deve ser menor que `PROXY_REQUEST_TIMEOUT_MS`.                                                      | `45000`                  |
+| `BAILEYS_SEND_TIMEOUT_MS`             | Prazo de um envio. Somado ao orçamento fixo de 20s do pré-processamento de áudio, deve ser menor que `PROXY_REQUEST_TIMEOUT_MS`.                                                      | `45000`                  |
 | `BAILEYS_SEND_STALL_RESTART_ENABLED`  | Permite que uma conexão cujos envios travam recrie o próprio socket. A detecção e os webhooks funcionam de todo jeito.  | `false`                  |
 | `REDIS_URL`                           | A URL de conexão para sua instância Redis.                                                                              | `redis://localhost:6379` |
 | `REDIS_PASSWORD`                      | A senha para sua instância Redis (se houver).                                                                           |                          |

--- a/README-pt.md
+++ b/README-pt.md
@@ -80,7 +80,9 @@ O que esta API oferece:
   `data.error = "send_stall_detected"` é emitido quando um travamento é
   detectado. O `sendStall.action` diz o que o provedor fez: `restart` (o socket
   foi recriado), `suppressed` (um backoff está segurando até `until`) ou
-  `cancelled` (a conexão se recuperou antes de o restart rodar).
+  `cancelled` (a conexão se recuperou antes de o restart rodar), ou `failed`
+  (o restart rodou e não conseguiu reconstruir o socket, que é onde alguém
+  precisa intervir).
 - **Recuperação automática.** Com `BAILEYS_SEND_STALL_RESTART_ENABLED=true`,
   uma conexão travada reinicia o próprio socket, com limite de taxa por
   processo e backoff por telefone.

--- a/README-pt.md
+++ b/README-pt.md
@@ -42,9 +42,58 @@ A API expõe os seguintes endpoints. Tenha em mente que este projeto está em de
 - `POST /connections/:phoneNumber/send-message`: Envia uma mensagem através de uma conexão ativa.
 - `POST /connections/:phoneNumber/read-messages`: Marca mensagens como lidas.
 - `DELETE /connections/:phoneNumber`: Faz logout e desconecta uma conexão WhatsApp.
+- `POST /connections/:phoneNumber/restart`: Recria o socket de uma conexão, preservando a sessão (sem QR, sem re-pareamento).
+- `GET /connections/:phoneNumber/health`: Saúde do envio de uma conexão. Veja "Conexões mudas" abaixo.
 
 > [!IMPORTANT]
 > O parâmetro `phoneNumber` na URL deve estar no formato `+<codigo_do_pais><telefone>`, ex: `+551234567890`.
+
+
+### Conexões mudas
+
+Uma conexão pode continuar recebendo mensagens e passar em todas as verificações
+de saúde enquanto nenhuma mensagem enviada realmente sai. Seis operações dentro
+do Baileys são serializadas por um único mutex por conexão, cuja chave é o JID
+da própria conexão, e esse mutex não tem timeout: se uma delas não retorna, todo
+envio entra numa fila que não anda, por minutos ou por horas, sem erro, sem log
+e sem desconexão. Recepção e consultas IQ não passam por esse mutex, e é por
+isso que a conexão parece perfeitamente saudável o tempo todo.
+
+`POST /connections/:phoneNumber` **não** recupera esse estado. Para uma conexão
+já registrada ele apenas envia um presence update, que não passa pelo keystore
+— ou seja, tem sucesso mesmo com o socket travado.
+
+O que esta API oferece:
+
+- **Envios com prazo.** Um envio que passa de `BAILEYS_SEND_TIMEOUT_MS`
+  responde `504` em vez de pendurar. Após três timeouts consecutivos, a conexão
+  responde `503` na hora, em vez de enfileirar mais trabalho atrás do mutex
+  travado.
+- **Recuperação sem QR.** `POST /connections/:phoneNumber/restart` derruba o
+  socket e o reconstrói a partir da sessão armazenada. O authState não é tocado,
+  então o aparelho não precisa escanear nada.
+- **Detecção.** `GET /connections/:phoneNumber/health` reporta `sendState`
+  (`unknown`/`ok`/`degraded`/`stalled`), a idade do último envio concluído e a
+  idade do último reconhecimento do WhatsApp para uma mensagem nossa — a única
+  prova fim a fim de que o envio funciona. `GET /cluster/health` traz
+  `stalledConnectionCount`. Um webhook `connection.update` com
+  `data.error = "send_stall_detected"` é emitido quando um travamento é
+  detectado.
+- **Recuperação automática.** Com `BAILEYS_SEND_STALL_RESTART_ENABLED=true`,
+  uma conexão travada reinicia o próprio socket, com limite de taxa por
+  processo e backoff por telefone.
+
+> [!NOTE]
+> Use `stalledConnectionCount` para alertas, nunca para liveness do container:
+> um health check reprovando reinicia o processo e derruba junto todas as
+> conexões saudáveis.
+
+> [!TIP]
+> Reserve o id da mensagem do WhatsApp pelo campo `messageId` do send-message.
+> Um envio que dá timeout ainda pode chegar ao WhatsApp; com um id reservado, a
+> retentativa reusa o mesmo id e o WhatsApp deduplica. Sem ele, a API não tem
+> como dizer ao caller que é seguro retentar, e responde `409` com
+> `x-baileys-idempotency-state: indeterminate`.
 
 ### Admin
 
@@ -137,6 +186,11 @@ Exemplo: um proxy no host A (`WORKER_BASE_URL` não usado), workers nos hosts B 
 | `LOG_LEVEL`                           | O nível geral de log para a aplicação.                                                                                  | `info`                   |
 | `BAILEYS_LOG_LEVEL`                   | Nível de log específico para a biblioteca Baileys.                                                                      | `warn`                   |
 | `BAILEYS_CLIENT_VERSION`              | A versão do cliente Baileys a ser utilizada. Só altere se você souber o que está fazendo!                               | `default`                |
+| `BAILEYS_HTTP_TIMEOUT_MS`             | Prazo para os downloads HTTP da própria biblioteca Baileys. Impede que um download travado prenda os envios da conexão. | `120000`                 |
+| `BAILEYS_TX_ACQUIRE_TIMEOUT_MS`       | Falha após esperar esse tempo pelo mutex de transação do keystore. `0` desativa. Veja "Conexões mudas" abaixo.          | `300000`                 |
+| `BAILEYS_TX_HOLD_WARN_MS`             | Reporta uma transação que ainda segura o mutex após esse tempo. Deve ser menor que o timeout de aquisição. `0` desativa. | `30000`                 |
+| `BAILEYS_SEND_TIMEOUT_MS`             | Prazo de um envio. Deve ser menor que `PROXY_REQUEST_TIMEOUT_MS`.                                                      | `45000`                  |
+| `BAILEYS_SEND_STALL_RESTART_ENABLED`  | Permite que uma conexão cujos envios travam recrie o próprio socket. A detecção e os webhooks funcionam de todo jeito.  | `false`                  |
 | `REDIS_URL`                           | A URL de conexão para sua instância Redis.                                                                              | `redis://localhost:6379` |
 | `REDIS_PASSWORD`                      | A senha para sua instância Redis (se houver).                                                                           |                          |
 | `WEBHOOK_RETRY_POLICY_MAX_RETRIES`    | Número máximo de tentativas para enviar eventos de webhook.                                                             | `3`                      |

--- a/README-pt.md
+++ b/README-pt.md
@@ -78,7 +78,9 @@ O que esta API oferece:
   prova fim a fim de que o envio funciona. `GET /cluster/health` traz
   `stalledConnectionCount`. Um webhook `connection.update` com
   `data.error = "send_stall_detected"` é emitido quando um travamento é
-  detectado.
+  detectado. O `sendStall.action` diz o que o provedor fez: `restart` (o socket
+  foi recriado), `suppressed` (um backoff está segurando até `until`) ou
+  `cancelled` (a conexão se recuperou antes de o restart rodar).
 - **Recuperação automática.** Com `BAILEYS_SEND_STALL_RESTART_ENABLED=true`,
   uma conexão travada reinicia o próprio socket, com limite de taxa por
   processo e backoff por telefone.

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ Example: a proxy on host A (`WORKER_BASE_URL` unused), workers on hosts B and C 
 | `BAILEYS_HTTP_TIMEOUT_MS`             | Deadline for the Baileys library's own HTTP downloads. Guards against a parked download wedging a connection's sends.   | `120000`                 |
 | `BAILEYS_TX_ACQUIRE_TIMEOUT_MS`       | Reject after waiting this long for the keystore transaction mutex. `0` disables. See "Silent send stalls" below.        | `300000`                 |
 | `BAILEYS_TX_HOLD_WARN_MS`             | Report a transaction still holding the keystore mutex after this long. Must be lower than the acquire timeout. `0` disables. | `30000`             |
-| `BAILEYS_SEND_TIMEOUT_MS`             | Deadline on a single send. Must be lower than `PROXY_REQUEST_TIMEOUT_MS`.                                              | `45000`                  |
+| `BAILEYS_SEND_TIMEOUT_MS`             | Deadline on a single send. Plus the fixed 20s audio-preprocessing budget, must be lower than `PROXY_REQUEST_TIMEOUT_MS`.                                              | `45000`                  |
 | `BAILEYS_SEND_STALL_RESTART_ENABLED`  | Allow a connection whose sends keep timing out to recreate its own socket. Detection and webhooks run either way.       | `false`                  |
 | `REDIS_URL`                           | The connection URL for your Redis instance.                                                                | `redis://localhost:6379` |
 | `REDIS_PASSWORD`                      | The password for your Redis instance (if any).                                                             |                          |

--- a/README.md
+++ b/README.md
@@ -42,9 +42,57 @@ The API exposes the following endpoints. Keep in mind this project is in early d
 - `POST /connections/:phoneNumber/send-message`: Sends a message through an active connection.
 - `POST /connections/:phoneNumber/read-messages`: Marks messages as read.
 - `DELETE /connections/:phoneNumber`: Logs out and disconnects a WhatsApp connection.
+- `POST /connections/:phoneNumber/restart`: Recreates the socket for a connection, keeping its session (no QR, no re-pairing).
+- `GET /connections/:phoneNumber/health`: Send-side health for a connection. See "Silent send stalls" below.
 
 > [!IMPORTANT]
 > The `phoneNumber` parameter in the URL should be in the format `+<country_code><phone_number>`, e.g. `+551234567890`.
+
+
+### Silent send stalls
+
+A connection can keep receiving messages and pass every health check while none
+of its outgoing messages actually go out. Six operations inside Baileys
+serialize on a single mutex per connection, keyed by that connection's own JID,
+and the mutex has no timeout: if one of them never returns, every send queues
+behind it, for minutes or for hours, with no error, no log and no disconnect.
+Receiving and IQ queries do not touch that mutex, which is why the connection
+looks perfectly healthy throughout.
+
+`POST /connections/:phoneNumber` does **not** recover this. For a connection
+that is already registered it only sends a presence update, which does not go
+through the keystore — so it succeeds against a wedged socket.
+
+What this API provides:
+
+- **Bounded sends.** A send that exceeds `BAILEYS_SEND_TIMEOUT_MS` answers
+  `504` instead of hanging. After three consecutive timeouts the connection
+  answers `503` immediately rather than queueing more work behind the stuck
+  mutex.
+- **Recovery without a QR.** `POST /connections/:phoneNumber/restart` tears
+  down the socket and rebuilds it from the stored session. The auth state is
+  untouched, so the phone does not need to scan anything.
+- **Detection.** `GET /connections/:phoneNumber/health` reports `sendState`
+  (`unknown`/`ok`/`degraded`/`stalled`), the age of the last completed send and
+  the age of the last WhatsApp acknowledgement of one of our messages — the only
+  end-to-end proof that sending works. `GET /cluster/health` carries
+  `stalledConnectionCount`. A `connection.update` webhook with
+  `data.error = "send_stall_detected"` is emitted when a stall is detected.
+- **Automatic recovery.** With `BAILEYS_SEND_STALL_RESTART_ENABLED=true`, a
+  stalled connection restarts its own socket, rate-limited per process and
+  backed off per phone.
+
+> [!NOTE]
+> Use `stalledConnectionCount` for alerting, never for container liveness: a
+> failing health check restarts the process and takes every healthy connection
+> down with it.
+
+> [!TIP]
+> Reserve the WhatsApp message id via the `messageId` field on send-message. A
+> send that times out may still reach WhatsApp; with a reserved id a retry
+> reuses the same id and WhatsApp deduplicates it. Without one the API cannot
+> tell the caller it is safe to retry, and answers `409` with
+> `x-baileys-idempotency-state: indeterminate` instead.
 
 ### Admin
 
@@ -137,6 +185,11 @@ Example: a proxy on host A (`WORKER_BASE_URL` unused), workers on hosts B and C 
 | `LOG_LEVEL`                           | The general log level for the application.                                                                 | `info`                   |
 | `BAILEYS_LOG_LEVEL`                   | Specific log level for the Baileys library.                                                                | `warn`                   |
 | `BAILEYS_CLIENT_VERSION`              | The Baileys client version to use. Only change if you know what you're doing!                              | `default`                |
+| `BAILEYS_HTTP_TIMEOUT_MS`             | Deadline for the Baileys library's own HTTP downloads. Guards against a parked download wedging a connection's sends.   | `120000`                 |
+| `BAILEYS_TX_ACQUIRE_TIMEOUT_MS`       | Reject after waiting this long for the keystore transaction mutex. `0` disables. See "Silent send stalls" below.        | `300000`                 |
+| `BAILEYS_TX_HOLD_WARN_MS`             | Report a transaction still holding the keystore mutex after this long. Must be lower than the acquire timeout. `0` disables. | `30000`             |
+| `BAILEYS_SEND_TIMEOUT_MS`             | Deadline on a single send. Must be lower than `PROXY_REQUEST_TIMEOUT_MS`.                                              | `45000`                  |
+| `BAILEYS_SEND_STALL_RESTART_ENABLED`  | Allow a connection whose sends keep timing out to recreate its own socket. Detection and webhooks run either way.       | `false`                  |
 | `REDIS_URL`                           | The connection URL for your Redis instance.                                                                | `redis://localhost:6379` |
 | `REDIS_PASSWORD`                      | The password for your Redis instance (if any).                                                             |                          |
 | `WEBHOOK_RETRY_POLICY_MAX_RETRIES`    | Maximum number of retries for sending webhook events.                                                      | `3`                      |

--- a/README.md
+++ b/README.md
@@ -80,7 +80,9 @@ What this API provides:
   `data.error = "send_stall_detected"` is emitted when a stall is detected. Its
   `sendStall.action` says what the provider did: `restart` (the socket was
   recreated), `suppressed` (a backoff is holding it off until `until`), or
-  `cancelled` (the connection recovered before the restart ran).
+  `cancelled` (the connection recovered before the restart ran), or `failed`
+  (the restart ran and could not rebuild the socket, which is where a human has
+  to step in).
 - **Automatic recovery.** With `BAILEYS_SEND_STALL_RESTART_ENABLED=true`, a
   stalled connection restarts its own socket, rate-limited per process and
   backed off per phone.

--- a/README.md
+++ b/README.md
@@ -77,7 +77,10 @@ What this API provides:
   the age of the last WhatsApp acknowledgement of one of our messages — the only
   end-to-end proof that sending works. `GET /cluster/health` carries
   `stalledConnectionCount`. A `connection.update` webhook with
-  `data.error = "send_stall_detected"` is emitted when a stall is detected.
+  `data.error = "send_stall_detected"` is emitted when a stall is detected. Its
+  `sendStall.action` says what the provider did: `restart` (the socket was
+  recreated), `suppressed` (a backoff is holding it off until `until`), or
+  `cancelled` (the connection recovered before the restart ran).
 - **Automatic recovery.** With `BAILEYS_SEND_STALL_RESTART_ENABLED=true`, a
   stalled connection restarts its own socket, rate-limited per process and
   backed off per phone.

--- a/bun.lock
+++ b/bun.lock
@@ -10,6 +10,7 @@
         "@ffmpeg-installer/ffmpeg": "^1.1.0",
         "@hapi/boom": "^10.0.1",
         "@whiskeysockets/baileys": "7.0.0-rc14",
+        "async-mutex": "^0.5.0",
         "audio-decode": "^2.2.3",
         "elysia": "^1.4.29",
         "fluent-ffmpeg": "^2.1.3",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@ffmpeg-installer/ffmpeg": "^1.1.0",
     "@hapi/boom": "^10.0.1",
     "@whiskeysockets/baileys": "7.0.0-rc14",
+    "async-mutex": "^0.5.0",
     "audio-decode": "^2.2.3",
     "elysia": "^1.4.29",
     "fluent-ffmpeg": "^2.1.3",

--- a/patches/@whiskeysockets%2Fbaileys@7.0.0-rc14.patch
+++ b/patches/@whiskeysockets%2Fbaileys@7.0.0-rc14.patch
@@ -322,10 +322,10 @@ index 0f4ff1ce169432faa8b0a7d2e2bca874c1d8092d..f7c20c3e93bd9a02aaa88df3910ea8b9
              const [image] = info.images;
              const urlInfo = {
 diff --git a/lib/Utils/messages-media.js b/lib/Utils/messages-media.js
-index a3d2fa6bae6af021a4a50b4270584fed08623f34..ea1e9ed9a4099e5609c0a483848f36a2bb6ec559 100644
+index a3d2fa6bae6af021a4a50b4270584fed08623f34..42b1f21786dd0d7bce3a09af35492a6c44516597 100644
 --- a/lib/Utils/messages-media.js
 +++ b/lib/Utils/messages-media.js
-@@ -295,10 +295,19 @@ export async function generateThumbnail(file, mediaType, options) {
+@@ -295,10 +295,26 @@ export async function generateThumbnail(file, mediaType, options) {
      };
  }
  export const getHttpStream = async (url, options = {}) => {
@@ -335,8 +335,15 @@ index a3d2fa6bae6af021a4a50b4270584fed08623f34..ea1e9ed9a4099e5609c0a483848f36a2
 +    // every send on the connection with no error, no log and no close -- the
 +    // silent send stall. `timeoutMs` comes from the socket's `options` config,
 +    // so the deadline stays policy-in-app and this patch stays mechanism-only.
++    // `timeout` first: link previews pass BOTH (messages-send.js builds
++    // `{ timeout: 3000, ...httpRequestOptions }`), and the tighter one is the
++    // right budget there -- a thumbnail is worth 3s, not two minutes of the
++    // caller's send, which would outlive the app-level send deadline and spend a
++    // stall strike on a keystore that is perfectly healthy. The app-state and
++    // media paths pass only `timeoutMs`, so they are unaffected.
++    const deadlineMs = options.timeout ?? options.timeoutMs;
 +    const signal = options.signal ??
-+        (options.timeoutMs ? AbortSignal.timeout(options.timeoutMs) : undefined);
++        (deadlineMs ? AbortSignal.timeout(deadlineMs) : undefined);
      const response = await fetch(url.toString(), {
          dispatcher: options.dispatcher,
          method: 'GET',

--- a/patches/@whiskeysockets%2Fbaileys@7.0.0-rc14.patch
+++ b/patches/@whiskeysockets%2Fbaileys@7.0.0-rc14.patch
@@ -197,10 +197,10 @@ index 24a358326a704e3f95b27ad996d2bc5e8ecfd101..f5a738f2b7d501ece18be53032540b05
                  releaseTxMutexRef(key);
              }
 diff --git a/lib/Utils/link-preview.js b/lib/Utils/link-preview.js
-index 0f4ff1ce169432faa8b0a7d2e2bca874c1d8092d..740c45d80b39355b4585e2af5f808aaf71e7be00 100644
+index 0f4ff1ce169432faa8b0a7d2e2bca874c1d8092d..f7c20c3e93bd9a02aaa88df3910ea8b9ff8f009d 100644
 --- a/lib/Utils/link-preview.js
 +++ b/lib/Utils/link-preview.js
-@@ -1,6 +1,52 @@
+@@ -1,6 +1,62 @@
  import { prepareWAMessageMedia } from './messages.js';
  import { extractImageThumb, getHttpStream } from './messages-media.js';
  const THUMBNAIL_WIDTH_PX = 192;
@@ -230,7 +230,17 @@ index 0f4ff1ce169432faa8b0a7d2e2bca874c1d8092d..740c45d80b39355b4585e2af5f808aaf
 +        throw new Error('Invalid YouTube URL');
 +    }
 +    const oembedUrl = `https://www.youtube.com/oembed?url=${encodeURIComponent(videoUrl)}&format=json`;
-+    const response = await fetch(oembedUrl, fetchOpts);
++    // Native fetch ignores both budgets the caller passes here: the lib's own
++    // `timeout` (3000, set in messages-send.js) and our `timeoutMs`. Unbounded,
++    // a parked oEmbed request holds the send until the app-level deadline gives
++    // up, counts a stall strike against a keystore that is perfectly healthy,
++    // and leaks the request forever. Prefer the lib's tighter link-preview
++    // budget: a preview is worth 3s, not two minutes of the caller's send.
++    const previewTimeoutMs = fetchOpts?.timeout ?? fetchOpts?.timeoutMs;
++    const response = await fetch(oembedUrl, {
++        ...fetchOpts,
++        signal: fetchOpts?.signal ?? (previewTimeoutMs ? AbortSignal.timeout(previewTimeoutMs) : undefined)
++    });
 +    if (!response.ok) {
 +        throw new Error(`Failed to fetch YouTube oEmbed data: ${response.statusText}`);
 +    }
@@ -253,7 +263,7 @@ index 0f4ff1ce169432faa8b0a7d2e2bca874c1d8092d..740c45d80b39355b4585e2af5f808aaf
  /** Fetches an image and generates a thumbnail for it */
  const getCompressedJpegThumbnail = async (url, { thumbnailWidth, fetchOpts }) => {
      const stream = await getHttpStream(url, fetchOpts);
-@@ -26,27 +72,36 @@ export const getUrlInfo = async (text, opts = {
+@@ -26,27 +82,36 @@ export const getUrlInfo = async (text, opts = {
          if (!text.startsWith('https://') && !text.startsWith('http://')) {
              previewLink = 'https://' + previewLink;
          }

--- a/patches/@whiskeysockets%2Fbaileys@7.0.0-rc14.patch
+++ b/patches/@whiskeysockets%2Fbaileys@7.0.0-rc14.patch
@@ -25,6 +25,30 @@ index ae34a8f315a0b9fd101472cc69e59624c6c63861..c4ddb74ddb49d1e161e6746147fca17e
          logger.error({ err }, `unexpected error in '${msg}'`);
      };
      /** await the next incoming message */
+diff --git a/lib/Types/Auth.d.ts b/lib/Types/Auth.d.ts
+index 035bd00ccc3b640daf417dd581add94dccedc7ac..547d7b265dea2ac2d77876aae8514d8f2193fc97 100644
+--- a/lib/Types/Auth.d.ts
++++ b/lib/Types/Auth.d.ts
+@@ -104,6 +104,19 @@ export type SignalKeyStoreWithTransaction = SignalKeyStore & {
+ export type TransactionCapabilityOptions = {
+     maxCommitRetries: number;
+     delayBetweenTriesMs: number;
++    /** reject after this long WAITING for the transaction mutex; 0 disables */
++    acquireTimeoutMs?: number;
++    /** report a transaction still holding the mutex after this long; 0 disables */
++    holdWarnMs?: number;
++    /** observability hook for mutex wait/hold; see addTransactionCapability */
++    onTransactionEvent?: (event: {
++        phase: 'acquired' | 'released' | 'stalled' | 'timeout';
++        key: string;
++        waitedMs: number;
++        heldMs?: number;
++        originStack?: string;
++        stillLocked?: boolean;
++    }) => void;
+ };
+ export type SignalAuthState = {
+     creds: SignalCreds;
 diff --git a/lib/Types/Message.d.ts b/lib/Types/Message.d.ts
 index 0004fb678bf732ec3fd5ec35ae48594bd5960c43..c0802d9e512724d06ef8f3bdd52f0325853c192f 100644
 --- a/lib/Types/Message.d.ts
@@ -46,6 +70,132 @@ index 0004fb678bf732ec3fd5ec35ae48594bd5960c43..c0802d9e512724d06ef8f3bdd52f0325
  };
  export type MessageGenerationOptionsFromContent = MiscMessageGenerationOptions & {
      userJid: string;
+diff --git a/lib/Types/Socket.d.ts b/lib/Types/Socket.d.ts
+index f9623cb6f91b9c9eedfedef730b6d88b319fe06a..7dbf0326c504e509e8620a4ea7442c67e2b77af4 100644
+--- a/lib/Types/Socket.d.ts
++++ b/lib/Types/Socket.d.ts
+@@ -122,7 +122,10 @@ export type SocketConfig = {
+         snapshot: boolean;
+     };
+     /** options for HTTP fetch requests */
+-    options: RequestInit;
++    options: RequestInit & {
++        /** deadline applied per request when the caller passes no `signal` */
++        timeoutMs?: number;
++    };
+     /**
+      * fetch a message from your store
+      * implement this so that messages failed to send
+diff --git a/lib/Utils/auth-utils.js b/lib/Utils/auth-utils.js
+index 24a358326a704e3f95b27ad996d2bc5e8ecfd101..f5a738f2b7d501ece18be53032540b0509bf0cc2 100644
+--- a/lib/Utils/auth-utils.js
++++ b/lib/Utils/auth-utils.js
+@@ -1,7 +1,7 @@
+ import NodeCache from '@cacheable/node-cache';
+ import { Boom } from '@hapi/boom';
+ import { AsyncLocalStorage } from 'async_hooks';
+-import { Mutex } from 'async-mutex';
++import { E_TIMEOUT, Mutex, withTimeout } from 'async-mutex';
+ import { randomBytes } from 'crypto';
+ import PQueue from 'p-queue';
+ import { DEFAULT_CACHE_TTLS } from '../Defaults/index.js';
+@@ -81,7 +81,7 @@ export function makeCacheableSignalKeyStore(store, logger, _cache) {
+  * @param logger logger to log events
+  * @returns SignalKeyStore with transaction capability
+  */
+-export const addTransactionCapability = (state, logger, { maxCommitRetries, delayBetweenTriesMs }) => {
++export const addTransactionCapability = (state, logger, { maxCommitRetries, delayBetweenTriesMs, acquireTimeoutMs = 0, holdWarnMs = 0, onTransactionEvent }) => {
+     const txStorage = new AsyncLocalStorage();
+     // Queues for concurrency control (keyed by signal data type - bounded set)
+     const keyQueues = new Map();
+@@ -236,10 +236,48 @@ export const addTransactionCapability = (state, logger, { maxCommitRetries, dela
+                 return work();
+             }
+             // New transaction - acquire mutex and create context
+-            const mutex = getTxMutex(key);
++            const rawMutex = getTxMutex(key);
+             acquireTxMutexRef(key);
++            // Captured out here, not inside runExclusive: once we are in the
++            // callback the async stack no longer names the caller, and naming
++            // the caller is the whole point of the stall diagnostic. Several
++            // operations share the key `meId`, so "who is holding it" is the
++            // one question the logs cannot otherwise answer.
++            const originStack = onTransactionEvent ? new Error('tx origin').stack : undefined;
++            const waitStartedAt = Date.now();
++            // Bounded ACQUISITION only, never a deadline on `work` itself:
++            // abandoning a transaction mid-flight would leave Signal ratchet
++            // state advanced in memory but uncommitted, which corrupts the
++            // session and costs a re-pair. A waiter that times out here never
++            // entered txStorage.run, so it touched no state at all.
++            const mutex = acquireTimeoutMs > 0 ? withTimeout(rawMutex, acquireTimeoutMs) : rawMutex;
+             try {
+                 return await mutex.runExclusive(async () => {
++                    const waitedMs = Date.now() - waitStartedAt;
++                    const heldStartedAt = Date.now();
++                    // A wedged holder never reaches any finally, so hold time
++                    // can only be observed from a timer armed on acquisition.
++                    // Re-arms with doubling so a six-hour stall logs a handful
++                    // of lines instead of hundreds.
++                    let stallTimer;
++                    const armStall = (delayMs) => {
++                        if (!(holdWarnMs > 0) || !onTransactionEvent) {
++                            return;
++                        }
++                        stallTimer = setTimeout(() => {
++                            onTransactionEvent({
++                                phase: 'stalled',
++                                key,
++                                waitedMs,
++                                heldMs: Date.now() - heldStartedAt,
++                                originStack
++                            });
++                            armStall(Math.min(delayMs * 2, 300000));
++                        }, delayMs);
++                        stallTimer.unref?.();
++                    };
++                    armStall(holdWarnMs);
++                    onTransactionEvent?.({ phase: 'acquired', key, waitedMs });
+                     const ctx = {
+                         cache: {},
+                         mutations: {},
+@@ -257,8 +295,37 @@ export const addTransactionCapability = (state, logger, { maxCommitRetries, dela
+                         logger.error({ error }, 'transaction failed, rolling back');
+                         throw error;
+                     }
++                    finally {
++                        clearTimeout(stallTimer);
++                        onTransactionEvent?.({
++                            phase: 'released',
++                            key,
++                            waitedMs,
++                            heldMs: Date.now() - heldStartedAt
++                        });
++                    }
+                 });
+             }
++            catch (error) {
++                if (error === E_TIMEOUT) {
++                    const waitedMs = Date.now() - waitStartedAt;
++                    onTransactionEvent?.({
++                        phase: 'timeout',
++                        key,
++                        waitedMs,
++                        originStack,
++                        stillLocked: rawMutex.isLocked()
++                    });
++                    // E_TIMEOUT is a module-level singleton Error in async-mutex:
++                    // no stack, no key, and mutable by whoever catches it. Always
++                    // wrap so the failure carries which key timed out.
++                    throw new Boom(`keystore transaction timed out acquiring lock for key=${key} after ${acquireTimeoutMs}ms`, {
++                        statusCode: 503,
++                        data: { key, acquireTimeoutMs, waitedMs, code: 'E_TX_MUTEX_TIMEOUT' }
++                    });
++                }
++                throw error;
++            }
+             finally {
+                 releaseTxMutexRef(key);
+             }
 diff --git a/lib/Utils/link-preview.js b/lib/Utils/link-preview.js
 index 0f4ff1ce169432faa8b0a7d2e2bca874c1d8092d..740c45d80b39355b4585e2af5f808aaf71e7be00 100644
 --- a/lib/Utils/link-preview.js
@@ -161,6 +311,31 @@ index 0f4ff1ce169432faa8b0a7d2e2bca874c1d8092d..740c45d80b39355b4585e2af5f808aaf
          if (info && 'title' in info && info.title) {
              const [image] = info.images;
              const urlInfo = {
+diff --git a/lib/Utils/messages-media.js b/lib/Utils/messages-media.js
+index a3d2fa6bae6af021a4a50b4270584fed08623f34..ea1e9ed9a4099e5609c0a483848f36a2bb6ec559 100644
+--- a/lib/Utils/messages-media.js
++++ b/lib/Utils/messages-media.js
+@@ -295,10 +295,19 @@ export async function generateThumbnail(file, mediaType, options) {
+     };
+ }
+ export const getHttpStream = async (url, options = {}) => {
++    // A parked TLS stream (headers sent, body never advances, no FIN) otherwise
++    // hangs this await forever. On the app-state path this runs inside the
++    // keystore transaction keyed by our own JID, so one stuck download wedges
++    // every send on the connection with no error, no log and no close -- the
++    // silent send stall. `timeoutMs` comes from the socket's `options` config,
++    // so the deadline stays policy-in-app and this patch stays mechanism-only.
++    const signal = options.signal ??
++        (options.timeoutMs ? AbortSignal.timeout(options.timeoutMs) : undefined);
+     const response = await fetch(url.toString(), {
+         dispatcher: options.dispatcher,
+         method: 'GET',
+-        headers: options.headers
++        headers: options.headers,
++        signal
+     });
+     if (!response.ok) {
+         throw new Boom(`Failed to fetch stream from ${url}`, { statusCode: response.status, data: { url } });
 diff --git a/lib/Utils/messages.js b/lib/Utils/messages.js
 index 247b1f12d912923d4ad032e6572fc76cd958e51b..284bb717c9f34a8580d1d14f1a4014df2e8a9aff 100644
 --- a/lib/Utils/messages.js

--- a/src/baileys/authTransactionTimeout.spec.ts
+++ b/src/baileys/authTransactionTimeout.spec.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+// Deep specifier on purpose. The preload mocks "@whiskeysockets/baileys", so
+// importing the package would hand us the fake socket and never exercise the
+// patch. The package has no "exports" map, so this path resolves the real,
+// patched file — which is the only way these tests mean anything.
+import { addTransactionCapability } from "@whiskeysockets/baileys/lib/Utils/auth-utils.js";
+
+const PATCHED_FILE =
+  "node_modules/@whiskeysockets/baileys/lib/Utils/auth-utils.js";
+
+const silentLogger = {
+  level: "silent",
+  trace: () => {},
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  child: () => silentLogger,
+} as unknown as Parameters<typeof addTransactionCapability>[1];
+
+function makeStore() {
+  const sets: unknown[] = [];
+  return {
+    sets,
+    store: {
+      get: async () => ({}),
+      set: async (data: unknown) => {
+        sets.push(data);
+      },
+      clear: async () => {},
+    },
+  };
+}
+
+function makeKeys(opts: Record<string, unknown> = {}) {
+  const { store, sets } = makeStore();
+  const keys = addTransactionCapability(store, silentLogger, {
+    maxCommitRetries: 1,
+    delayBetweenTriesMs: 1,
+    ...opts,
+  });
+  return { keys, sets };
+}
+
+const ME = "5511999999999:1@s.whatsapp.net";
+const BYTES = new Uint8Array([1, 2, 3]);
+
+describe("addTransactionCapability patch", () => {
+  // The number one failure mode of a patch-based fix is the patch silently not
+  // applying after a dependency bump or a lockfile change. Everything else here
+  // would still pass against stale-but-loaded code, so check the file on disk.
+  it("is actually present in the installed package", () => {
+    const source = readFileSync(PATCHED_FILE, "utf8");
+    expect(source).toContain("E_TX_MUTEX_TIMEOUT");
+    expect(source).toContain("withTimeout");
+  });
+
+  it("behaves exactly like upstream when the timeout is disabled", async () => {
+    const { keys, sets } = makeKeys({ acquireTimeoutMs: 0 });
+
+    await keys.transaction(async () => {
+      await keys.set({ session: { a: BYTES } });
+    }, ME);
+    await keys.transaction(async () => {
+      await keys.set({ session: { b: BYTES } });
+    }, ME);
+
+    expect(sets).toEqual([
+      { session: { a: BYTES } },
+      { session: { b: BYTES } },
+    ]);
+  });
+
+  // Reproduces the production failure in milliseconds: a holder that never
+  // returns. Before the patch this second transaction waited forever, with no
+  // error, no log and no close — the silent send stall.
+  it("rejects a waiter when the holder never returns", async () => {
+    const { keys } = makeKeys({ acquireTimeoutMs: 50 });
+
+    // Deliberately not awaited: this is the wedged holder.
+    void keys.transaction(() => new Promise<never>(() => {}), ME);
+    await new Promise((resolve) => setTimeout(resolve, 5));
+
+    await expect(keys.transaction(async () => "second", ME)).rejects.toThrow(
+      /E_TX_MUTEX_TIMEOUT|timed out acquiring lock/,
+    );
+  });
+
+  it("carries the key on the timeout error", async () => {
+    const { keys } = makeKeys({ acquireTimeoutMs: 50 });
+    void keys.transaction(() => new Promise<never>(() => {}), ME);
+    await new Promise((resolve) => setTimeout(resolve, 5));
+
+    let caught: { data?: Record<string, unknown> } | undefined;
+    try {
+      await keys.transaction(async () => "second", ME);
+    } catch (e) {
+      caught = e as { data?: Record<string, unknown> };
+    }
+
+    expect(caught?.data?.key).toBe(ME);
+    expect(caught?.data?.code).toBe("E_TX_MUTEX_TIMEOUT");
+  });
+
+  // The safety property the whole design rests on: bounding ACQUISITION means
+  // a timed-out waiter never entered the transaction, so it read nothing, wrote
+  // nothing and committed nothing. A deadline on the work itself would instead
+  // abandon it mid-flight and could leave Signal state half-committed.
+  it("leaves no trace of the transaction that timed out", async () => {
+    const { keys, sets } = makeKeys({ acquireTimeoutMs: 50 });
+    void keys.transaction(() => new Promise<never>(() => {}), ME);
+    await new Promise((resolve) => setTimeout(resolve, 5));
+
+    let ran = false;
+    await keys
+      .transaction(async () => {
+        ran = true;
+        await keys.set({ session: { never: BYTES } });
+      }, ME)
+      .catch(() => {});
+
+    expect(ran).toBe(false);
+    expect(sets).toEqual([]);
+  });
+
+  // Guards the `existing` short-circuit: a nested transaction reuses the
+  // context and must NOT try to take the mutex its own parent is holding.
+  it("does not time out a nested transaction on the same key", async () => {
+    const { keys } = makeKeys({ acquireTimeoutMs: 50 });
+
+    const result = await keys.transaction(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 80));
+      return keys.transaction(async () => "inner", ME);
+    }, ME);
+
+    expect(result).toBe("inner");
+  });
+
+  // A timeout must not poison the mutex: the waiter's abandoned acquire is
+  // released as soon as it resolves, so later transactions still work.
+  it("recovers once the holder finally releases", async () => {
+    const { keys } = makeKeys({ acquireTimeoutMs: 50 });
+
+    let release: () => void = () => {};
+    void keys.transaction(
+      () => new Promise<void>((resolve) => (release = resolve)),
+      ME,
+    );
+    await new Promise((resolve) => setTimeout(resolve, 5));
+
+    await expect(keys.transaction(async () => "a", ME)).rejects.toThrow();
+    release();
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    await expect(keys.transaction(async () => "b", ME)).resolves.toBe("b");
+  });
+
+  // A wedged holder never reaches any finally, so hold time is only observable
+  // from a timer armed at acquisition. This report — with the origin stack — is
+  // what names the culprit among the operations sharing the `meId` key.
+  it("reports a holder that keeps the mutex, with its origin stack", async () => {
+    const events: { phase: string; key: string; originStack?: string }[] = [];
+    const { keys } = makeKeys({
+      acquireTimeoutMs: 0,
+      holdWarnMs: 20,
+      onTransactionEvent: (event: (typeof events)[number]) =>
+        events.push(event),
+    });
+
+    void keys.transaction(() => new Promise<never>(() => {}), ME);
+    await new Promise((resolve) => setTimeout(resolve, 60));
+
+    const stalled = events.filter((event) => event.phase === "stalled");
+    expect(stalled.length).toBeGreaterThan(0);
+    expect(stalled[0]?.key).toBe(ME);
+    expect(stalled[0]?.originStack).toContain("auth-utils");
+  });
+
+  it("does not report a stall for a transaction that finishes promptly", async () => {
+    const events: { phase: string }[] = [];
+    const { keys } = makeKeys({
+      holdWarnMs: 50,
+      onTransactionEvent: (event: (typeof events)[number]) =>
+        events.push(event),
+    });
+
+    await keys.transaction(async () => "quick", ME);
+    await new Promise((resolve) => setTimeout(resolve, 80));
+
+    expect(events.some((event) => event.phase === "stalled")).toBe(false);
+    expect(events.map((event) => event.phase)).toEqual([
+      "acquired",
+      "released",
+    ]);
+  });
+
+  it("does not leave an unhandled rejection behind", async () => {
+    const unhandled: unknown[] = [];
+    const onUnhandled = (reason: unknown) => unhandled.push(reason);
+    process.on("unhandledRejection", onUnhandled);
+
+    try {
+      const { keys } = makeKeys({ acquireTimeoutMs: 30 });
+      void keys.transaction(() => new Promise<never>(() => {}), ME);
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      await keys.transaction(async () => "x", ME).catch(() => {});
+      await new Promise((resolve) => setTimeout(resolve, 60));
+
+      expect(unhandled).toEqual([]);
+    } finally {
+      process.off("unhandledRejection", onUnhandled);
+    }
+  });
+});

--- a/src/baileys/connection.spec.ts
+++ b/src/baileys/connection.spec.ts
@@ -1009,6 +1009,42 @@ describe("BaileysConnection", () => {
     });
   });
 
+  describe("#connect failure", () => {
+    // Reconnects are fire-and-forget, and connect() now rejects when it cannot
+    // build a socket at all. An unhandled rejection is fatal in Bun, so one
+    // failed reconnect would take the worker down and every other connection
+    // with it. Aborting rather than only logging, because a connection left
+    // registered with no socket is the dark phone this change exists to end.
+    it("aborts instead of crashing when a reconnect cannot rebuild", async () => {
+      const closes: string[] = [];
+      connection = new BaileysConnection("+5511999999999", {
+        ...defaultOptions,
+        onConnectionClose: () => closes.push("closed"),
+      });
+      await connection.connect();
+
+      const baileysMod = (await import("@whiskeysockets/baileys")) as any;
+      const makeSocket = baileysMod.default as ReturnType<typeof mock>;
+      makeSocket.mockImplementationOnce(() => {
+        throw new Error("no socket for you");
+      });
+
+      await mockEventHandlers.get("connection.update")?.({
+        connection: "close" as const,
+        lastDisconnect: {
+          error: { output: { statusCode: 500, payload: {} }, message: "x" },
+        },
+      });
+
+      for (let i = 0; i < 50 && closes.length === 0; i += 1) {
+        await new Promise((resolve) => setTimeout(resolve, 5));
+      }
+
+      expect(closes.length).toBeGreaterThan(0);
+      expect(connection.isOpen).toBe(false);
+    });
+  });
+
   describe("#sendMessage", () => {
     it("throws BaileysNotConnectedError if not connected", async () => {
       await expect(

--- a/src/baileys/connection.spec.ts
+++ b/src/baileys/connection.spec.ts
@@ -6,6 +6,7 @@ import {
   it,
   mock,
   setSystemTime,
+  spyOn,
 } from "bun:test";
 
 // Track fetch calls for webhook tests
@@ -14,6 +15,7 @@ const originalFetch = globalThis.fetch;
 
 import * as baileysModule from "@whiskeysockets/baileys";
 import { clusterKeys } from "@/cluster/keys";
+import * as sendStallStore from "@/cluster/sendStallStore";
 import config from "@/config";
 import { asyncSleep } from "@/helpers/asyncSleep";
 import { OperationTimeoutError } from "@/helpers/withTimeout";
@@ -1399,6 +1401,54 @@ describe("BaileysConnection", () => {
 
       setSystemTime();
       await redis.del(clusterKeys.sendStall("+5511999999999"));
+    });
+
+    // maybeReportSendStall raises the silence to Infinity before launching the
+    // async verdict, so anything that returns without lowering it mutes the
+    // connection for the life of the socket: the breaker rejects every later send
+    // without touching the socket, so nothing else would ever bring it back up for
+    // review, and the restart it needed is never requested.
+    it("re-arms the episode when the backoff lookup fails", async () => {
+      connection = new BaileysConnection("+5511999999999", {
+        ...defaultOptions,
+        requestRestart: () => {},
+      });
+      config.baileys.sendStallRestartEnabled = true;
+      const canRestart = spyOn(sendStallStore, "canRestart").mockRejectedValue(
+        new Error("redis down"),
+      );
+      const start = Date.now();
+
+      try {
+        await connection.connect();
+        wedge();
+
+        await expect(send()).rejects.toThrow(OperationTimeoutError);
+        await expect(send()).rejects.toThrow(OperationTimeoutError);
+        setSystemTime(new Date(start + 120_000));
+        await expect(send()).rejects.toThrow(OperationTimeoutError);
+        await asyncSleep(0);
+
+        const stallCalls = () =>
+          fetchCalls.filter((call) => call.body.includes("send_stall_detected"))
+            .length;
+        expect(stallCalls()).toBe(1);
+
+        // Inside the cooldown the failure does not become a webhook per send.
+        setSystemTime(new Date(start + 130_000));
+        await expect(send()).rejects.toThrow(BaileysSendStalledError);
+        await asyncSleep(0);
+        expect(stallCalls()).toBe(1);
+
+        // Past it, the connection is due for review again.
+        setSystemTime(new Date(start + 200_000));
+        await expect(send()).rejects.toThrow(BaileysSendStalledError);
+        await asyncSleep(0);
+        expect(stallCalls()).toBe(2);
+      } finally {
+        canRestart.mockRestore();
+        setSystemTime();
+      }
     });
 
     // The one that made the watchdog defeat itself in production. `isOnline` is

--- a/src/baileys/connection.spec.ts
+++ b/src/baileys/connection.spec.ts
@@ -13,6 +13,7 @@ const fetchCalls: Array<{ url: string; body: string }> = [];
 const originalFetch = globalThis.fetch;
 
 import * as baileysModule from "@whiskeysockets/baileys";
+import { clusterKeys } from "@/cluster/keys";
 import config from "@/config";
 import { asyncSleep } from "@/helpers/asyncSleep";
 import { OperationTimeoutError } from "@/helpers/withTimeout";
@@ -1320,6 +1321,64 @@ describe("BaileysConnection", () => {
         key: { id: "msg-id" },
       }));
       await expect(send()).resolves.toBeDefined();
+    });
+
+    // The backoff branch advertises an `until` to the client. Staying silent past
+    // it would make that timestamp a lie: the breaker rejects every send without
+    // touching the socket, so nothing else brings the connection back up for
+    // review and it would sit muted for the life of the socket.
+    it("reconsiders the episode once the advertised backoff expires", async () => {
+      connection = new BaileysConnection("+5511999999999", {
+        ...defaultOptions,
+        requestRestart: () => {},
+      });
+      config.baileys.sendStallRestartEnabled = true;
+      const start = Date.now();
+      // Already backed off: a restart is not allowed until start + 300s.
+      await redis.set(
+        clusterKeys.sendStall("+5511999999999"),
+        JSON.stringify({
+          restarts: 1,
+          nextRestartAllowedAt: start + 300_000,
+        }),
+      );
+      await connection.connect();
+      wedge();
+
+      await expect(send()).rejects.toThrow(OperationTimeoutError);
+      await expect(send()).rejects.toThrow(OperationTimeoutError);
+      setSystemTime(new Date(start + 120_000));
+      await expect(send()).rejects.toThrow(OperationTimeoutError);
+      await asyncSleep(0);
+
+      const first = fetchCalls.filter((call) =>
+        call.body.includes("send_stall_detected"),
+      );
+      expect(first.length).toBe(1);
+      expect(JSON.parse(first[0]?.body ?? "{}").data.sendStall.action).toBe(
+        "suppressed",
+      );
+
+      // Still inside the advertised window: nothing new to say.
+      setSystemTime(new Date(start + 200_000));
+      await expect(send()).rejects.toThrow(BaileysSendStalledError);
+      await asyncSleep(0);
+      expect(
+        fetchCalls.filter((call) => call.body.includes("send_stall_detected"))
+          .length,
+      ).toBe(1);
+
+      // Past it: the connection is due for review again.
+      setSystemTime(new Date(start + 400_000));
+      await expect(send()).rejects.toThrow(BaileysSendStalledError);
+      await asyncSleep(0);
+      expect(
+        fetchCalls.filter((call) => call.body.includes("send_stall_detected"))
+          .length,
+      ).toBe(2);
+
+      setSystemTime();
+      await redis.del(clusterKeys.sendStall("+5511999999999"));
     });
 
     it("reports sendState unknown until a send has actually been observed", async () => {

--- a/src/baileys/connection.spec.ts
+++ b/src/baileys/connection.spec.ts
@@ -1382,6 +1382,99 @@ describe("BaileysConnection", () => {
       expect(connection.sendState).not.toBe("stalled");
     });
 
+    // The holder can let go between the acquisition giving up and the Boom
+    // reaching the breaker. handleTxEvent sees that release while nothing is
+    // armed yet and rightly ignores it -- and it is the only one that key will
+    // ever emit, so arming afterwards waits for a second release that never
+    // comes. With automatic restart off, that is 503 for the life of a socket
+    // whose mutex is free: the round 16 latch, through a narrower door.
+    it("does not arm on a key that released while its timeout propagated", async () => {
+      await connectOpen();
+      const baileysModule = (await import("@whiskeysockets/baileys")) as any;
+      const makeSocket = baileysModule.default as ReturnType<typeof mock>;
+      const emit = (event: Record<string, unknown>) =>
+        makeSocket.mock.calls
+          .at(-1)![0]
+          .transactionOpts.onTransactionEvent(event);
+      const wedgeError = () =>
+        Promise.reject(
+          Object.assign(new Error("keystore transaction timed out"), {
+            data: { key: "me@s.whatsapp.net", code: "E_TX_MUTEX_TIMEOUT" },
+          }),
+        );
+
+      // Once, and only once: the patch emits `timeout` and throws in the same
+      // breath, and the holder's release lands while that Boom is still
+      // travelling up the send path. That release is the only one this key will
+      // ever emit -- the holder is gone.
+      mockSocket.sendMessage.mockImplementationOnce(() => {
+        emit({ phase: "timeout", key: "me@s.whatsapp.net", waitedMs: 90_000 });
+        emit({
+          phase: "released",
+          key: "me@s.whatsapp.net",
+          waitedMs: 0,
+          heldMs: 90_001,
+        });
+        return wedgeError();
+      });
+      mockSocket.sendMessage.mockImplementation(wedgeError);
+
+      await expect(send()).rejects.toThrow("keystore transaction timed out");
+      await expect(send()).rejects.toThrow("keystore transaction timed out");
+      await expect(send()).rejects.toThrow("keystore transaction timed out");
+
+      // That first failure did not count towards a wedge, because the wedge had
+      // already cleared. Two strikes, not three, so the socket is still reachable.
+      mockSocket.sendMessage.mockClear();
+      await expect(send()).rejects.toThrow("keystore transaction timed out");
+      expect(mockSocket.sendMessage).toHaveBeenCalled();
+    });
+
+    // The audio work can await for the whole preprocessing budget, and a
+    // reconnect inside that window clears the id history with the socket that
+    // owned it. The send then leaves on the replacement carrying a reserved id
+    // the history no longer holds, so every ack for it is rejected as not ours
+    // and lastOutgoingAckAt -- the only evidence that does not come from us --
+    // stays null for a send that went through perfectly.
+    it("re-registers a reserved id when the socket changed during preprocessing", async () => {
+      await connectOpen();
+      const baileysModule = (await import("@whiskeysockets/baileys")) as any;
+      const makeSocket = baileysModule.default as ReturnType<typeof mock>;
+
+      const preprocess = preprocessAudio as unknown as ReturnType<typeof mock>;
+      const reconnectDuringPreprocessing = async () => {
+        await mockEventHandlers.get("connection.update")!({
+          connection: "close" as const,
+          lastDisconnect: {
+            error: { output: { statusCode: 500, payload: {} }, message: "x" },
+          },
+        });
+        let stable = -1;
+        while (stable !== makeSocket.mock.calls.length) {
+          stable = makeSocket.mock.calls.length;
+          await new Promise((r) => setImmediate(r));
+        }
+        await mockEventHandlers.get("connection.update")?.({
+          connection: "open",
+        });
+        return Buffer.from("converted");
+      };
+      preprocess.mockImplementationOnce(reconnectDuringPreprocessing);
+      preprocess.mockImplementationOnce(async () => Buffer.from("wav"));
+
+      await connection.sendMessage(
+        "jid@s.whatsapp.net",
+        { audio: Buffer.from("audio"), ptt: true } as never,
+        { messageId: "3EB0RESERVED" },
+      );
+
+      mockEventHandlers.get("messages.update")?.([
+        { key: { fromMe: true, id: "3EB0RESERVED" }, update: { status: 2 } },
+      ]);
+
+      expect(connection.lastOutgoingAckAt).not.toBeNull();
+    });
+
     // The mirror of the reconnect finding: maybeReportSendStall already refuses to
     // call this a stall while the socket is not open, and the REFUSAL has to agree.
     // The stall-specific 503 tells the caller the connection is up and must not be

--- a/src/baileys/connection.spec.ts
+++ b/src/baileys/connection.spec.ts
@@ -1133,6 +1133,7 @@ describe("BaileysConnection", () => {
 
     afterEach(() => {
       config.baileys.sendTimeoutMs = 45_000;
+      config.baileys.audioPreprocessTimeoutMs = 20_000;
       config.baileys.sendStallRestartEnabled = false;
       mockSocket.sendMessage.mockImplementation(async () => ({
         key: { id: "msg-id" },
@@ -1229,6 +1230,38 @@ describe("BaileysConnection", () => {
       await expect(send()).rejects.toThrow(BaileysSendStalledError);
 
       expect(mockSocket.sendMessage.mock.calls.length).toBe(3);
+    });
+
+    // The audio work is deliberately OUTSIDE the send deadline: ffmpeg is local
+    // and legitimately slow, so charging it to the send budget would open the
+    // breaker and recreate a socket that refused nothing. But it runs BEFORE that
+    // deadline is armed, so leaving it unbounded defeats the guarantee
+    // sendTimeoutMs < PROXY_REQUEST_TIMEOUT_MS exists to give: the proxy cuts
+    // first, answers its own generic 504, and the worker never reaches the code
+    // that releases the idempotency lock or counts the stall.
+    it("bounds the audio preprocessing that precedes the send deadline", async () => {
+      await connectOpen();
+      config.baileys.audioPreprocessTimeoutMs = 10;
+      // mockImplementationOnce, twice (a PTT runs two jobs), so nothing leaks into
+      // the spec that exercises the real preprocessAudio.
+      const preprocess = preprocessAudio as unknown as ReturnType<typeof mock>;
+      preprocess.mockImplementationOnce(() => new Promise(() => {}));
+      preprocess.mockImplementationOnce(() => new Promise(() => {}));
+
+      // Raced rather than awaited: without the deadline this send never settles,
+      // and a hung example is a worse CI failure than a failed assertion.
+      const outcome = await Promise.race([
+        connection
+          .sendMessage("jid@s.whatsapp.net", {
+            audio: Buffer.from("audio"),
+            ptt: true,
+          } as never)
+          .then(() => "sent"),
+        new Promise((resolve) => setTimeout(() => resolve("hung"), 500)),
+      ]);
+
+      expect(outcome).toBe("sent");
+      expect(mockSocket.sendMessage).toHaveBeenCalled();
     });
 
     // preprocessAudio runs up to two ffmpeg jobs for a PTT. A caller retrying into

--- a/src/baileys/connection.spec.ts
+++ b/src/baileys/connection.spec.ts
@@ -1913,6 +1913,53 @@ describe("BaileysConnection", () => {
       }
     });
 
+    // `action` is documented as whether the socket was recreated, and everything
+    // after the decision can still call the restart off. Announcing "restart" up
+    // front tells a consumer recovery is underway when it may never start.
+    it("does not announce a restart it has not committed to", async () => {
+      const restarts: string[] = [];
+      connection = new BaileysConnection("+5511999999999", {
+        ...defaultOptions,
+        requestRestart: (reason: string) => restarts.push(reason),
+      });
+      config.baileys.sendStallRestartEnabled = true;
+      await connectOpen();
+      wedge();
+
+      const key = clusterKeys.sendStall("+5511999999999");
+      const setMock = redis.set as unknown as ReturnType<typeof mock>;
+      setMock.mockImplementationOnce(async (k: string, v: string) => {
+        // Recovery lands while the strike is being written.
+        await mockEventHandlers.get("connection.update")?.({
+          connection: "open",
+        });
+        (
+          redis as unknown as { __stringData: Map<string, string> }
+        ).__stringData.set(k, v);
+        return "OK";
+      });
+
+      try {
+        const start = Date.now();
+        await expect(send()).rejects.toThrow(OperationTimeoutError);
+        await expect(send()).rejects.toThrow(OperationTimeoutError);
+        setSystemTime(new Date(start + 120_000));
+        await expect(send()).rejects.toThrow(OperationTimeoutError);
+        await asyncSleep(0);
+
+        expect(restarts.length).toBe(0);
+        // Nothing was announced either: no restart happened, and the episode was
+        // never suppressed by a backoff, so there is no verdict to report.
+        expect(
+          fetchCalls.filter((call) => call.body.includes("send_stall_detected"))
+            .length,
+        ).toBe(0);
+      } finally {
+        setSystemTime();
+        await redis.del(key);
+      }
+    });
+
     // Without this, the breaker stays open across an in-place reconnect (the
     // connection object survives a socket drop) and the connection answers 503
     // forever — worse than the original stall, which at least cleared itself

--- a/src/baileys/connection.spec.ts
+++ b/src/baileys/connection.spec.ts
@@ -1115,6 +1115,16 @@ describe("BaileysConnection", () => {
       );
     const send = () =>
       connection.sendMessage("jid@s.whatsapp.net", { text: "hi" });
+    // A stall is a claim about a socket that is UP: during a first connect or a
+    // slow reconnect the socket object exists while the handshake is still
+    // running, and sends timing out in that window are an ordinary outage. The
+    // watchdog now requires the open, so these examples have to reach it.
+    const connectOpen = async () => {
+      await connection.connect();
+      await mockEventHandlers.get("connection.update")?.({
+        connection: "open",
+      });
+    };
 
     beforeEach(() => {
       config.baileys.sendTimeoutMs = 10;
@@ -1136,7 +1146,7 @@ describe("BaileysConnection", () => {
     });
 
     it("fails a send that never completes instead of hanging forever", async () => {
-      await connection.connect();
+      await connectOpen();
       wedge();
       await expect(send()).rejects.toThrow(OperationTimeoutError);
     });
@@ -1146,7 +1156,7 @@ describe("BaileysConnection", () => {
     // releases while the socket is still open they all fire at once — a burst
     // of duplicate messages to real customers, hours late.
     it("stops touching the socket once the connection is known stalled", async () => {
-      await connection.connect();
+      await connectOpen();
       wedge();
       mockSocket.sendMessage.mockClear();
 
@@ -1163,7 +1173,7 @@ describe("BaileysConnection", () => {
     // a stalled connection would burn that CPU on every attempt only to be told 503
     // at the end, which is not what "fails immediately" means.
     it("refuses a stalled send before spending ffmpeg on it", async () => {
-      await connection.connect();
+      await connectOpen();
       wedge();
       await expect(send()).rejects.toThrow(OperationTimeoutError);
       await expect(send()).rejects.toThrow(OperationTimeoutError);
@@ -1188,7 +1198,7 @@ describe("BaileysConnection", () => {
     // The failure is total: one success proves the mutex is free, so the
     // counter has to reset rather than accumulate across unrelated hiccups.
     it("resets the streak after a send succeeds", async () => {
-      await connection.connect();
+      await connectOpen();
       wedge();
       await expect(send()).rejects.toThrow(OperationTimeoutError);
       await expect(send()).rejects.toThrow(OperationTimeoutError);
@@ -1207,7 +1217,7 @@ describe("BaileysConnection", () => {
     // a bare "three in a row" rule would let one short hiccup recreate a
     // perfectly healthy socket.
     it("does not report a stall until the streak has lasted long enough", async () => {
-      await connection.connect();
+      await connectOpen();
       wedge();
       fetchCalls.length = 0;
 
@@ -1225,7 +1235,7 @@ describe("BaileysConnection", () => {
     // evaluated on a fresh timeout, three concurrent sends would disarm the
     // watchdog for the life of the socket: 503 forever, no webhook, no restart.
     it("still reports the stall once the latched streak ages past the minimum", async () => {
-      await connection.connect();
+      await connectOpen();
       wedge();
       const start = Date.now();
 
@@ -1247,7 +1257,7 @@ describe("BaileysConnection", () => {
     // The breaker rejects for as long as the socket lives, so an unguarded
     // re-evaluation would emit one webhook per rejected send.
     it("reports the stall once per episode, not once per rejected send", async () => {
-      await connection.connect();
+      await connectOpen();
       wedge();
       const start = Date.now();
 
@@ -1270,7 +1280,7 @@ describe("BaileysConnection", () => {
     });
 
     it("emits send_stall_detected once the streak is long enough", async () => {
-      await connection.connect();
+      await connectOpen();
       wedge();
       const start = Date.now();
 
@@ -1306,7 +1316,7 @@ describe("BaileysConnection", () => {
       (
         BaileysConnection as unknown as { lastStallRestartAt: number }
       ).lastStallRestartAt = performance.now();
-      await connection.connect();
+      await connectOpen();
       wedge();
       const start = Date.now();
 
@@ -1340,7 +1350,7 @@ describe("BaileysConnection", () => {
         requestRestart: (reason: string) => restarts.push(reason),
       });
       config.baileys.sendStallRestartEnabled = true;
-      await connection.connect();
+      await connectOpen();
       wedge();
       const start = Date.now();
 
@@ -1352,7 +1362,17 @@ describe("BaileysConnection", () => {
 
       expect(restarts.length).toBe(1);
       expect(restarts[0]).toContain("send stall");
+      // The strike lands only once the restart has actually been asked for. The
+      // ordering is what guarantees "a strike implies a restart"; this pins the
+      // committed half of it, since with the recording moved after the final gate
+      // there is no longer an await in that span for a cancellation to slip into.
+      expect(
+        JSON.parse(
+          (await redis.get(clusterKeys.sendStall("+5511999999999"))) ?? "{}",
+        ).restarts,
+      ).toBe(1);
       setSystemTime();
+      await redis.del(clusterKeys.sendStall("+5511999999999"));
     });
 
     // Without this, the breaker stays open across an in-place reconnect (the
@@ -1360,7 +1380,7 @@ describe("BaileysConnection", () => {
     // forever — worse than the original stall, which at least cleared itself
     // when WhatsApp dropped the socket.
     it("reopens the circuit when the connection opens again", async () => {
-      await connection.connect();
+      await connectOpen();
       wedge();
       await expect(send()).rejects.toThrow(OperationTimeoutError);
       await expect(send()).rejects.toThrow(OperationTimeoutError);
@@ -1384,7 +1404,7 @@ describe("BaileysConnection", () => {
     // rejecting, no send reaches the socket, so the success that would close it
     // can never happen and the connection answers 503 until it reconnects.
     it("reopens the circuit when an abandoned send finally completes", async () => {
-      await connection.connect();
+      await connectOpen();
       let release: ((value: { key: { id: string } }) => void) | undefined;
       mockSocket.sendMessage.mockImplementation(
         () =>
@@ -1429,7 +1449,7 @@ describe("BaileysConnection", () => {
           nextRestartAllowedAt: start + 300_000,
         }),
       );
-      await connection.connect();
+      await connectOpen();
       wedge();
 
       await expect(send()).rejects.toThrow(OperationTimeoutError);
@@ -1489,7 +1509,7 @@ describe("BaileysConnection", () => {
       const start = Date.now();
 
       try {
-        await connection.connect();
+        await connectOpen();
         wedge();
 
         await expect(send()).rejects.toThrow(OperationTimeoutError);
@@ -1520,6 +1540,36 @@ describe("BaileysConnection", () => {
       }
     });
 
+    // A socket still handshaking is not a wedged one. Sends that time out while a
+    // first connect or a slow reconnect is in flight are an ordinary outage, and
+    // tearing the socket down for them would do it again on the replacement.
+    it("does not call a still-connecting socket stalled", async () => {
+      config.baileys.sendStallRestartEnabled = true;
+      const restarts: string[] = [];
+      connection = new BaileysConnection("+5511999999999", {
+        ...defaultOptions,
+        requestRestart: (reason: string) => restarts.push(reason),
+      });
+      await connection.connect();
+      // No `connection: "open"` — the socket object exists, the handshake does not.
+      wedge();
+      fetchCalls.length = 0;
+      const start = Date.now();
+
+      await expect(send()).rejects.toThrow(OperationTimeoutError);
+      await expect(send()).rejects.toThrow(OperationTimeoutError);
+      setSystemTime(new Date(start + 120_000));
+      await expect(send()).rejects.toThrow(OperationTimeoutError);
+      await asyncSleep(0);
+
+      expect(
+        fetchCalls.filter((call) => call.body.includes("send_stall_detected"))
+          .length,
+      ).toBe(0);
+      expect(restarts.length).toBe(0);
+      setSystemTime();
+    });
+
     // Every await inside handleSendStall is a window in which WhatsApp can drop and
     // remake the socket on its own. The replacement gets a fresh keystore and clears
     // the breaker, so acting on the verdict afterwards means reporting a stall on a
@@ -1546,7 +1596,7 @@ describe("BaileysConnection", () => {
       const start = Date.now();
 
       try {
-        await connection.connect();
+        await connectOpen();
         wedge();
         fetchCalls.length = 0;
 
@@ -1575,7 +1625,7 @@ describe("BaileysConnection", () => {
     // breaker on a timer, and every reset lets another batch of sends queue
     // behind the same stuck mutex.
     it("does not reopen the circuit for a presence echo on the same socket", async () => {
-      await connection.connect();
+      await connectOpen();
       wedge();
       await expect(send()).rejects.toThrow(OperationTimeoutError);
       await expect(send()).rejects.toThrow(OperationTimeoutError);
@@ -1594,7 +1644,7 @@ describe("BaileysConnection", () => {
     // them expiring after the swap open the breaker on a replacement that never
     // refused a send.
     it("ignores timeouts left over from a socket that has been replaced", async () => {
-      await connection.connect();
+      await connectOpen();
       wedge();
 
       // Three sends parked on the socket that is about to be thrown away.
@@ -1637,7 +1687,7 @@ describe("BaileysConnection", () => {
     // connection where nothing is parked at all, and every later plain-text
     // send answers 503 until the socket is recreated.
     it("reopens the circuit when an abandoned send finally fails", async () => {
-      await connection.connect();
+      await connectOpen();
       let reject: ((error: unknown) => void) | undefined;
       mockSocket.sendMessage.mockImplementation(
         () =>
@@ -1673,7 +1723,7 @@ describe("BaileysConnection", () => {
     // Closing the breaker on it sends the next batch straight back into the
     // queue the breaker exists to keep bounded.
     it("keeps the circuit open when an abandoned send fails on the transaction mutex", async () => {
-      await connection.connect();
+      await connectOpen();
       let reject: ((error: unknown) => void) | undefined;
       mockSocket.sendMessage.mockImplementation(
         () =>
@@ -1698,7 +1748,7 @@ describe("BaileysConnection", () => {
     });
 
     it("reports sendState unknown until a send has actually been observed", async () => {
-      await connection.connect();
+      await connectOpen();
       expect(connection.sendState).toBe("unknown");
     });
 
@@ -1706,7 +1756,7 @@ describe("BaileysConnection", () => {
     // sending is dead. Only WhatsApp acknowledging one of OUR messages proves
     // the send path end to end.
     it("records an outgoing ack from messages.update", async () => {
-      await connection.connect();
+      await connectOpen();
       expect(connection.lastOutgoingAckAt).toBeNull();
 
       await connection.sendMessage(
@@ -1725,7 +1775,7 @@ describe("BaileysConnection", () => {
     // messages.update. Without this a connection that only writes to groups sits
     // at `unknown` forever no matter how many recipients confirmed.
     it("records an outgoing ack from a group receipt", async () => {
-      await connection.connect();
+      await connectOpen();
       await connection.sendMessage(
         "group@g.us",
         { text: "hi" },
@@ -1747,7 +1797,7 @@ describe("BaileysConnection", () => {
     // message the PREVIOUS socket sent would otherwise present end-to-end evidence
     // about a replacement that has sent nothing and may itself be wedged.
     it("stops honouring acks for ids the replaced socket submitted", async () => {
-      await connection.connect();
+      await connectOpen();
       await connection.sendMessage(
         "jid@s.whatsapp.net",
         { text: "hi" },
@@ -1758,7 +1808,7 @@ describe("BaileysConnection", () => {
       // the replacement through the real connect(), which is what bumps the
       // generation and clears the history.
       (connection as unknown as { socket: unknown }).socket = null;
-      await connection.connect();
+      await connectOpen();
 
       mockEventHandlers.get("messages.update")?.([
         { key: { fromMe: true, id: "3EB0OLDSOCKET" }, update: { status: 2 } },
@@ -1783,12 +1833,12 @@ describe("BaileysConnection", () => {
     // that has never sent anything would inherit the previous socket's health
     // report and hold it indefinitely — including one that is itself wedged.
     it("stops reporting healthy on the replaced socket's evidence", async () => {
-      await connection.connect();
+      await connectOpen();
       await connection.sendMessage("jid@s.whatsapp.net", { text: "hi" });
       expect(connection.sendState).toBe("ok");
 
       (connection as unknown as { socket: unknown }).socket = null;
-      await connection.connect();
+      await connectOpen();
 
       expect(connection.lastSendCompletedAt).toBeNull();
       expect(connection.lastOutgoingAckAt).toBeNull();
@@ -1801,7 +1851,7 @@ describe("BaileysConnection", () => {
     // connection reporting `ok`, which is the exact blindness this signal exists
     // to remove.
     it("ignores an ack for a message this socket never sent", async () => {
-      await connection.connect();
+      await connectOpen();
 
       mockEventHandlers.get("messages.update")?.([
         {
@@ -1815,7 +1865,7 @@ describe("BaileysConnection", () => {
     });
 
     it("ignores status updates for messages that are not ours", async () => {
-      await connection.connect();
+      await connectOpen();
 
       mockEventHandlers.get("messages.update")?.([
         { key: { fromMe: false, id: "x" }, update: { status: 2 } },

--- a/src/baileys/connection.spec.ts
+++ b/src/baileys/connection.spec.ts
@@ -2556,6 +2556,43 @@ describe("BaileysConnection", () => {
       config.baileys.sendTimeoutMs = 45_000;
     });
 
+    // Without a reserved id we only learn the generated one when
+    // socket.sendMessage resolves, and WhatsApp can acknowledge before that --
+    // the node is on the wire while the enclosing keystore transaction is still
+    // committing. Discarding that ack leaves lastOutgoingAckAt null for a
+    // message that was demonstrably delivered.
+    it("claims an ack that arrived before the generated id was known", async () => {
+      await connectOpen();
+      expect(connection.lastOutgoingAckAt).toBeNull();
+
+      mockSocket.sendMessage.mockImplementationOnce(async () => {
+        // WhatsApp acknowledges while the send is still resolving.
+        mockEventHandlers.get("messages.update")?.([
+          {
+            key: { fromMe: true, id: "GENERATED-EARLY" },
+            update: { status: 2 },
+          },
+        ]);
+        return { key: { id: "GENERATED-EARLY" } };
+      });
+
+      await connection.sendMessage("jid@s.whatsapp.net", { text: "hi" });
+
+      expect(connection.lastOutgoingAckAt).not.toBeNull();
+    });
+
+    // A `fromMe` ack is not proof our send path works: it also covers messages
+    // the operator sent from the phone itself. Holding one must not credit it.
+    it("does not credit an ack for a message it never submitted", async () => {
+      await connectOpen();
+
+      mockEventHandlers.get("messages.update")?.([
+        { key: { fromMe: true, id: "FROM-THE-PHONE" }, update: { status: 2 } },
+      ]);
+
+      expect(connection.lastOutgoingAckAt).toBeNull();
+    });
+
     // Group delivery and read acknowledgements ride message-receipt.update, not
     // messages.update. Without this a connection that only writes to groups sits
     // at `unknown` forever no matter how many recipients confirmed.

--- a/src/baileys/connection.spec.ts
+++ b/src/baileys/connection.spec.ts
@@ -2306,6 +2306,68 @@ describe("BaileysConnection", () => {
       }
     });
 
+    // A Redis lookup can outlive the episode that started it. An in-place
+    // reconnect keeps THIS object and only bumps the generation, so a cooldown
+    // written from the failure path lands on the new socket's detector and mutes
+    // it for a stall it never had, while the `suppressed` verdict describes an
+    // episode that is already over.
+    it("drops a stale episode when the backoff lookup fails after recovery", async () => {
+      const restarts: string[] = [];
+      connection = new BaileysConnection("+5511999999999", {
+        ...defaultOptions,
+        requestRestart: (reason: string) => restarts.push(reason),
+      });
+      config.baileys.sendStallRestartEnabled = true;
+      const key = clusterKeys.sendStall("+5511999999999");
+      const canRestart = spyOn(sendStallStore, "canRestart").mockImplementation(
+        async () => {
+          // Recovery lands while the lookup is in flight, and only then does the
+          // lookup fail.
+          await mockEventHandlers.get("connection.update")?.({
+            connection: "open",
+          });
+          throw new Error("redis down");
+        },
+      );
+
+      try {
+        await connectOpen();
+        wedge();
+        const start = Date.now();
+
+        await expect(send()).rejects.toThrow(OperationTimeoutError);
+        await expect(send()).rejects.toThrow(OperationTimeoutError);
+        setSystemTime(new Date(start + 120_000));
+        fetchCalls.length = 0;
+        await expect(send()).rejects.toThrow(OperationTimeoutError);
+        await new Promise((r) => setTimeout(r, 5));
+
+        const stallCalls = () =>
+          fetchCalls.filter((call) => call.body.includes("send_stall_detected"))
+            .length;
+        // Nothing reported: the episode this verdict would describe is over.
+        expect(stallCalls()).toBe(0);
+        expect(restarts.length).toBe(0);
+
+        // And the detector is not muted. The silence went back to 0, so a fresh
+        // episode on the recovered socket reports itself instead of waiting out
+        // a cooldown it did not earn.
+        canRestart.mockRestore();
+        const second = Date.now();
+        await expect(send()).rejects.toThrow(OperationTimeoutError);
+        await expect(send()).rejects.toThrow(OperationTimeoutError);
+        setSystemTime(new Date(second + 120_000));
+        await expect(send()).rejects.toThrow(OperationTimeoutError);
+        await new Promise((r) => setTimeout(r, 5));
+
+        expect(stallCalls()).toBe(1);
+      } finally {
+        canRestart.mockRestore();
+        setSystemTime();
+        await redis.del(key);
+      }
+    });
+
     // The backoff key is per phone number and outlives the session by up to 24h,
     // so a strike written while this session is being torn down is inherited by
     // whatever is paired on that number next -- its watchdog suppressed on the

--- a/src/baileys/connection.spec.ts
+++ b/src/baileys/connection.spec.ts
@@ -1596,6 +1596,27 @@ describe("BaileysConnection", () => {
       expect(mockSocket.sendMessage).toHaveBeenCalled();
     });
 
+    // The breaker only opens after three COMPLETED timeouts, a whole send
+    // deadline away. Everything arriving inside that first window passes an empty
+    // counter and parks behind the wedged mutex, and those operations are not
+    // cancellable: if the mutex frees while the socket is alive they all fire at
+    // once, hours late, at a real customer whose caller long since retried. The
+    // queue depth was "however many sends arrived in 45 seconds", not three.
+    it("caps how many sends can queue behind a wedged mutex", async () => {
+      await connectOpen();
+      wedge();
+      mockSocket.sendMessage.mockClear();
+
+      // None of these settle, so none of them are counted yet -- which is the
+      // whole point: the breaker cannot see them.
+      const pending = Array.from({ length: 12 }, () =>
+        send().catch(() => "rejected"),
+      );
+      await Promise.all(pending);
+
+      expect(mockSocket.sendMessage.mock.calls.length).toBeLessThanOrEqual(8);
+    });
+
     // preprocessAudio runs up to two ffmpeg jobs for a PTT. A caller retrying into
     // a stalled connection would burn that CPU on every attempt only to be told 503
     // at the end, which is not what "fails immediately" means.

--- a/src/baileys/connection.spec.ts
+++ b/src/baileys/connection.spec.ts
@@ -1617,6 +1617,32 @@ describe("BaileysConnection", () => {
       expect(mockSocket.sendMessage.mock.calls.length).toBeLessThanOrEqual(8);
     });
 
+    // The slot belongs to the operation, not to our wait on it. Giving it back
+    // when withTimeout rejects lets a replacement in while the abandoned send is
+    // still parked in the mutex -- so the queue grows past the ceiling exactly
+    // when the breaker closes, which is the moment sends start flowing again.
+    it("keeps a timed-out send's slot until the operation settles", async () => {
+      await connectOpen();
+      wedge();
+      mockSocket.sendMessage.mockClear();
+
+      // Eight admitted, all timing out, none of them settling underneath.
+      await Promise.all(
+        Array.from({ length: 8 }, () => send().catch(() => "rejected")),
+      );
+      expect(mockSocket.sendMessage.mock.calls.length).toBe(8);
+
+      // An `open` clears the breaker -- but the eight operations are still
+      // parked, so the ceiling has to keep holding on its own.
+      await mockEventHandlers.get("connection.update")?.({
+        connection: "open",
+      });
+      mockSocket.sendMessage.mockClear();
+
+      await expect(send()).rejects.toThrow(BaileysSendStalledError);
+      expect(mockSocket.sendMessage).not.toHaveBeenCalled();
+    });
+
     // preprocessAudio runs up to two ffmpeg jobs for a PTT. A caller retrying into
     // a stalled connection would burn that CPU on every attempt only to be told 503
     // at the end, which is not what "fails immediately" means.

--- a/src/baileys/connection.spec.ts
+++ b/src/baileys/connection.spec.ts
@@ -1859,6 +1859,63 @@ describe("BaileysConnection", () => {
       await redis.del(clusterKeys.sendStall("+5511999999999"));
     });
 
+    // The distributed fence, and this was the one socket-creating path without
+    // it: the claim cycle acquires, the explicit paths force-acquire behind a
+    // live-owner guard, and the connectionReplaced kick yields on the same
+    // lease read. The watchdog decided on local state alone, so a phone
+    // force-taken over while this handler awaited Redis would be rebuilt here
+    // under a lease that is no longer ours -- two sockets fighting for one
+    // identity until the next renew cycle noticed.
+    it("yields instead of restarting when the lease moved to another instance", async () => {
+      const restarts: string[] = [];
+      let closed = 0;
+      connection = new BaileysConnection("+5511999999999", {
+        ...defaultOptions,
+        requestRestart: (reason: string) => restarts.push(reason),
+        onConnectionClose: () => {
+          closed += 1;
+        },
+      });
+      config.baileys.sendStallRestartEnabled = true;
+      await connectOpen();
+      wedge();
+      const start = Date.now();
+
+      // Another instance force-acquired this phone -- our registry entry went
+      // stale for a beat and it took us for dead.
+      (redis as any).__stringData.set(
+        "@baileys-api:cluster:lease:+5511999999999",
+        JSON.stringify({ owner: "other-instance", epoch: 9 }),
+      );
+      fetchCalls.length = 0;
+
+      await expect(send()).rejects.toThrow(OperationTimeoutError);
+      await expect(send()).rejects.toThrow(OperationTimeoutError);
+      setSystemTime(new Date(start + 120_000));
+      await expect(send()).rejects.toThrow(OperationTimeoutError);
+      await new Promise((r) => setTimeout(r, 5));
+
+      // No socket rebuilt under a lease that is not ours.
+      expect(restarts.length).toBe(0);
+      // And no strike spent. The backoff key is per phone number and
+      // cluster-wide, so charging one here would suppress the watchdog of the
+      // instance that legitimately owns the number.
+      expect(
+        await redis.get(clusterKeys.sendStall("+5511999999999")),
+      ).toBeNull();
+      // Nothing narrated either: the new owner speaks for this number now, and
+      // our webhook would carry the older epoch.
+      expect(
+        fetchCalls.some((call) => call.body.includes("send_stall_detected")),
+      ).toBe(false);
+      // Aborted, not merely skipped -- a socket for a phone somebody else owns
+      // is a duplicate that is still receiving.
+      expect(closed).toBe(1);
+      expect(connection.isOpen).toBe(false);
+
+      setSystemTime();
+    });
+
     // The backoff key is per phone number and outlives the session by up to 24h,
     // so a strike written while this session is being torn down is inherited by
     // whatever is paired on that number next -- its watchdog suppressed on the

--- a/src/baileys/connection.spec.ts
+++ b/src/baileys/connection.spec.ts
@@ -1218,6 +1218,28 @@ describe("BaileysConnection", () => {
       });
     };
 
+    // The strike write is a compare-and-set EVAL now, not a plain SET. This runs
+    // `during` at the moment that write lands and then applies what the script
+    // would have written, so an example can still drive the race it is about.
+    const interceptStrikeWrite = (during: () => void | Promise<void>) => {
+      const evalMock = redis.eval as unknown as ReturnType<typeof mock>;
+      const keysWritten: string[] = [];
+      evalMock.mockImplementationOnce(
+        async (
+          _script: string,
+          opts: { keys: string[]; arguments: string[] },
+        ) => {
+          keysWritten.push(opts.keys[0]);
+          await during();
+          (
+            redis as unknown as { __stringData: Map<string, string> }
+          ).__stringData.set(opts.keys[0], opts.arguments[1]);
+          return 1;
+        },
+      );
+      return keysWritten;
+    };
+
     beforeEach(() => {
       config.baileys.sendTimeoutMs = 10;
       config.baileys.sendStallRestartEnabled = false;
@@ -2184,15 +2206,10 @@ describe("BaileysConnection", () => {
       await connectOpen();
       wedge();
 
-      const setMock = redis.set as unknown as ReturnType<typeof mock>;
-      setMock.mockImplementationOnce(async (k: string, v: string) => {
+      interceptStrikeWrite(() => {
         // A concurrent POST /restart discards this socket and spawns its
         // replacement. The session lives on; only this socket is gone.
         (connection as unknown as { isDiscarded: boolean }).isDiscarded = true;
-        (
-          redis as unknown as { __stringData: Map<string, string> }
-        ).__stringData.set(k, v);
-        return "OK";
       });
 
       try {
@@ -2392,15 +2409,8 @@ describe("BaileysConnection", () => {
       // The preload's redis.set is itself a mock, and laying a spyOn over one is
       // the pattern that leaks across spec files here. Use its own one-shot API
       // and write straight into the fake's store.
-      const setMock = redis.set as unknown as ReturnType<typeof mock>;
-      const setKeys: string[] = [];
-      setMock.mockImplementationOnce(async (k: string, v: string) => {
-        setKeys.push(k);
+      const setKeys = interceptStrikeWrite(() => {
         (connection as unknown as { isDiscarded: boolean }).isDiscarded = true;
-        (
-          redis as unknown as { __stringData: Map<string, string> }
-        ).__stringData.set(k, v);
-        return "OK";
       });
 
       try {
@@ -2438,19 +2448,12 @@ describe("BaileysConnection", () => {
       wedge();
 
       const key = clusterKeys.sendStall("+5511999999999");
-      const setMock = redis.set as unknown as ReturnType<typeof mock>;
-      const setKeys: string[] = [];
-      setMock.mockImplementationOnce(async (k: string, v: string) => {
-        setKeys.push(k);
+      const setKeys = interceptStrikeWrite(async () => {
         // A genuine recovery signal, not a hand-cleared flag: `open` is a new
         // socket, and clearing the stall is what withdraws the restart.
         await mockEventHandlers.get("connection.update")?.({
           connection: "open",
         });
-        (
-          redis as unknown as { __stringData: Map<string, string> }
-        ).__stringData.set(k, v);
-        return "OK";
       });
 
       try {
@@ -2541,16 +2544,11 @@ describe("BaileysConnection", () => {
       wedge();
 
       const key = clusterKeys.sendStall("+5511999999999");
-      const setMock = redis.set as unknown as ReturnType<typeof mock>;
-      setMock.mockImplementationOnce(async (k: string, v: string) => {
+      interceptStrikeWrite(async () => {
         // Recovery lands while the strike is being written.
         await mockEventHandlers.get("connection.update")?.({
           connection: "open",
         });
-        (
-          redis as unknown as { __stringData: Map<string, string> }
-        ).__stringData.set(k, v);
-        return "OK";
       });
 
       try {
@@ -2616,18 +2614,13 @@ describe("BaileysConnection", () => {
       await connectOpen();
       wedge();
 
-      const setMock = redis.set as unknown as ReturnType<typeof mock>;
-      setMock.mockImplementationOnce(async (k: string, v: string) => {
+      interceptStrikeWrite(() => {
         // Logout landing inside the write: it marks the session ended and
         // discards before its first await, and close() DELs this key.
         Object.assign(connection as unknown as Record<string, unknown>, {
           isDiscarded: true,
           sessionEnded: true,
         });
-        (
-          redis as unknown as { __stringData: Map<string, string> }
-        ).__stringData.set(k, v);
-        return "OK";
       });
 
       try {
@@ -2661,18 +2654,13 @@ describe("BaileysConnection", () => {
       wedge();
 
       const key = clusterKeys.sendStall("+5511999999999");
-      const setMock = redis.set as unknown as ReturnType<typeof mock>;
-      setMock.mockImplementationOnce(async (k: string, v: string) => {
+      interceptStrikeWrite(async () => {
         await mockEventHandlers.get("connection.update")?.({
           connection: "close" as const,
           lastDisconnect: {
             error: { output: { statusCode: 401, payload: {} }, message: "x" },
           },
         });
-        (
-          redis as unknown as { __stringData: Map<string, string> }
-        ).__stringData.set(k, v);
-        return "OK";
       });
 
       try {

--- a/src/baileys/connection.spec.ts
+++ b/src/baileys/connection.spec.ts
@@ -1960,6 +1960,75 @@ describe("BaileysConnection", () => {
       }
     });
 
+    // The coordinator clears this key in logoutWithLease, but that is one of
+    // several destructive paths: admin logoutAll, the wrong-number
+    // requestLogout and a remote `loggedOut` close all go through close()
+    // instead. The key is per phone number and lives 24h, so whatever is paired
+    // on that number next inherits a suppression it never earned.
+    it("clears the stall backoff when the session is torn down", async () => {
+      const key = clusterKeys.sendStall("+5511999999999");
+      await redis.set(
+        key,
+        JSON.stringify({ restarts: 3, nextRestartAllowedAt: Date.now() + 1e6 }),
+      );
+
+      await connectOpen();
+      // Through a real destructive path rather than the private close() it
+      // funnels into, so the example still means something if that plumbing
+      // changes.
+      await connection.logout();
+
+      expect(await redis.get(key)).toBe(null);
+    });
+
+    // Discarded and recovered undo differently. A torn-down session's logout
+    // DELETES this key, so restoring the previous episode's value resurrects a
+    // backoff for a session that no longer exists and hands it to the next
+    // pairing on this number.
+    it("does not resurrect an old backoff when the session is discarded", async () => {
+      const restarts: string[] = [];
+      connection = new BaileysConnection("+5511999999999", {
+        ...defaultOptions,
+        requestRestart: (reason: string) => restarts.push(reason),
+      });
+      config.baileys.sendStallRestartEnabled = true;
+      const key = clusterKeys.sendStall("+5511999999999");
+      // An earlier genuine episode, which is what makes `previous` non-null.
+      await redis.set(
+        key,
+        JSON.stringify({ restarts: 1, nextRestartAllowedAt: Date.now() - 1 }),
+      );
+
+      await connectOpen();
+      wedge();
+
+      const setMock = redis.set as unknown as ReturnType<typeof mock>;
+      setMock.mockImplementationOnce(async (k: string, v: string) => {
+        // Logout landing inside the write: it sets isDiscarded before its first
+        // await, and the coordinator DELs this key in its finally.
+        (connection as unknown as { isDiscarded: boolean }).isDiscarded = true;
+        (
+          redis as unknown as { __stringData: Map<string, string> }
+        ).__stringData.set(k, v);
+        return "OK";
+      });
+
+      try {
+        const start = Date.now();
+        await expect(send()).rejects.toThrow(OperationTimeoutError);
+        await expect(send()).rejects.toThrow(OperationTimeoutError);
+        setSystemTime(new Date(start + 120_000));
+        await expect(send()).rejects.toThrow(OperationTimeoutError);
+        await asyncSleep(0);
+
+        expect(await redis.get(key)).toBe(null);
+        expect(restarts.length).toBe(0);
+      } finally {
+        setSystemTime();
+        await redis.del(key);
+      }
+    });
+
     // Without this, the breaker stays open across an in-place reconnect (the
     // connection object survives a socket drop) and the connection answers 503
     // forever — worse than the original stall, which at least cleared itself

--- a/src/baileys/connection.spec.ts
+++ b/src/baileys/connection.spec.ts
@@ -1312,6 +1312,40 @@ describe("BaileysConnection", () => {
       await expect(send()).rejects.toThrow(BaileysSendStalledError);
     });
 
+    // `isOnline` is a presence echo on the socket we already have, not a
+    // handshake result: sendPresenceUpdate("available") emits one, and POST
+    // /connections calls exactly that when it reuses a live connection -- which
+    // is the Chatwoot health check, every five minutes. Taken as connectivity it
+    // flips isOpen mid-handshake, which is the gate deciding whether a run of
+    // timeouts is an ordinary reconnect outage or a send stall.
+    it("does not treat a presence echo as the socket being open", async () => {
+      // Deliberately no `open`: the handshake has not finished.
+      await connection.connect();
+      expect(connection.isOpen).toBe(false);
+
+      await mockEventHandlers.get("connection.update")?.({ isOnline: true });
+
+      expect(connection.isOpen).toBe(false);
+      // The rewrite itself stays: clients are still told `open`, which is the
+      // contract this echo has always had.
+      expect(
+        fetchCalls.some(
+          (call) =>
+            call.body.includes('"isOnline":true') &&
+            call.body.includes('"connection":"open"'),
+        ),
+      ).toBe(true);
+
+      wedge();
+      await expect(send()).rejects.toThrow(OperationTimeoutError);
+      await expect(send()).rejects.toThrow(OperationTimeoutError);
+      await expect(send()).rejects.toThrow(OperationTimeoutError);
+
+      // An ordinary outage, not a stall: the socket never opened.
+      await expect(send()).rejects.toThrow(BaileysNotConnectedError);
+      expect(connection.sendState).not.toBe("stalled");
+    });
+
     // The mirror of the reconnect finding: maybeReportSendStall already refuses to
     // call this a stall while the socket is not open, and the REFUSAL has to agree.
     // The stall-specific 503 tells the caller the connection is up and must not be

--- a/src/baileys/connection.spec.ts
+++ b/src/baileys/connection.spec.ts
@@ -1916,6 +1916,78 @@ describe("BaileysConnection", () => {
       setSystemTime();
     });
 
+    // The fence above is one Redis round trip old by the time the restart is
+    // actually asked for, and a takeover can land inside that round trip. This is
+    // the one that has to hold, because it is the last point before the socket is
+    // rebuilt.
+    it("yields when the lease moves while the strike is being written", async () => {
+      const key = clusterKeys.sendStall("+5511999999999");
+      const stringData = (
+        redis as unknown as { __stringData: Map<string, string> }
+      ).__stringData;
+      // An earlier genuine episode, already past its backoff window, so the
+      // rollback has something to restore and can be told apart from a wipe.
+      stringData.set(
+        key,
+        JSON.stringify({ restarts: 1, nextRestartAllowedAt: Date.now() - 1 }),
+      );
+
+      const restarts: string[] = [];
+      let closed = 0;
+      connection = new BaileysConnection("+5511999999999", {
+        ...defaultOptions,
+        requestRestart: (reason: string) => restarts.push(reason),
+        onConnectionClose: () => {
+          closed += 1;
+        },
+      });
+      config.baileys.sendStallRestartEnabled = true;
+      await connectOpen();
+      wedge();
+
+      const realRecord = sendStallStore.recordRestart;
+      const record = spyOn(sendStallStore, "recordRestart").mockImplementation(
+        async (phone: string) => {
+          // Another instance force-acquires inside the window this write
+          // occupies -- after the earlier fence read, before the later one.
+          stringData.set(
+            "@baileys-api:cluster:lease:+5511999999999",
+            JSON.stringify({ owner: "other-instance", epoch: 9 }),
+          );
+          return realRecord(phone);
+        },
+      );
+
+      try {
+        const start = Date.now();
+        await expect(send()).rejects.toThrow(OperationTimeoutError);
+        await expect(send()).rejects.toThrow(OperationTimeoutError);
+        setSystemTime(new Date(start + 120_000));
+        fetchCalls.length = 0;
+        await expect(send()).rejects.toThrow(OperationTimeoutError);
+        await new Promise((r) => setTimeout(r, 5));
+
+        // The write did happen -- the fence is downstream of it.
+        expect(record).toHaveBeenCalledTimes(1);
+        // No socket rebuilt against the legitimate owner's.
+        expect(restarts.length).toBe(0);
+        // And the increment is taken back rather than the key wiped: the backoff
+        // is cluster-wide, so charging a strike for a restart we are not
+        // performing would suppress the new owner's watchdog, while deleting
+        // would hand the phone a clean slate an earlier episode already spent.
+        expect(JSON.parse(stringData.get(key) ?? "{}").restarts).toBe(1);
+        expect(closed).toBe(1);
+        expect(connection.isOpen).toBe(false);
+        expect(
+          fetchCalls.some((call) => call.body.includes("send_stall_detected")),
+        ).toBe(false);
+      } finally {
+        record.mockRestore();
+        setSystemTime();
+        await redis.del(key);
+      }
+    });
+
     // The backoff key is per phone number and outlives the session by up to 24h,
     // so a strike written while this session is being torn down is inherited by
     // whatever is paired on that number next -- its watchdog suppressed on the

--- a/src/baileys/connection.spec.ts
+++ b/src/baileys/connection.spec.ts
@@ -1382,6 +1382,82 @@ describe("BaileysConnection", () => {
       expect(connection.sendState).not.toBe("stalled");
     });
 
+    // The queue cap is exactly what a send lands on during an ordinary outage: a
+    // socket that closes with its sends unresolved keeps every one of them
+    // holding a slot, because the slot belongs to the operation and not to our
+    // wait on it. Answering `stalled` there tells the caller the connection is up
+    // and must NOT be marked down, and costs it the reconnect it needed.
+    it("reports a closed socket as disconnected even with the send queue full", async () => {
+      await connectOpen();
+      wedge();
+
+      // Eight concurrent sends, started before any of them can time out, so all
+      // eight take a slot instead of being turned away by the breaker.
+      const inFlight = Array.from({ length: 8 }, () => send().catch(() => {}));
+      await new Promise((r) => setTimeout(r, 5));
+
+      // The queue is full: a ninth send is refused without reaching the socket.
+      const callsBefore = mockSocket.sendMessage.mock.calls.length;
+      await expect(send()).rejects.toThrow(BaileysSendStalledError);
+      expect(mockSocket.sendMessage.mock.calls.length).toBe(callsBefore);
+
+      // Now the socket drops. The eight are still parked, so the cap still bites
+      // -- but this is an outage, not a wedge.
+      (connection as unknown as { connectionState: string }).connectionState =
+        "close";
+
+      await expect(send()).rejects.toThrow(BaileysNotConnectedError);
+      expect(connection.sendState).not.toBe("stalled");
+
+      await Promise.all(inFlight);
+    });
+
+    // The one late verdict that is not ambiguous. A mutex-acquire timeout means
+    // the waiter never entered txStorage.run -- it read nothing, wrote nothing
+    // and relayed nothing -- so the "outcome unknown" its caller was already
+    // given is now known, and the marker holding that caller's resend can go.
+    it("tells the caller when a parked send is proved never to have been sent", async () => {
+      await connectOpen();
+      let notSent = 0;
+      let rejectLate: ((error: unknown) => void) | undefined;
+      mockSocket.sendMessage.mockImplementation(
+        () =>
+          new Promise((_resolve, reject) => {
+            rejectLate = reject;
+          }),
+      );
+      const sendWithHook = () =>
+        connection.sendMessage(
+          "jid@s.whatsapp.net",
+          { text: "hi" },
+          {
+            onLateDefinitiveFailure: () => {
+              notSent += 1;
+            },
+          },
+        );
+
+      await expect(sendWithHook()).rejects.toThrow(OperationTimeoutError);
+      // Still unknown at this point: the send is parked, not resolved.
+      expect(notSent).toBe(0);
+
+      rejectLate?.(
+        Object.assign(new Error("keystore transaction timed out"), {
+          data: { key: "me@s.whatsapp.net", code: "E_TX_MUTEX_TIMEOUT" },
+        }),
+      );
+      await new Promise((r) => setTimeout(r, 5));
+      expect(notSent).toBe(1);
+
+      // Any other late failure stays ambiguous -- media generation and upload run
+      // BEFORE the transaction is taken, so a rejection from there says nothing
+      // about whether a message went out.
+      await expect(sendWithHook()).rejects.toThrow(OperationTimeoutError);
+      rejectLate?.(new Error("upload failed"));
+      await new Promise((r) => setTimeout(r, 5));
+      expect(notSent).toBe(1);
+    });
+
     // The holder can let go between the acquisition giving up and the Boom
     // reaching the breaker. handleTxEvent sees that release while nothing is
     // armed yet and rightly ignores it -- and it is the only one that key will

--- a/src/baileys/connection.spec.ts
+++ b/src/baileys/connection.spec.ts
@@ -1592,7 +1592,17 @@ describe("BaileysConnection", () => {
       const restarts: string[] = [];
       connection = new BaileysConnection("+5511999999999", {
         ...defaultOptions,
-        requestRestart: (reason: string) => restarts.push(reason),
+        requestRestart: (reason: string) => {
+          restarts.push(reason);
+          // What the real handler does. connectionsHandler.connect runs
+          // synchronously up to its first await when the per-number slot is
+          // free, and discard() is inside that stretch -- so anything this
+          // connection does AFTER calling requestRestart sees itself discarded.
+          // A double that skips this hid exactly that, and the strike below
+          // stopped being recorded at all.
+          (connection as unknown as { isDiscarded: boolean }).isDiscarded =
+            true;
+        },
       });
       config.baileys.sendStallRestartEnabled = true;
       await connectOpen();
@@ -1630,31 +1640,48 @@ describe("BaileysConnection", () => {
       const restarts: string[] = [];
       connection = new BaileysConnection("+5511999999999", {
         ...defaultOptions,
-        requestRestart: () => {
-          restarts.push("asked");
-          // Stands in for logout landing while the strike is being written:
-          // logout() sets this before its first await.
-          (connection as unknown as { isDiscarded: boolean }).isDiscarded =
-            true;
-        },
+        requestRestart: (reason: string) => restarts.push(reason),
       });
       config.baileys.sendStallRestartEnabled = true;
       await connectOpen();
       wedge();
-      const start = Date.now();
 
-      await expect(send()).rejects.toThrow(OperationTimeoutError);
-      await expect(send()).rejects.toThrow(OperationTimeoutError);
-      setSystemTime(new Date(start + 120_000));
-      await expect(send()).rejects.toThrow(OperationTimeoutError);
-      await asyncSleep(0);
+      // Logout landing inside the write, which is the only window the pre-check
+      // cannot see: it sets isDiscarded before its first await, and the
+      // coordinator DELs this key in its finally.
+      const key = clusterKeys.sendStall("+5511999999999");
+      // The preload's redis.set is itself a mock, and laying a spyOn over one is
+      // the pattern that leaks across spec files here. Use its own one-shot API
+      // and write straight into the fake's store.
+      const setMock = redis.set as unknown as ReturnType<typeof mock>;
+      const setKeys: string[] = [];
+      setMock.mockImplementationOnce(async (k: string, v: string) => {
+        setKeys.push(k);
+        (connection as unknown as { isDiscarded: boolean }).isDiscarded = true;
+        (
+          redis as unknown as { __stringData: Map<string, string> }
+        ).__stringData.set(k, v);
+        return "OK";
+      });
 
-      expect(restarts.length).toBe(1);
-      expect(await redis.get(clusterKeys.sendStall("+5511999999999"))).toBe(
-        null,
-      );
-      setSystemTime();
-      await redis.del(clusterKeys.sendStall("+5511999999999"));
+      try {
+        const start = Date.now();
+        await expect(send()).rejects.toThrow(OperationTimeoutError);
+        await expect(send()).rejects.toThrow(OperationTimeoutError);
+        setSystemTime(new Date(start + 120_000));
+        await expect(send()).rejects.toThrow(OperationTimeoutError);
+        await asyncSleep(0);
+
+        // Guards the stub itself: if some other write came first, the fence was
+        // never exercised and the rest of this example would prove nothing.
+        expect(setKeys).toEqual([key]);
+        expect(await redis.get(key)).toBe(null);
+        // And the restart is abandoned with it: the session is going away.
+        expect(restarts.length).toBe(0);
+      } finally {
+        setSystemTime();
+        await redis.del(key);
+      }
     });
 
     // Without this, the breaker stays open across an in-place reconnect (the

--- a/src/baileys/connection.spec.ts
+++ b/src/baileys/connection.spec.ts
@@ -1169,6 +1169,68 @@ describe("BaileysConnection", () => {
       expect(mockSocket.sendMessage.mock.calls.length).toBe(3);
     });
 
+    // The breaker counts refusals by ONE socket's keystore mutex, and a replacement
+    // brings a new one. A streak that survives the swap accuses the wrong socket:
+    // two stale timeouts plus one during the new handshake (safeSocket only needs a
+    // socket object, and the replacement has one before `open` arrives) answer the
+    // stall-specific 503 for what was an ordinary reconnect.
+    it("does not carry a send-timeout streak across a new socket", async () => {
+      await connectOpen();
+      wedge();
+      await expect(send()).rejects.toThrow(OperationTimeoutError);
+      await expect(send()).rejects.toThrow(OperationTimeoutError);
+
+      // A real reconnect through the close path, not a hand-cleared counter:
+      // creating the socket is what bumps the generation, so it is what has to
+      // take the streak along.
+      const baileysModule = (await import("@whiskeysockets/baileys")) as any;
+      const makeSocket = baileysModule.default as ReturnType<typeof mock>;
+      const socketsBefore = makeSocket.mock.calls.length;
+      await mockEventHandlers.get("connection.update")!({
+        connection: "close" as const,
+        lastDisconnect: {
+          error: { output: { statusCode: 500, payload: {} }, message: "x" },
+        },
+      });
+      let stable = -1;
+      while (stable !== makeSocket.mock.calls.length) {
+        stable = makeSocket.mock.calls.length;
+        await new Promise((r) => setImmediate(r));
+      }
+      expect(makeSocket.mock.calls.length).toBeGreaterThan(socketsBefore);
+      // The replacement comes with its own mock, at zero calls; wedge that one.
+      wedge();
+
+      // Three, all admitted: this socket has refused none of them yet.
+      await expect(send()).rejects.toThrow(OperationTimeoutError);
+      await expect(send()).rejects.toThrow(OperationTimeoutError);
+      await expect(send()).rejects.toThrow(OperationTimeoutError);
+      expect(mockSocket.sendMessage.mock.calls.length).toBe(3);
+    });
+
+    // Which deadline fires first is decided by configuration, not by the failure:
+    // BAILEYS_TX_ACQUIRE_TIMEOUT_MS set below BAILEYS_SEND_TIMEOUT_MS makes the wedge
+    // report itself before our own deadline does. Counting only OperationTimeoutError
+    // would blind the detector in exactly the setup that detects a wedge fastest.
+    it("counts a keystore mutex timeout toward the breaker", async () => {
+      await connectOpen();
+      mockSocket.sendMessage.mockImplementation(() =>
+        Promise.reject(
+          Object.assign(new Error("keystore transaction timed out"), {
+            data: { key: "me@s.whatsapp.net", code: "E_TX_MUTEX_TIMEOUT" },
+          }),
+        ),
+      );
+      mockSocket.sendMessage.mockClear();
+
+      await expect(send()).rejects.toThrow("keystore transaction timed out");
+      await expect(send()).rejects.toThrow("keystore transaction timed out");
+      await expect(send()).rejects.toThrow("keystore transaction timed out");
+      await expect(send()).rejects.toThrow(BaileysSendStalledError);
+
+      expect(mockSocket.sendMessage.mock.calls.length).toBe(3);
+    });
+
     // preprocessAudio runs up to two ffmpeg jobs for a PTT. A caller retrying into
     // a stalled connection would burn that CPU on every attempt only to be told 503
     // at the end, which is not what "fails immediately" means.

--- a/src/baileys/connection.spec.ts
+++ b/src/baileys/connection.spec.ts
@@ -1988,6 +1988,69 @@ describe("BaileysConnection", () => {
       }
     });
 
+    // `failed` and `cancelled` exist to retract a `restart` already announced, and
+    // sendToWebhook gives no ordering: each payload runs its own retry loop, so a
+    // `restart` that needed a second attempt lands after a `failed` that went out
+    // on the first. A consumer reading them in that order concludes recovery is
+    // underway on a connection that never came back, which is the exact reading
+    // this feature exists to prevent.
+    it("delivers the restart verdict before the failure that retracts it", async () => {
+      const delivered: string[] = [];
+      const outerFetch = globalThis.fetch;
+      const outerRetries = config.webhook.retryPolicy.maxRetries;
+      // One retry, so the restart verdict's first attempt can fail while the
+      // failure verdict's first attempt succeeds.
+      config.webhook.retryPolicy.maxRetries = 1;
+      let restartAttempts = 0;
+      globalThis.fetch = mock(
+        async (_url: string | URL | Request, init?: RequestInit) => {
+          const body = (init?.body as string) ?? "";
+          if (body.includes('"action":"restart"')) {
+            restartAttempts += 1;
+            if (restartAttempts === 1) {
+              return new Response("nope", { status: 500 });
+            }
+            delivered.push("restart");
+            return new Response("ok", { status: 200 });
+          }
+          if (body.includes('"action":"failed"')) {
+            delivered.push("failed");
+          }
+          return new Response("ok", { status: 200 });
+        },
+      ) as unknown as typeof globalThis.fetch;
+
+      connection = new BaileysConnection("+5511999999999", {
+        ...defaultOptions,
+        requestRestart: () => {
+          // What the handler does when the replacement cannot be built: the
+          // connect rejects and it retracts the verdict it already announced.
+          connection.reportFailedStallRestart();
+        },
+      });
+      config.baileys.sendStallRestartEnabled = true;
+      const key = clusterKeys.sendStall("+5511999999999");
+
+      try {
+        await connectOpen();
+        wedge();
+        const start = Date.now();
+
+        await expect(send()).rejects.toThrow(OperationTimeoutError);
+        await expect(send()).rejects.toThrow(OperationTimeoutError);
+        setSystemTime(new Date(start + 120_000));
+        await expect(send()).rejects.toThrow(OperationTimeoutError);
+        await new Promise((r) => setTimeout(r, 20));
+
+        expect(delivered).toEqual(["restart", "failed"]);
+      } finally {
+        globalThis.fetch = outerFetch;
+        config.webhook.retryPolicy.maxRetries = outerRetries;
+        setSystemTime();
+        await redis.del(key);
+      }
+    });
+
     // The backoff key is per phone number and outlives the session by up to 24h,
     // so a strike written while this session is being torn down is inherited by
     // whatever is paired on that number next -- its watchdog suppressed on the
@@ -2443,11 +2506,15 @@ describe("BaileysConnection", () => {
         await connectOpen();
         wedge();
 
+        // Real timers, not asyncSleep(0): the verdicts are chained, so a second
+        // one is not even dispatched until the first delivery settles.
+        const settle = () => new Promise((r) => setTimeout(r, 5));
+
         await expect(send()).rejects.toThrow(OperationTimeoutError);
         await expect(send()).rejects.toThrow(OperationTimeoutError);
         setSystemTime(new Date(start + 120_000));
         await expect(send()).rejects.toThrow(OperationTimeoutError);
-        await asyncSleep(0);
+        await settle();
 
         const stallCalls = () =>
           fetchCalls.filter((call) => call.body.includes("send_stall_detected"))
@@ -2457,13 +2524,13 @@ describe("BaileysConnection", () => {
         // Inside the cooldown the failure does not become a webhook per send.
         setSystemTime(new Date(start + 130_000));
         await expect(send()).rejects.toThrow(BaileysSendStalledError);
-        await asyncSleep(0);
+        await settle();
         expect(stallCalls()).toBe(1);
 
         // Past it, the connection is due for review again.
         setSystemTime(new Date(start + 200_000));
         await expect(send()).rejects.toThrow(BaileysSendStalledError);
-        await asyncSleep(0);
+        await settle();
         expect(stallCalls()).toBe(2);
       } finally {
         canRestart.mockRestore();

--- a/src/baileys/connection.spec.ts
+++ b/src/baileys/connection.spec.ts
@@ -1381,11 +1381,22 @@ describe("BaileysConnection", () => {
     it("bounds the audio preprocessing that precedes the send deadline", async () => {
       await connectOpen();
       config.baileys.audioPreprocessTimeoutMs = 10;
-      // mockImplementationOnce, twice (a PTT runs two jobs), so nothing leaks into
-      // the spec that exercises the real preprocessAudio.
+      // Honours the signal, like the real implementation: what this layer owes is
+      // a deadline the worker can act on, and a stub that ignores it would pass
+      // whether or not one was ever passed. mockImplementationOnce, twice (a PTT
+      // runs two jobs), so nothing leaks into the spec that exercises the real
+      // preprocessAudio.
+      const parked = (
+        _audio: unknown,
+        _format: unknown,
+        signal?: AbortSignal,
+      ) =>
+        new Promise((_resolve, reject) => {
+          signal?.addEventListener("abort", () => reject(new Error("aborted")));
+        });
       const preprocess = preprocessAudio as unknown as ReturnType<typeof mock>;
-      preprocess.mockImplementationOnce(() => new Promise(() => {}));
-      preprocess.mockImplementationOnce(() => new Promise(() => {}));
+      preprocess.mockImplementationOnce(parked);
+      preprocess.mockImplementationOnce(parked);
 
       // Raced rather than awaited: without the deadline this send never settles,
       // and a hung example is a worse CI failure than a failed assertion.
@@ -1605,6 +1616,43 @@ describe("BaileysConnection", () => {
           (await redis.get(clusterKeys.sendStall("+5511999999999"))) ?? "{}",
         ).restarts,
       ).toBe(1);
+      setSystemTime();
+      await redis.del(clusterKeys.sendStall("+5511999999999"));
+    });
+
+    // The backoff key is per phone number and outlives the session by up to 24h,
+    // so a strike written while this session is being torn down is inherited by
+    // whatever is paired on that number next -- its watchdog suppressed on the
+    // strength of a socket that no longer exists. The coordinator DELs the key in
+    // logout's finally, and the store is a plain read-modify-write, so a write
+    // that straddles the DEL simply recreates it.
+    it("does not leave a stall strike behind for a session being discarded", async () => {
+      const restarts: string[] = [];
+      connection = new BaileysConnection("+5511999999999", {
+        ...defaultOptions,
+        requestRestart: () => {
+          restarts.push("asked");
+          // Stands in for logout landing while the strike is being written:
+          // logout() sets this before its first await.
+          (connection as unknown as { isDiscarded: boolean }).isDiscarded =
+            true;
+        },
+      });
+      config.baileys.sendStallRestartEnabled = true;
+      await connectOpen();
+      wedge();
+      const start = Date.now();
+
+      await expect(send()).rejects.toThrow(OperationTimeoutError);
+      await expect(send()).rejects.toThrow(OperationTimeoutError);
+      setSystemTime(new Date(start + 120_000));
+      await expect(send()).rejects.toThrow(OperationTimeoutError);
+      await asyncSleep(0);
+
+      expect(restarts.length).toBe(1);
+      expect(await redis.get(clusterKeys.sendStall("+5511999999999"))).toBe(
+        null,
+      );
       setSystemTime();
       await redis.del(clusterKeys.sendStall("+5511999999999"));
     });

--- a/src/baileys/connection.spec.ts
+++ b/src/baileys/connection.spec.ts
@@ -558,6 +558,42 @@ describe("BaileysConnection", () => {
       conn.discard();
     });
 
+    it("refuses an epoch that would go backwards", async () => {
+      // Two explicit operations racing. The one that acquired the OLDER epoch can
+      // still be parked before the handler when the newer one replaces the
+      // socket, and it arrives here afterwards carrying its own. Taking it leaves
+      // a live connection stamping events the client discards as stale while the
+      // coordinator renews an epoch nobody publishes: the channel stops updating.
+      const conn = new BaileysConnection("+5511999999999", {
+        ...defaultOptions,
+        leaseEpoch: 9,
+      });
+      await conn.connect();
+      const handler = mockEventHandlers.get("connection.update")!;
+
+      await conn.updateOptions({
+        ...defaultOptions,
+        webhookUrl: "https://reconfigured.example/hook",
+        leaseEpoch: 7,
+      });
+      fetchCalls.length = 0;
+
+      await handler({ isNewLogin: true });
+      // A bounded wait, not the spin the sibling examples use: this one asserts
+      // an epoch is ABSENT, and a regression that stamps 7 would hang a spin for
+      // 9 instead of failing.
+      await new Promise((r) => setTimeout(r, 10));
+
+      expect(fetchCalls.some((c) => c.body?.includes('"epoch":9'))).toBe(true);
+      expect(fetchCalls.some((c) => c.body?.includes('"epoch":7'))).toBe(false);
+      // The rest of that operation still applied: it is a real reconfiguration,
+      // just no longer the owner of record.
+      expect(conn.currentOptions.webhookUrl).toBe(
+        "https://reconfigured.example/hook",
+      );
+      conn.discard();
+    });
+
     it("omits the epoch when none was provided", async () => {
       await connection.connect();
       const handler = mockEventHandlers.get("connection.update")!;

--- a/src/baileys/connection.spec.ts
+++ b/src/baileys/connection.spec.ts
@@ -1185,18 +1185,36 @@ describe("BaileysConnection", () => {
           .at(-1)![0]
           .transactionOpts.onTransactionEvent(event);
 
-      wedge();
-      await expect(send()).rejects.toThrow(OperationTimeoutError);
-      await expect(send()).rejects.toThrow(OperationTimeoutError);
-      await expect(send()).rejects.toThrow(OperationTimeoutError);
+      // The send's own failure is what names the blocked key, exactly as in
+      // production: the Boom the patched transaction throws carries it.
+      mockSocket.sendMessage.mockImplementation(() =>
+        Promise.reject(
+          Object.assign(new Error("keystore transaction timed out"), {
+            data: { key: "me@s.whatsapp.net", code: "E_TX_MUTEX_TIMEOUT" },
+          }),
+        ),
+      );
+      await expect(send()).rejects.toThrow("keystore transaction timed out");
+      await expect(send()).rejects.toThrow("keystore transaction timed out");
+      await expect(send()).rejects.toThrow("keystore transaction timed out");
       await expect(send()).rejects.toThrow(BaileysSendStalledError);
 
-      // The wedge names its own key.
-      emit({ phase: "stalled", key: "me@s.whatsapp.net", waitedMs: 0 });
-
-      // A release on a DIFFERENT key proves nothing: the mutexes live in a
-      // per-key map, and this one was never the problem.
-      emit({ phase: "released", key: "lid-mapping", waitedMs: 0, heldMs: 5 });
+      // An unrelated key holding past the warn threshold, then releasing. Both
+      // must be inert: `stalled` names whatever key is held long, not the one
+      // blocking sends, and a release on a key we were never waiting for proves
+      // nothing -- the mutexes live in a per-key map.
+      emit({
+        phase: "stalled",
+        key: "lid-mapping",
+        waitedMs: 0,
+        heldMs: 31_000,
+      });
+      emit({
+        phase: "released",
+        key: "lid-mapping",
+        waitedMs: 0,
+        heldMs: 32_000,
+      });
       await expect(send()).rejects.toThrow(BaileysSendStalledError);
 
       emit({
@@ -1207,7 +1225,7 @@ describe("BaileysConnection", () => {
       });
 
       mockSocket.sendMessage.mockClear();
-      await expect(send()).rejects.toThrow(OperationTimeoutError);
+      await expect(send()).rejects.toThrow("keystore transaction timed out");
       expect(mockSocket.sendMessage).toHaveBeenCalled();
     });
 

--- a/src/baileys/connection.spec.ts
+++ b/src/baileys/connection.spec.ts
@@ -1684,6 +1684,53 @@ describe("BaileysConnection", () => {
       }
     });
 
+    // The strike stands for a restart. If recovery lands while the write is in
+    // flight, the handler's own guard vetoes the restart -- and a strike left
+    // behind then suppresses the NEXT genuine stall for five minutes on the
+    // strength of a connection that healed itself.
+    it("rolls the strike back when recovery cancels the restart", async () => {
+      const restarts: string[] = [];
+      connection = new BaileysConnection("+5511999999999", {
+        ...defaultOptions,
+        requestRestart: (reason: string) => restarts.push(reason),
+      });
+      config.baileys.sendStallRestartEnabled = true;
+      await connectOpen();
+      wedge();
+
+      const key = clusterKeys.sendStall("+5511999999999");
+      const setMock = redis.set as unknown as ReturnType<typeof mock>;
+      const setKeys: string[] = [];
+      setMock.mockImplementationOnce(async (k: string, v: string) => {
+        setKeys.push(k);
+        // A genuine recovery signal, not a hand-cleared flag: `open` is a new
+        // socket, and clearing the stall is what withdraws the restart.
+        await mockEventHandlers.get("connection.update")?.({
+          connection: "open",
+        });
+        (
+          redis as unknown as { __stringData: Map<string, string> }
+        ).__stringData.set(k, v);
+        return "OK";
+      });
+
+      try {
+        const start = Date.now();
+        await expect(send()).rejects.toThrow(OperationTimeoutError);
+        await expect(send()).rejects.toThrow(OperationTimeoutError);
+        setSystemTime(new Date(start + 120_000));
+        await expect(send()).rejects.toThrow(OperationTimeoutError);
+        await asyncSleep(0);
+
+        expect(setKeys).toEqual([key]);
+        expect(await redis.get(key)).toBe(null);
+        expect(restarts.length).toBe(0);
+      } finally {
+        setSystemTime();
+        await redis.del(key);
+      }
+    });
+
     // Without this, the breaker stays open across an in-place reconnect (the
     // connection object survives a socket drop) and the connection answers 503
     // forever — worse than the original stall, which at least cleared itself
@@ -2126,6 +2173,42 @@ describe("BaileysConnection", () => {
       ]);
 
       expect(connection.lastOutgoingAckAt).not.toBeNull();
+    });
+
+    // The send whose outcome we could not confirm is exactly the one whose
+    // acknowledgement matters most, and it is the one that used to be
+    // unmatchable: the success path that records Baileys' generated id never
+    // ran, so every receipt for it was rejected as not ours and the only
+    // end-to-end evidence there is stayed null. Reachable only without a
+    // reserved messageId; with one the same id was tracked before the send left.
+    it("matches acks for a send that only succeeded after timing out", async () => {
+      config.baileys.sendTimeoutMs = 10;
+      await connectOpen();
+      expect(connection.lastOutgoingAckAt).toBeNull();
+
+      mockSocket.sendMessage.mockImplementationOnce(
+        () =>
+          new Promise((resolve) =>
+            setTimeout(() => resolve({ key: { id: "GENERATED-LATE" } }), 30),
+          ),
+      );
+      await expect(
+        connection.sendMessage("jid@s.whatsapp.net", { text: "hi" }),
+      ).rejects.toThrow(OperationTimeoutError);
+
+      // Real timers: asyncSleep is mocked in preload and would spin without ever
+      // letting the 30ms settle fire.
+      for (let i = 0; i < 50 && connection.lastSendCompletedAt === null; i++) {
+        await new Promise((resolve) => setTimeout(resolve, 5));
+      }
+      expect(connection.lastSendCompletedAt).not.toBeNull();
+
+      mockEventHandlers.get("messages.update")?.([
+        { key: { fromMe: true, id: "GENERATED-LATE" }, update: { status: 2 } },
+      ]);
+
+      expect(connection.lastOutgoingAckAt).not.toBeNull();
+      config.baileys.sendTimeoutMs = 45_000;
     });
 
     // Group delivery and read acknowledgements ride message-receipt.update, not

--- a/src/baileys/connection.spec.ts
+++ b/src/baileys/connection.spec.ts
@@ -1046,6 +1046,44 @@ describe("BaileysConnection", () => {
       });
       expect(connection.isOpen).toBe(false);
     });
+
+    // The reconnect branch returns before the assignment at the bottom of
+    // handleConnectionUpdate, and on its way out it creates the replacement
+    // socket — so a state recorded only there would leave `open` standing while
+    // `socket !== null` came back, and the health endpoint would report
+    // `connected: true` for the whole handshake.
+    it("stops reporting open the moment an established socket closes", async () => {
+      await connection.connect();
+      await mockEventHandlers.get("connection.update")?.({
+        connection: "open",
+      });
+      expect(connection.isOpen).toBe(true);
+
+      await mockEventHandlers.get("connection.update")?.({
+        connection: "close" as const,
+        lastDisconnect: {
+          error: {
+            output: {
+              statusCode: 500,
+              payload: {
+                statusCode: 500,
+                error: "Unknown",
+                message: "Stream Errored",
+              },
+            },
+            message: "Stream Errored",
+          },
+        },
+      });
+
+      // The reconnect leaves `socket` null only until connect() finishes, and
+      // isOpen would answer false for that reason alone. Stand a socket back up
+      // directly instead of racing the async reconnect, so what is asserted is
+      // the recorded state and not the gap.
+      (connection as unknown as { socket: unknown }).socket = {};
+
+      expect(connection.isOpen).toBe(false);
+    });
   });
 
   // A later POST /connections reuses a live connection and mutates its options

--- a/src/baileys/connection.spec.ts
+++ b/src/baileys/connection.spec.ts
@@ -1489,6 +1489,53 @@ describe("BaileysConnection", () => {
       }
     });
 
+    // Every await inside handleSendStall is a window in which WhatsApp can drop and
+    // remake the socket on its own. The replacement gets a fresh keystore and clears
+    // the breaker, so acting on the verdict afterwards means reporting a stall on a
+    // healthy connection and asking the handler to throw it away.
+    it("abandons the episode when the socket is replaced while the backoff is read", async () => {
+      const restarts: string[] = [];
+      connection = new BaileysConnection("+5511999999999", {
+        ...defaultOptions,
+        requestRestart: (reason: string) => restarts.push(reason),
+      });
+      config.baileys.sendStallRestartEnabled = true;
+      const canRestart = spyOn(sendStallStore, "canRestart").mockImplementation(
+        async () => {
+          // WhatsApp remade the socket while Redis was answering.
+          (
+            connection as unknown as { socketGeneration: number }
+          ).socketGeneration += 1;
+          (
+            connection as unknown as { _consecutiveSendTimeouts: number }
+          )._consecutiveSendTimeouts = 0;
+          return true;
+        },
+      );
+      const start = Date.now();
+
+      try {
+        await connection.connect();
+        wedge();
+        fetchCalls.length = 0;
+
+        await expect(send()).rejects.toThrow(OperationTimeoutError);
+        await expect(send()).rejects.toThrow(OperationTimeoutError);
+        setSystemTime(new Date(start + 120_000));
+        await expect(send()).rejects.toThrow(OperationTimeoutError);
+        await asyncSleep(0);
+
+        expect(
+          fetchCalls.filter((call) => call.body.includes("send_stall_detected"))
+            .length,
+        ).toBe(0);
+        expect(restarts.length).toBe(0);
+      } finally {
+        canRestart.mockRestore();
+        setSystemTime();
+      }
+    });
+
     // The one that made the watchdog defeat itself in production. `isOnline` is
     // a presence echo on the socket we already have — sendPresenceUpdate emits
     // it, and POST /connections calls exactly that when it reuses a live

--- a/src/baileys/connection.spec.ts
+++ b/src/baileys/connection.spec.ts
@@ -14,6 +14,7 @@ const fetchCalls: Array<{ url: string; body: string }> = [];
 const originalFetch = globalThis.fetch;
 
 import * as baileysModule from "@whiskeysockets/baileys";
+import { WAMessageStatus } from "@whiskeysockets/baileys";
 import { preprocessAudio } from "@/baileys/helpers/preprocessAudio";
 import { clusterKeys } from "@/cluster/keys";
 import * as sendStallStore from "@/cluster/sendStallStore";
@@ -3174,6 +3175,73 @@ describe("BaileysConnection", () => {
 
       expect(connection.lastOutgoingAckAt).not.toBeNull();
       config.baileys.sendTimeoutMs = 45_000;
+    });
+
+    // The retroactive claim above is the whole reason isOurSubmittedKey has a side
+    // effect, and it is why the status has to be read BEFORE it. An update that
+    // is not an acknowledgement -- an ERROR status, or an edit carrying none --
+    // would otherwise park its id, and the send that follows would claim it as
+    // end-to-end proof. /health would then report delivery for a message
+    // WhatsApp rejected, which is worse than reporting nothing.
+    it("does not claim a failed update as an acknowledgement", async () => {
+      await connectOpen();
+      expect(connection.lastOutgoingAckAt).toBeNull();
+
+      mockSocket.sendMessage.mockImplementationOnce(async () => {
+        // WhatsApp answers while the send is still resolving -- but with a
+        // rejection, and then with an update carrying no status at all.
+        mockEventHandlers.get("messages.update")?.([
+          {
+            key: { fromMe: true, id: "GENERATED-FAILED" },
+            update: { status: WAMessageStatus.ERROR },
+          },
+        ]);
+        mockEventHandlers.get("messages.update")?.([
+          { key: { fromMe: true, id: "GENERATED-FAILED" }, update: {} },
+        ]);
+        return { key: { id: "GENERATED-FAILED" } };
+      });
+
+      await connection.sendMessage("jid@s.whatsapp.net", { text: "hi" });
+
+      // The send itself resolved, so sendState is legitimately `ok` -- that only
+      // says the keystore mutex was free. lastOutgoingAckAt is the end-to-end
+      // half, and nothing here earned it.
+      expect(connection.lastOutgoingAckAt).toBeNull();
+
+      // A real acknowledgement for the same message still lands, so this is not
+      // passing by refusing everything.
+      mockEventHandlers.get("messages.update")?.([
+        {
+          key: { fromMe: true, id: "GENERATED-FAILED" },
+          update: { status: WAMessageStatus.SERVER_ACK },
+        },
+      ]);
+      expect(connection.lastOutgoingAckAt).not.toBeNull();
+    });
+
+    // A receipt with no timestamp on it is not an acknowledgement either.
+    it("does not claim an empty receipt as an acknowledgement", async () => {
+      await connectOpen();
+
+      mockSocket.sendMessage.mockImplementationOnce(async () => {
+        mockEventHandlers.get("message-receipt.update")?.([
+          { key: { fromMe: true, id: "GENERATED-GROUP" }, receipt: {} },
+        ]);
+        return { key: { id: "GENERATED-GROUP" } };
+      });
+
+      await connection.sendMessage("group@g.us", { text: "hi" });
+
+      expect(connection.lastOutgoingAckAt).toBeNull();
+
+      mockEventHandlers.get("message-receipt.update")?.([
+        {
+          key: { fromMe: true, id: "GENERATED-GROUP" },
+          receipt: { receiptTimestamp: 1 },
+        },
+      ]);
+      expect(connection.lastOutgoingAckAt).not.toBeNull();
     });
 
     // Without a reserved id we only learn the generated one when

--- a/src/baileys/connection.spec.ts
+++ b/src/baileys/connection.spec.ts
@@ -14,6 +14,7 @@ const fetchCalls: Array<{ url: string; body: string }> = [];
 const originalFetch = globalThis.fetch;
 
 import * as baileysModule from "@whiskeysockets/baileys";
+import { preprocessAudio } from "@/baileys/helpers/preprocessAudio";
 import { clusterKeys } from "@/cluster/keys";
 import * as sendStallStore from "@/cluster/sendStallStore";
 import config from "@/config";
@@ -1158,6 +1159,32 @@ describe("BaileysConnection", () => {
       expect(mockSocket.sendMessage.mock.calls.length).toBe(3);
     });
 
+    // preprocessAudio runs up to two ffmpeg jobs for a PTT. A caller retrying into
+    // a stalled connection would burn that CPU on every attempt only to be told 503
+    // at the end, which is not what "fails immediately" means.
+    it("refuses a stalled send before spending ffmpeg on it", async () => {
+      await connection.connect();
+      wedge();
+      await expect(send()).rejects.toThrow(OperationTimeoutError);
+      await expect(send()).rejects.toThrow(OperationTimeoutError);
+      await expect(send()).rejects.toThrow(OperationTimeoutError);
+
+      // The preload already replaces this module, so read ITS mock rather than
+      // laying a spy over it: a spy on an already-mocked module export outlives
+      // mockRestore and breaks the spec that tests the real implementation.
+      const preprocess = preprocessAudio as unknown as ReturnType<typeof mock>;
+      preprocess.mockClear();
+
+      await expect(
+        connection.sendMessage("jid@s.whatsapp.net", {
+          audio: Buffer.from("fake-audio"),
+          ptt: true,
+        }),
+      ).rejects.toThrow(BaileysSendStalledError);
+
+      expect(preprocess.mock.calls.length).toBe(0);
+    });
+
     // The failure is total: one success proves the mutex is free, so the
     // counter has to reset rather than accumulate across unrelated hiccups.
     it("resets the streak after a send succeeds", async () => {
@@ -1428,14 +1455,18 @@ describe("BaileysConnection", () => {
           .length,
       ).toBe(1);
 
-      // Past it: the connection is due for review again.
+      // Past it: the connection is due for review again. Waited for rather than
+      // timed: the breaker now rejects before any of the send-path work, so the
+      // caller's rejection arrives ahead of the episode the rejection triggered.
       setSystemTime(new Date(start + 400_000));
       await expect(send()).rejects.toThrow(BaileysSendStalledError);
-      await asyncSleep(0);
-      expect(
+      const stallWebhooks = () =>
         fetchCalls.filter((call) => call.body.includes("send_stall_detected"))
-          .length,
-      ).toBe(2);
+          .length;
+      for (let i = 0; i < 50 && stallWebhooks() < 2; i += 1) {
+        await asyncSleep(1);
+      }
+      expect(stallWebhooks()).toBe(2);
 
       setSystemTime();
       await redis.del(clusterKeys.sendStall("+5511999999999"));
@@ -1623,11 +1654,18 @@ describe("BaileysConnection", () => {
       reject?.(new Error("upload failed"));
       await asyncSleep(0);
 
-      expect(connection.consecutiveSendTimeouts).toBe(0);
-      // The failure says the queue drained, NOT that a message went out, so the
+      // ONE slot back, not the whole queue: the rejection proves this operation
+      // left, and media upload runs BEFORE the mutex is taken, so it says nothing
+      // about whether the others are still queued behind a wedged one.
+      expect(connection.consecutiveSendTimeouts).toBe(2);
+      // The failure says an operation departed, NOT that a message went out, so the
       // health timestamp must stay untouched.
       expect(connection.lastSendCompletedAt).toBeNull();
-      expect(connection.sendState).toBe("unknown");
+      // And the freed slot is real: the next send reaches the socket instead of
+      // being refused outright.
+      mockSocket.sendMessage.mockClear();
+      await expect(send()).rejects.toThrow(OperationTimeoutError);
+      expect(mockSocket.sendMessage.mock.calls.length).toBe(1);
     });
 
     // The exception that makes the rule safe: a rejection that IS the
@@ -1671,11 +1709,35 @@ describe("BaileysConnection", () => {
       await connection.connect();
       expect(connection.lastOutgoingAckAt).toBeNull();
 
+      await connection.sendMessage(
+        "jid@s.whatsapp.net",
+        { text: "hi" },
+        { messageId: "3EB0RESERVED" },
+      );
       mockEventHandlers.get("messages.update")?.([
-        { key: { fromMe: true, id: "x" }, update: { status: 2 } },
+        { key: { fromMe: true, id: "3EB0RESERVED" }, update: { status: 2 } },
       ]);
 
       expect(connection.lastOutgoingAckAt).not.toBeNull();
+    });
+
+    // `fromMe` is true for everything the account sends, including from the phone
+    // and from other linked devices — none of which went through this socket's
+    // keystore mutex. Counting those would let a busy account keep a wedged
+    // connection reporting `ok`, which is the exact blindness this signal exists
+    // to remove.
+    it("ignores an ack for a message this socket never sent", async () => {
+      await connection.connect();
+
+      mockEventHandlers.get("messages.update")?.([
+        {
+          key: { fromMe: true, id: "SENT_FROM_THE_PHONE" },
+          update: { status: 2 },
+        },
+      ]);
+
+      expect(connection.lastOutgoingAckAt).toBeNull();
+      expect(connection.sendState).toBe("unknown");
     });
 
     it("ignores status updates for messages that are not ours", async () => {

--- a/src/baileys/connection.spec.ts
+++ b/src/baileys/connection.spec.ts
@@ -1617,6 +1617,54 @@ describe("BaileysConnection", () => {
       }
     });
 
+    // The entry gate checks isOpen, but the verdict is decided after two Redis
+    // round trips. A socket that emits `close` in that window still matches on
+    // generation and streak, so without carrying the gate across the awaits an
+    // ordinary disconnect is reported as a stall, spends a backoff strike and
+    // asks for a restart of something already reconnecting on its own.
+    it("abandons the episode when the socket closes while the backoff is read", async () => {
+      const restarts: string[] = [];
+      connection = new BaileysConnection("+5511999999999", {
+        ...defaultOptions,
+        requestRestart: (reason: string) => restarts.push(reason),
+      });
+      config.baileys.sendStallRestartEnabled = true;
+      const canRestart = spyOn(sendStallStore, "canRestart").mockImplementation(
+        async () => {
+          // WhatsApp dropped the socket while Redis was answering.
+          (
+            connection as unknown as { connectionState: string }
+          ).connectionState = "close";
+          return true;
+        },
+      );
+      const start = Date.now();
+
+      try {
+        await connectOpen();
+        wedge();
+        fetchCalls.length = 0;
+
+        await expect(send()).rejects.toThrow(OperationTimeoutError);
+        await expect(send()).rejects.toThrow(OperationTimeoutError);
+        setSystemTime(new Date(start + 120_000));
+        await expect(send()).rejects.toThrow(OperationTimeoutError);
+        await asyncSleep(0);
+
+        expect(
+          fetchCalls.filter((call) => call.body.includes("send_stall_detected"))
+            .length,
+        ).toBe(0);
+        expect(restarts.length).toBe(0);
+        expect(await redis.get(clusterKeys.sendStall("+5511999999999"))).toBe(
+          null,
+        );
+      } finally {
+        canRestart.mockRestore();
+        setSystemTime();
+      }
+    });
+
     // The one that made the watchdog defeat itself in production. `isOnline` is
     // a presence echo on the socket we already have — sendPresenceUpdate emits
     // it, and POST /connections calls exactly that when it reuses a live

--- a/src/baileys/connection.spec.ts
+++ b/src/baileys/connection.spec.ts
@@ -1229,6 +1229,70 @@ describe("BaileysConnection", () => {
       expect(mockSocket.sendMessage).toHaveBeenCalled();
     });
 
+    // recordSendTimeout drops a stale generation, but noteMutexWedge ran first and
+    // stamped the replaced socket's key onto the live watchdog. A release on THAT
+    // key then closes a breaker that is open because of a different one.
+    it("ignores a mutex timeout that belongs to a replaced socket", async () => {
+      config.baileys.sendTimeoutMs = 5_000;
+      await connectOpen();
+      const baileysModule = (await import("@whiskeysockets/baileys")) as any;
+      const makeSocket = baileysModule.default as ReturnType<typeof mock>;
+      const emit = (event: Record<string, unknown>) =>
+        makeSocket.mock.calls
+          .at(-1)![0]
+          .transactionOpts.onTransactionEvent(event);
+
+      // A send left in flight on the socket that is about to be replaced.
+      let rejectStale!: (error: unknown) => void;
+      mockSocket.sendMessage.mockImplementationOnce(
+        () =>
+          new Promise((_resolve, reject) => {
+            rejectStale = reject;
+          }),
+      );
+      const stale = send().catch(() => "settled");
+
+      await mockEventHandlers.get("connection.update")!({
+        connection: "close" as const,
+        lastDisconnect: {
+          error: { output: { statusCode: 500, payload: {} }, message: "x" },
+        },
+      });
+      let stable = -1;
+      while (stable !== makeSocket.mock.calls.length) {
+        stable = makeSocket.mock.calls.length;
+        await new Promise((r) => setImmediate(r));
+      }
+      await mockEventHandlers.get("connection.update")?.({
+        connection: "open",
+      });
+
+      // The replacement wedges on its OWN key, which is what the breaker is about.
+      mockSocket.sendMessage.mockImplementation(() =>
+        Promise.reject(
+          Object.assign(new Error("live wedge"), {
+            data: { key: "live-key", code: "E_TX_MUTEX_TIMEOUT" },
+          }),
+        ),
+      );
+      await expect(send()).rejects.toThrow("live wedge");
+      await expect(send()).rejects.toThrow("live wedge");
+      await expect(send()).rejects.toThrow("live wedge");
+      await expect(send()).rejects.toThrow(BaileysSendStalledError);
+
+      // Only now does the replaced socket's send report its own, different key.
+      rejectStale(
+        Object.assign(new Error("stale wedge"), {
+          data: { key: "stale-key", code: "E_TX_MUTEX_TIMEOUT" },
+        }),
+      );
+      await stale;
+
+      // A key the live socket was never blocked on says nothing about it.
+      emit({ phase: "released", key: "stale-key", waitedMs: 0, heldMs: 1_000 });
+      await expect(send()).rejects.toThrow(BaileysSendStalledError);
+    });
+
     // The mirror of the reconnect finding: maybeReportSendStall already refuses to
     // call this a stall while the socket is not open, and the REFUSAL has to agree.
     // The stall-specific 503 tells the caller the connection is up and must not be

--- a/src/baileys/connection.spec.ts
+++ b/src/baileys/connection.spec.ts
@@ -990,6 +990,25 @@ describe("BaileysConnection", () => {
     });
   });
 
+  describe("#connect failure", () => {
+    // Resolving here reports a connect that built nothing as success:
+    // spawnConnection's cleanup never runs, so its registry entry is gone while
+    // the caller is told all is well; an automatic restart never reports the
+    // failure, so the lease is held for a phone with no socket; and POST
+    // /restart answers 202 for a replacement that does not exist.
+    it("propagates a socket that could not be created", async () => {
+      const baileysMod = (await import("@whiskeysockets/baileys")) as any;
+      const makeSocket = baileysMod.default as ReturnType<typeof mock>;
+      makeSocket.mockImplementationOnce(() => {
+        throw new Error("socket construction failed");
+      });
+
+      await expect(connection.connect()).rejects.toThrow(
+        "socket construction failed",
+      );
+    });
+  });
+
   describe("#sendMessage", () => {
     it("throws BaileysNotConnectedError if not connected", async () => {
       await expect(

--- a/src/baileys/connection.spec.ts
+++ b/src/baileys/connection.spec.ts
@@ -3208,6 +3208,57 @@ describe("BaileysConnection", () => {
       expect(connection.lastOutgoingAckAt).not.toBeNull();
     });
 
+    // A parked ack can be claimed long after it arrived: the send it belongs to
+    // may take the full send timeout to resolve, and other sends acknowledge in
+    // between. Writing the older timestamp over the newer one makes /health
+    // report a send path staler than it is -- a false alarm on the one signal
+    // that does not come from us.
+    it("does not roll the newest acknowledgement backwards", async () => {
+      await connectOpen();
+
+      let resolveFirst: ((value: unknown) => void) | undefined;
+      mockSocket.sendMessage.mockImplementationOnce(() => {
+        // WhatsApp acknowledges the first send before it resolves.
+        mockEventHandlers.get("messages.update")?.([
+          {
+            key: { fromMe: true, id: "GENERATED-FIRST" },
+            update: { status: WAMessageStatus.SERVER_ACK },
+          },
+        ]);
+        return new Promise((resolve) => {
+          resolveFirst = () => resolve({ key: { id: "GENERATED-FIRST" } });
+        });
+      });
+      const first = connection.sendMessage("jid@s.whatsapp.net", {
+        text: "one",
+      });
+      await new Promise((r) => setTimeout(r, 5));
+      // Nothing claimed yet: the id is still unknown to us.
+      expect(connection.lastOutgoingAckAt).toBeNull();
+
+      // A second send goes out and is acknowledged, all while the first is still
+      // resolving.
+      await connection.sendMessage(
+        "jid@s.whatsapp.net",
+        { text: "two" },
+        { messageId: "RESERVED-SECOND" },
+      );
+      mockEventHandlers.get("messages.update")?.([
+        {
+          key: { fromMe: true, id: "RESERVED-SECOND" },
+          update: { status: WAMessageStatus.SERVER_ACK },
+        },
+      ]);
+      const newest = connection.lastOutgoingAckAt;
+      expect(newest).not.toBeNull();
+
+      // Only now does the first send resolve and claim its parked ack.
+      resolveFirst?.(undefined);
+      await first;
+
+      expect(connection.lastOutgoingAckAt).toBe(newest);
+    });
+
     // A receipt with no timestamp on it is not an acknowledgement either.
     it("does not claim an empty receipt as an acknowledgement", async () => {
       await connectOpen();

--- a/src/baileys/connection.spec.ts
+++ b/src/baileys/connection.spec.ts
@@ -1026,6 +1026,26 @@ describe("BaileysConnection", () => {
     });
   });
 
+  describe("#isOpen", () => {
+    // Reported by the health endpoint, where "we hold the object" would be a
+    // false connectivity signal during QR pairing and reconnect backoff.
+    it("follows the socket's state rather than the connection's existence", async () => {
+      expect(connection.isOpen).toBe(false);
+      await connection.connect();
+      expect(connection.isOpen).toBe(false);
+
+      await mockEventHandlers.get("connection.update")?.({
+        connection: "open",
+      });
+      expect(connection.isOpen).toBe(true);
+
+      await mockEventHandlers.get("connection.update")?.({
+        connection: "connecting",
+      });
+      expect(connection.isOpen).toBe(false);
+    });
+  });
+
   // A later POST /connections reuses a live connection and mutates its options
   // in place. Anything that rebuilds the socket has to read the current values,
   // or connect() would persist the superseded ones back to Redis and revert a

--- a/src/baileys/connection.spec.ts
+++ b/src/baileys/connection.spec.ts
@@ -2076,6 +2076,53 @@ describe("BaileysConnection", () => {
       }
     });
 
+    // A terminal `loggedOut` close lands while the strike is being written. It
+    // destroys the auth state, so rebuilding a socket afterwards would pair a
+    // fresh QR session conjured out of a logout -- and until close() marked
+    // itself, this connection still looked live enough to ask for one.
+    it("does not restart into a session that was just logged out", async () => {
+      const restarts: string[] = [];
+      connection = new BaileysConnection("+5511999999999", {
+        ...defaultOptions,
+        requestRestart: (reason: string) => restarts.push(reason),
+      });
+      config.baileys.sendStallRestartEnabled = true;
+      await connectOpen();
+      wedge();
+
+      const key = clusterKeys.sendStall("+5511999999999");
+      const setMock = redis.set as unknown as ReturnType<typeof mock>;
+      setMock.mockImplementationOnce(async (k: string, v: string) => {
+        await mockEventHandlers.get("connection.update")?.({
+          connection: "close" as const,
+          lastDisconnect: {
+            error: { output: { statusCode: 401, payload: {} }, message: "x" },
+          },
+        });
+        (
+          redis as unknown as { __stringData: Map<string, string> }
+        ).__stringData.set(k, v);
+        return "OK";
+      });
+
+      try {
+        const start = Date.now();
+        await expect(send()).rejects.toThrow(OperationTimeoutError);
+        await expect(send()).rejects.toThrow(OperationTimeoutError);
+        setSystemTime(new Date(start + 120_000));
+        await expect(send()).rejects.toThrow(OperationTimeoutError);
+        await asyncSleep(0);
+
+        expect(restarts.length).toBe(0);
+        // And the backoff goes with the session rather than being restored for
+        // whatever pairs on this number next.
+        expect(await redis.get(key)).toBe(null);
+      } finally {
+        setSystemTime();
+        await redis.del(key);
+      }
+    });
+
     // Without this, the breaker stays open across an in-place reconnect (the
     // connection object survives a socket drop) and the connection answers 503
     // forever — worse than the original stall, which at least cleared itself

--- a/src/baileys/connection.spec.ts
+++ b/src/baileys/connection.spec.ts
@@ -1779,6 +1779,22 @@ describe("BaileysConnection", () => {
       expect(connection.lastOutgoingAckAt).not.toBeNull();
     });
 
+    // Any non-null timestamp makes sendState read `ok`, so a replacement socket
+    // that has never sent anything would inherit the previous socket's health
+    // report and hold it indefinitely — including one that is itself wedged.
+    it("stops reporting healthy on the replaced socket's evidence", async () => {
+      await connection.connect();
+      await connection.sendMessage("jid@s.whatsapp.net", { text: "hi" });
+      expect(connection.sendState).toBe("ok");
+
+      (connection as unknown as { socket: unknown }).socket = null;
+      await connection.connect();
+
+      expect(connection.lastSendCompletedAt).toBeNull();
+      expect(connection.lastOutgoingAckAt).toBeNull();
+      expect(connection.sendState).toBe("unknown");
+    });
+
     // `fromMe` is true for everything the account sends, including from the phone
     // and from other linked devices — none of which went through this socket's
     // keystore mutex. Counting those would let a busy account keep a wedged

--- a/src/baileys/connection.spec.ts
+++ b/src/baileys/connection.spec.ts
@@ -1721,6 +1721,64 @@ describe("BaileysConnection", () => {
       expect(connection.lastOutgoingAckAt).not.toBeNull();
     });
 
+    // Group delivery and read acknowledgements ride message-receipt.update, not
+    // messages.update. Without this a connection that only writes to groups sits
+    // at `unknown` forever no matter how many recipients confirmed.
+    it("records an outgoing ack from a group receipt", async () => {
+      await connection.connect();
+      await connection.sendMessage(
+        "group@g.us",
+        { text: "hi" },
+        { messageId: "3EB0GROUP" },
+      );
+      expect(connection.lastOutgoingAckAt).toBeNull();
+
+      mockEventHandlers.get("message-receipt.update")?.([
+        {
+          key: { fromMe: true, id: "3EB0GROUP", remoteJid: "group@g.us" },
+          receipt: { userJid: "5511@s.whatsapp.net", receiptTimestamp: 1 },
+        },
+      ]);
+
+      expect(connection.lastOutgoingAckAt).not.toBeNull();
+    });
+
+    // The id history describes the socket that submitted them. A receipt for a
+    // message the PREVIOUS socket sent would otherwise present end-to-end evidence
+    // about a replacement that has sent nothing and may itself be wedged.
+    it("stops honouring acks for ids the replaced socket submitted", async () => {
+      await connection.connect();
+      await connection.sendMessage(
+        "jid@s.whatsapp.net",
+        { text: "hi" },
+        { messageId: "3EB0OLDSOCKET" },
+      );
+
+      // The reconnect path, minus its async scheduling: drop the socket and build
+      // the replacement through the real connect(), which is what bumps the
+      // generation and clears the history.
+      (connection as unknown as { socket: unknown }).socket = null;
+      await connection.connect();
+
+      mockEventHandlers.get("messages.update")?.([
+        { key: { fromMe: true, id: "3EB0OLDSOCKET" }, update: { status: 2 } },
+      ]);
+
+      expect(connection.lastOutgoingAckAt).toBeNull();
+
+      // And the replacement can still prove itself on its own traffic.
+      await connection.sendMessage(
+        "jid@s.whatsapp.net",
+        { text: "hi" },
+        { messageId: "3EB0NEWSOCKET" },
+      );
+      mockEventHandlers.get("messages.update")?.([
+        { key: { fromMe: true, id: "3EB0NEWSOCKET" }, update: { status: 2 } },
+      ]);
+
+      expect(connection.lastOutgoingAckAt).not.toBeNull();
+    });
+
     // `fromMe` is true for everything the account sends, including from the phone
     // and from other linked devices — none of which went through this socket's
     // keystore mutex. Counting those would let a busy account keep a wedged

--- a/src/baileys/connection.spec.ts
+++ b/src/baileys/connection.spec.ts
@@ -2051,6 +2051,149 @@ describe("BaileysConnection", () => {
       }
     });
 
+    // isDiscarded is set by an ordinary replacement too -- a POST /restart, the
+    // lease fence, a respawn -- and those keep the session. Treating them like a
+    // logout wipes the phone's whole 24h history and hands it a clean backoff
+    // slate that an earlier genuine stall already spent.
+    it("keeps the earlier history when the socket is merely replaced", async () => {
+      const restarts: string[] = [];
+      connection = new BaileysConnection("+5511999999999", {
+        ...defaultOptions,
+        requestRestart: (reason: string) => restarts.push(reason),
+      });
+      config.baileys.sendStallRestartEnabled = true;
+      const key = clusterKeys.sendStall("+5511999999999");
+      await redis.set(
+        key,
+        JSON.stringify({ restarts: 1, nextRestartAllowedAt: Date.now() - 1 }),
+      );
+
+      await connectOpen();
+      wedge();
+
+      const setMock = redis.set as unknown as ReturnType<typeof mock>;
+      setMock.mockImplementationOnce(async (k: string, v: string) => {
+        // A concurrent POST /restart discards this socket and spawns its
+        // replacement. The session lives on; only this socket is gone.
+        (connection as unknown as { isDiscarded: boolean }).isDiscarded = true;
+        (
+          redis as unknown as { __stringData: Map<string, string> }
+        ).__stringData.set(k, v);
+        return "OK";
+      });
+
+      try {
+        const start = Date.now();
+        await expect(send()).rejects.toThrow(OperationTimeoutError);
+        await expect(send()).rejects.toThrow(OperationTimeoutError);
+        setSystemTime(new Date(start + 120_000));
+        await expect(send()).rejects.toThrow(OperationTimeoutError);
+        await new Promise((r) => setTimeout(r, 5));
+
+        expect(restarts.length).toBe(0);
+        // Our increment is taken back; the phone's earlier strike stays.
+        expect(JSON.parse((await redis.get(key)) ?? "{}").restarts).toBe(1);
+      } finally {
+        setSystemTime();
+        await redis.del(key);
+      }
+    });
+
+    // The strike is what turns "restarting is not curing this" into "give up and
+    // let the operator see it". Restarting anyway when it cannot be written means
+    // a phone that keeps stalling restarts on every episode for as long as Redis
+    // is unreachable -- and a Redis outage is fleet-wide, so that is every
+    // stalled inbox looping while the system is already degraded.
+    it("suppresses the restart when the strike cannot be written", async () => {
+      const restarts: string[] = [];
+      connection = new BaileysConnection("+5511999999999", {
+        ...defaultOptions,
+        requestRestart: (reason: string) => restarts.push(reason),
+      });
+      config.baileys.sendStallRestartEnabled = true;
+      const record = spyOn(sendStallStore, "recordRestart").mockRejectedValue(
+        new Error("redis down"),
+      );
+
+      try {
+        await connectOpen();
+        wedge();
+        const start = Date.now();
+
+        await expect(send()).rejects.toThrow(OperationTimeoutError);
+        await expect(send()).rejects.toThrow(OperationTimeoutError);
+        setSystemTime(new Date(start + 120_000));
+        fetchCalls.length = 0;
+        await expect(send()).rejects.toThrow(OperationTimeoutError);
+        await new Promise((r) => setTimeout(r, 5));
+
+        expect(record).toHaveBeenCalledTimes(1);
+        expect(restarts.length).toBe(0);
+        const verdicts = fetchCalls
+          .filter((call) => call.body.includes("send_stall_detected"))
+          .map((call) => JSON.parse(call.body).data.sendStall.action);
+        expect(verdicts).toEqual(["suppressed"]);
+
+        // Re-armed on the cooldown, so the connection is due for review again
+        // rather than muted for the life of the socket. The process-wide restart
+        // slot is separate state on the class and runs on performance.now(),
+        // which setSystemTime does not move, so it has to be released by hand or
+        // the second episode is merely deferred instead of re-evaluated.
+        (
+          BaileysConnection as unknown as { lastStallRestartAt: number }
+        ).lastStallRestartAt = Number.NEGATIVE_INFINITY;
+        setSystemTime(new Date(start + 200_000));
+        await expect(send()).rejects.toThrow(BaileysSendStalledError);
+        await new Promise((r) => setTimeout(r, 5));
+        expect(
+          fetchCalls.filter((call) => call.body.includes("send_stall_detected"))
+            .length,
+        ).toBe(2);
+      } finally {
+        record.mockRestore();
+        setSystemTime();
+        await redis.del(clusterKeys.sendStall("+5511999999999"));
+      }
+    });
+
+    // The verdicts are chained, so the delivery starts a microtask later --
+    // while requestRestart discards this connection synchronously. The handler
+    // reads inFlightWebhooks at exactly that moment to decide whether to hold the
+    // old connection open for a graceful shutdown, so the queued verdict has to
+    // be counted before the chain runs, not when it does.
+    it("counts a queued verdict as in flight before the discard sees it", async () => {
+      let inFlightAtRestart = -1;
+      connection = new BaileysConnection("+5511999999999", {
+        ...defaultOptions,
+        requestRestart: () => {
+          // The handler's forceRestart branch, at the line that decides whether
+          // this connection joins drainingWebhooks.
+          inFlightAtRestart = connection.inFlightWebhooks;
+        },
+      });
+      config.baileys.sendStallRestartEnabled = true;
+      const key = clusterKeys.sendStall("+5511999999999");
+
+      try {
+        await connectOpen();
+        wedge();
+        const start = Date.now();
+
+        await expect(send()).rejects.toThrow(OperationTimeoutError);
+        await expect(send()).rejects.toThrow(OperationTimeoutError);
+        setSystemTime(new Date(start + 120_000));
+        await expect(send()).rejects.toThrow(OperationTimeoutError);
+        await new Promise((r) => setTimeout(r, 5));
+
+        expect(inFlightAtRestart).toBeGreaterThan(0);
+        // And it comes back down, or a graceful shutdown would wait forever.
+        expect(connection.inFlightWebhooks).toBe(0);
+      } finally {
+        setSystemTime();
+        await redis.del(key);
+      }
+    });
+
     // The backoff key is per phone number and outlives the session by up to 24h,
     // so a strike written while this session is being torn down is inherited by
     // whatever is paired on that number next -- its watchdog suppressed on the
@@ -2191,8 +2334,11 @@ describe("BaileysConnection", () => {
         expect(JSON.parse(stringData.get(key) ?? "{}").restarts).toBe(2);
 
         // The logout that was holding the handler's slot runs: it ends the
-        // session, and the coordinator DELs this key on the way out.
-        (connection as unknown as { isDiscarded: boolean }).isDiscarded = true;
+        // session, and close() DELs this key on the way out.
+        Object.assign(connection as unknown as Record<string, unknown>, {
+          isDiscarded: true,
+          sessionEnded: true,
+        });
         stringData.delete(key);
 
         // The handler drains, sees the connection is no longer registered, and
@@ -2297,9 +2443,12 @@ describe("BaileysConnection", () => {
 
       const setMock = redis.set as unknown as ReturnType<typeof mock>;
       setMock.mockImplementationOnce(async (k: string, v: string) => {
-        // Logout landing inside the write: it sets isDiscarded before its first
-        // await, and the coordinator DELs this key in its finally.
-        (connection as unknown as { isDiscarded: boolean }).isDiscarded = true;
+        // Logout landing inside the write: it marks the session ended and
+        // discards before its first await, and close() DELs this key.
+        Object.assign(connection as unknown as Record<string, unknown>, {
+          isDiscarded: true,
+          sessionEnded: true,
+        });
         (
           redis as unknown as { __stringData: Map<string, string> }
         ).__stringData.set(k, v);

--- a/src/baileys/connection.spec.ts
+++ b/src/baileys/connection.spec.ts
@@ -1401,6 +1401,129 @@ describe("BaileysConnection", () => {
       await redis.del(clusterKeys.sendStall("+5511999999999"));
     });
 
+    // The one that made the watchdog defeat itself in production. `isOnline` is
+    // a presence echo on the socket we already have — sendPresenceUpdate emits
+    // it, and POST /connections calls exactly that when it reuses a live
+    // connection, which is what the Chatwoot health check does every five
+    // minutes. Treating it as an open would hand a still-wedged socket a clean
+    // breaker on a timer, and every reset lets another batch of sends queue
+    // behind the same stuck mutex.
+    it("does not reopen the circuit for a presence echo on the same socket", async () => {
+      await connection.connect();
+      wedge();
+      await expect(send()).rejects.toThrow(OperationTimeoutError);
+      await expect(send()).rejects.toThrow(OperationTimeoutError);
+      await expect(send()).rejects.toThrow(OperationTimeoutError);
+      expect(connection.sendState).toBe("stalled");
+
+      await mockEventHandlers.get("connection.update")?.({ isOnline: true });
+
+      expect(connection.consecutiveSendTimeouts).toBe(3);
+      expect(connection.sendState).toBe("stalled");
+      await expect(send()).rejects.toThrow(BaileysSendStalledError);
+    });
+
+    // The mirror image: `withTimeout` cannot cancel, so deadlines armed against
+    // the old socket keep running after it is replaced. Unstamped, three of
+    // them expiring after the swap open the breaker on a replacement that never
+    // refused a send.
+    it("ignores timeouts left over from a socket that has been replaced", async () => {
+      await connection.connect();
+      wedge();
+
+      // Three sends parked on the socket that is about to be thrown away.
+      const parked = [send(), send(), send()].map((promise) =>
+        promise.catch((error) => error),
+      );
+
+      await mockEventHandlers.get("connection.update")?.({
+        connection: "close" as const,
+        lastDisconnect: {
+          error: {
+            output: {
+              statusCode: 500,
+              payload: {
+                statusCode: 500,
+                error: "Unknown",
+                message: "Stream Errored",
+              },
+            },
+            message: "Stream Errored",
+          },
+        },
+      });
+      // The replacement socket is healthy.
+      mockSocket.sendMessage.mockImplementation(async () => ({
+        key: { id: "msg-id" },
+      }));
+
+      const settled = await Promise.all(parked);
+      expect(
+        settled.every((error) => error instanceof OperationTimeoutError),
+      ).toBe(true);
+
+      expect(connection.consecutiveSendTimeouts).toBe(0);
+      await expect(send()).resolves.toBeDefined();
+    });
+
+    // A slow FAILING upload empties the mutex queue exactly like a slow
+    // succeeding one. Reporting only late successes latches the breaker on a
+    // connection where nothing is parked at all, and every later plain-text
+    // send answers 503 until the socket is recreated.
+    it("reopens the circuit when an abandoned send finally fails", async () => {
+      await connection.connect();
+      let reject: ((error: unknown) => void) | undefined;
+      mockSocket.sendMessage.mockImplementation(
+        () =>
+          new Promise<never>((_, rej) => {
+            reject = rej;
+          }),
+      );
+
+      await expect(send()).rejects.toThrow(OperationTimeoutError);
+      await expect(send()).rejects.toThrow(OperationTimeoutError);
+      await expect(send()).rejects.toThrow(OperationTimeoutError);
+      expect(connection.sendState).toBe("stalled");
+
+      reject?.(new Error("upload failed"));
+      await asyncSleep(0);
+
+      expect(connection.consecutiveSendTimeouts).toBe(0);
+      // The failure says the queue drained, NOT that a message went out, so the
+      // health timestamp must stay untouched.
+      expect(connection.lastSendCompletedAt).toBeNull();
+      expect(connection.sendState).toBe("unknown");
+    });
+
+    // The exception that makes the rule safe: a rejection that IS the
+    // transaction-mutex timeout reports a wedged mutex, not a freed one.
+    // Closing the breaker on it sends the next batch straight back into the
+    // queue the breaker exists to keep bounded.
+    it("keeps the circuit open when an abandoned send fails on the transaction mutex", async () => {
+      await connection.connect();
+      let reject: ((error: unknown) => void) | undefined;
+      mockSocket.sendMessage.mockImplementation(
+        () =>
+          new Promise<never>((_, rej) => {
+            reject = rej;
+          }),
+      );
+
+      await expect(send()).rejects.toThrow(OperationTimeoutError);
+      await expect(send()).rejects.toThrow(OperationTimeoutError);
+      await expect(send()).rejects.toThrow(OperationTimeoutError);
+
+      reject?.(
+        Object.assign(new Error("keystore transaction timed out"), {
+          data: { key: "+5511999999999", code: "E_TX_MUTEX_TIMEOUT" },
+        }),
+      );
+      await asyncSleep(0);
+
+      expect(connection.consecutiveSendTimeouts).toBe(3);
+      await expect(send()).rejects.toThrow(BaileysSendStalledError);
+    });
+
     it("reports sendState unknown until a send has actually been observed", async () => {
       await connection.connect();
       expect(connection.sendState).toBe("unknown");

--- a/src/baileys/connection.spec.ts
+++ b/src/baileys/connection.spec.ts
@@ -15,8 +15,13 @@ const originalFetch = globalThis.fetch;
 import * as baileysModule from "@whiskeysockets/baileys";
 import config from "@/config";
 import { asyncSleep } from "@/helpers/asyncSleep";
+import { OperationTimeoutError } from "@/helpers/withTimeout";
 import redis from "@/lib/redis";
-import { BaileysConnection, BaileysNotConnectedError } from "./connection";
+import {
+  BaileysConnection,
+  BaileysNotConnectedError,
+  BaileysSendStalledError,
+} from "./connection";
 
 const mockSocket = (baileysModule as any).__mockSocket;
 const mockEventHandlers = (baileysModule as any).__mockEventHandlers;
@@ -1017,6 +1022,280 @@ describe("BaileysConnection", () => {
       await connection.sendMessage("jid@s.whatsapp.net", { text: "hi" });
       const options = mockSocket.sendMessage.mock.calls[0]?.[2];
       expect(Object.keys(options as object)).not.toContain("messageId");
+    });
+  });
+
+  describe("send stall watchdog", () => {
+    const wedge = () =>
+      mockSocket.sendMessage.mockImplementation(
+        () => new Promise<never>(() => {}),
+      );
+    const send = () =>
+      connection.sendMessage("jid@s.whatsapp.net", { text: "hi" });
+
+    beforeEach(() => {
+      config.baileys.sendTimeoutMs = 10;
+      config.baileys.sendStallRestartEnabled = false;
+    });
+
+    afterEach(() => {
+      config.baileys.sendTimeoutMs = 45_000;
+      config.baileys.sendStallRestartEnabled = false;
+      mockSocket.sendMessage.mockImplementation(async () => ({
+        key: { id: "msg-id" },
+      }));
+      // The restart cooldown is process-wide state on the class, so it leaks
+      // between examples: without this reset, whichever example claims the slot
+      // first silently starves every later one for 30 real seconds.
+      (
+        BaileysConnection as unknown as { lastStallRestartAt: number }
+      ).lastStallRestartAt = Number.NEGATIVE_INFINITY;
+    });
+
+    it("fails a send that never completes instead of hanging forever", async () => {
+      await connection.connect();
+      wedge();
+      await expect(send()).rejects.toThrow(OperationTimeoutError);
+    });
+
+    // The circuit breaker. Without it every caller retry parks another
+    // operation behind the wedged keystore mutex, and if that mutex ever
+    // releases while the socket is still open they all fire at once — a burst
+    // of duplicate messages to real customers, hours late.
+    it("stops touching the socket once the connection is known stalled", async () => {
+      await connection.connect();
+      wedge();
+      mockSocket.sendMessage.mockClear();
+
+      await expect(send()).rejects.toThrow(OperationTimeoutError);
+      await expect(send()).rejects.toThrow(OperationTimeoutError);
+      await expect(send()).rejects.toThrow(OperationTimeoutError);
+      await expect(send()).rejects.toThrow(BaileysSendStalledError);
+      await expect(send()).rejects.toThrow(BaileysSendStalledError);
+
+      expect(mockSocket.sendMessage.mock.calls.length).toBe(3);
+    });
+
+    // The failure is total: one success proves the mutex is free, so the
+    // counter has to reset rather than accumulate across unrelated hiccups.
+    it("resets the streak after a send succeeds", async () => {
+      await connection.connect();
+      wedge();
+      await expect(send()).rejects.toThrow(OperationTimeoutError);
+      await expect(send()).rejects.toThrow(OperationTimeoutError);
+      expect(connection.consecutiveSendTimeouts).toBe(2);
+
+      mockSocket.sendMessage.mockImplementation(async () => ({
+        key: { id: "msg-id" },
+      }));
+      await send();
+
+      expect(connection.consecutiveSendTimeouts).toBe(0);
+      expect(connection.sendState).toBe("ok");
+    });
+
+    // Three concurrent sends started together all expire at sendTimeoutMs, so
+    // a bare "three in a row" rule would let one short hiccup recreate a
+    // perfectly healthy socket.
+    it("does not report a stall until the streak has lasted long enough", async () => {
+      await connection.connect();
+      wedge();
+      fetchCalls.length = 0;
+
+      await expect(send()).rejects.toThrow(OperationTimeoutError);
+      await expect(send()).rejects.toThrow(OperationTimeoutError);
+      await expect(send()).rejects.toThrow(OperationTimeoutError);
+
+      expect(
+        fetchCalls.some((call) => call.body.includes("send_stall_detected")),
+      ).toBe(false);
+    });
+
+    // Depth alone latches the breaker, and once it is open no send reaches the
+    // socket, so no further timeout is ever recorded. If the trigger were only
+    // evaluated on a fresh timeout, three concurrent sends would disarm the
+    // watchdog for the life of the socket: 503 forever, no webhook, no restart.
+    it("still reports the stall once the latched streak ages past the minimum", async () => {
+      await connection.connect();
+      wedge();
+      const start = Date.now();
+
+      await expect(send()).rejects.toThrow(OperationTimeoutError);
+      await expect(send()).rejects.toThrow(OperationTimeoutError);
+      await expect(send()).rejects.toThrow(OperationTimeoutError);
+      fetchCalls.length = 0;
+
+      setSystemTime(new Date(start + 120_000));
+      await expect(send()).rejects.toThrow(BaileysSendStalledError);
+      await asyncSleep(0);
+
+      expect(
+        fetchCalls.some((call) => call.body.includes("send_stall_detected")),
+      ).toBe(true);
+      setSystemTime();
+    });
+
+    // The breaker rejects for as long as the socket lives, so an unguarded
+    // re-evaluation would emit one webhook per rejected send.
+    it("reports the stall once per episode, not once per rejected send", async () => {
+      await connection.connect();
+      wedge();
+      const start = Date.now();
+
+      await expect(send()).rejects.toThrow(OperationTimeoutError);
+      await expect(send()).rejects.toThrow(OperationTimeoutError);
+      await expect(send()).rejects.toThrow(OperationTimeoutError);
+      setSystemTime(new Date(start + 120_000));
+      fetchCalls.length = 0;
+
+      await expect(send()).rejects.toThrow(BaileysSendStalledError);
+      await expect(send()).rejects.toThrow(BaileysSendStalledError);
+      await expect(send()).rejects.toThrow(BaileysSendStalledError);
+      await asyncSleep(0);
+
+      expect(
+        fetchCalls.filter((call) => call.body.includes("send_stall_detected"))
+          .length,
+      ).toBe(1);
+      setSystemTime();
+    });
+
+    it("emits send_stall_detected once the streak is long enough", async () => {
+      await connection.connect();
+      wedge();
+      const start = Date.now();
+
+      await expect(send()).rejects.toThrow(OperationTimeoutError);
+      await expect(send()).rejects.toThrow(OperationTimeoutError);
+      // Push the streak past the minimum duration before the third timeout.
+      setSystemTime(new Date(start + 120_000));
+      fetchCalls.length = 0;
+      await expect(send()).rejects.toThrow(OperationTimeoutError);
+      await asyncSleep(0);
+
+      const stall = fetchCalls.find((call) =>
+        call.body.includes("send_stall_detected"),
+      );
+      expect(stall).toBeDefined();
+      const payload = JSON.parse(stall?.body ?? "{}");
+      expect(payload.data.sendStall.action).toBe("suppressed");
+      expect(payload.data.sendStall.consecutiveTimeouts).toBe(3);
+      setSystemTime();
+    });
+
+    // The process-wide cooldown spreads a fleet-wide stall over minutes. It is
+    // a scheduling delay, not a verdict, so the episode must stay open: closing
+    // it here would turn 8 stalled inboxes into 8 alerts and 1 recovery.
+    it("keeps the episode open when the restart is only deferred by the cooldown", async () => {
+      const restarts: string[] = [];
+      connection = new BaileysConnection("+5511999999999", {
+        ...defaultOptions,
+        requestRestart: (reason: string) => restarts.push(reason),
+      });
+      config.baileys.sendStallRestartEnabled = true;
+      // Another connection in this process restarted a moment ago.
+      (
+        BaileysConnection as unknown as { lastStallRestartAt: number }
+      ).lastStallRestartAt = performance.now();
+      await connection.connect();
+      wedge();
+      const start = Date.now();
+
+      await expect(send()).rejects.toThrow(OperationTimeoutError);
+      await expect(send()).rejects.toThrow(OperationTimeoutError);
+      setSystemTime(new Date(start + 120_000));
+      fetchCalls.length = 0;
+      await expect(send()).rejects.toThrow(OperationTimeoutError);
+      await asyncSleep(0);
+
+      // Deferred, not decided: no restart, and no "suppressed" webhook that
+      // would read as a verdict on this connection.
+      expect(restarts.length).toBe(0);
+      expect(
+        fetchCalls.some((call) => call.body.includes("send_stall_detected")),
+      ).toBe(false);
+
+      // The episode is still open, so the next attempt re-evaluates instead of
+      // silently giving up for the life of the socket.
+      await expect(send()).rejects.toThrow(BaileysSendStalledError);
+      await asyncSleep(0);
+      expect(restarts.length).toBe(0);
+
+      setSystemTime();
+    });
+
+    it("recreates the socket through the handler when restart is enabled", async () => {
+      const restarts: string[] = [];
+      connection = new BaileysConnection("+5511999999999", {
+        ...defaultOptions,
+        requestRestart: (reason: string) => restarts.push(reason),
+      });
+      config.baileys.sendStallRestartEnabled = true;
+      await connection.connect();
+      wedge();
+      const start = Date.now();
+
+      await expect(send()).rejects.toThrow(OperationTimeoutError);
+      await expect(send()).rejects.toThrow(OperationTimeoutError);
+      setSystemTime(new Date(start + 120_000));
+      await expect(send()).rejects.toThrow(OperationTimeoutError);
+      await asyncSleep(0);
+
+      expect(restarts.length).toBe(1);
+      expect(restarts[0]).toContain("send stall");
+      setSystemTime();
+    });
+
+    // Without this, the breaker stays open across an in-place reconnect (the
+    // connection object survives a socket drop) and the connection answers 503
+    // forever — worse than the original stall, which at least cleared itself
+    // when WhatsApp dropped the socket.
+    it("reopens the circuit when the connection opens again", async () => {
+      await connection.connect();
+      wedge();
+      await expect(send()).rejects.toThrow(OperationTimeoutError);
+      await expect(send()).rejects.toThrow(OperationTimeoutError);
+      await expect(send()).rejects.toThrow(OperationTimeoutError);
+      await expect(send()).rejects.toThrow(BaileysSendStalledError);
+
+      mockSocket.sendMessage.mockImplementation(async () => ({
+        key: { id: "msg-id" },
+      }));
+      await mockEventHandlers.get("connection.update")?.({
+        connection: "open",
+      });
+
+      expect(connection.consecutiveSendTimeouts).toBe(0);
+      await expect(send()).resolves.toBeDefined();
+    });
+
+    it("reports sendState unknown until a send has actually been observed", async () => {
+      await connection.connect();
+      expect(connection.sendState).toBe("unknown");
+    });
+
+    // markTraffic() fires on inbound traffic too, so it stays fresh while
+    // sending is dead. Only WhatsApp acknowledging one of OUR messages proves
+    // the send path end to end.
+    it("records an outgoing ack from messages.update", async () => {
+      await connection.connect();
+      expect(connection.lastOutgoingAckAt).toBeNull();
+
+      mockEventHandlers.get("messages.update")?.([
+        { key: { fromMe: true, id: "x" }, update: { status: 2 } },
+      ]);
+
+      expect(connection.lastOutgoingAckAt).not.toBeNull();
+    });
+
+    it("ignores status updates for messages that are not ours", async () => {
+      await connection.connect();
+
+      mockEventHandlers.get("messages.update")?.([
+        { key: { fromMe: false, id: "x" }, update: { status: 2 } },
+      ]);
+
+      expect(connection.lastOutgoingAckAt).toBeNull();
     });
   });
 

--- a/src/baileys/connection.spec.ts
+++ b/src/baileys/connection.spec.ts
@@ -1170,6 +1170,63 @@ describe("BaileysConnection", () => {
       expect(mockSocket.sendMessage.mock.calls.length).toBe(3);
     });
 
+    // Once the wedge starts reporting itself through mutex timeouts, every
+    // abandoned send rejects with E_TX_MUTEX_TIMEOUT, which recordLateSettle
+    // refuses to read as recovery. An open breaker means no send reaches the
+    // socket, so the ordinary success path that would close it can never run --
+    // and with restart disabled (the default) the connection would answer 503 for
+    // the life of a socket whose mutex freed itself hours ago.
+    it("closes the breaker when the wedged keystore key is released", async () => {
+      await connectOpen();
+      const baileysModule = (await import("@whiskeysockets/baileys")) as any;
+      const makeSocket = baileysModule.default as ReturnType<typeof mock>;
+      const emit = (event: Record<string, unknown>) =>
+        makeSocket.mock.calls
+          .at(-1)![0]
+          .transactionOpts.onTransactionEvent(event);
+
+      wedge();
+      await expect(send()).rejects.toThrow(OperationTimeoutError);
+      await expect(send()).rejects.toThrow(OperationTimeoutError);
+      await expect(send()).rejects.toThrow(OperationTimeoutError);
+      await expect(send()).rejects.toThrow(BaileysSendStalledError);
+
+      // The wedge names its own key.
+      emit({ phase: "stalled", key: "me@s.whatsapp.net", waitedMs: 0 });
+
+      // A release on a DIFFERENT key proves nothing: the mutexes live in a
+      // per-key map, and this one was never the problem.
+      emit({ phase: "released", key: "lid-mapping", waitedMs: 0, heldMs: 5 });
+      await expect(send()).rejects.toThrow(BaileysSendStalledError);
+
+      emit({
+        phase: "released",
+        key: "me@s.whatsapp.net",
+        waitedMs: 0,
+        heldMs: 120_000,
+      });
+
+      mockSocket.sendMessage.mockClear();
+      await expect(send()).rejects.toThrow(OperationTimeoutError);
+      expect(mockSocket.sendMessage).toHaveBeenCalled();
+    });
+
+    // The mirror of the reconnect finding: maybeReportSendStall already refuses to
+    // call this a stall while the socket is not open, and the REFUSAL has to agree.
+    // The stall-specific 503 tells the caller the connection is up and must not be
+    // marked down, which would cost a handshaking socket the reconnect it needed.
+    it("refuses as not-connected, not as stalled, while the socket is not open", async () => {
+      // Deliberately no `open`: the socket object exists, the handshake does not.
+      await connection.connect();
+      wedge();
+      await expect(send()).rejects.toThrow(OperationTimeoutError);
+      await expect(send()).rejects.toThrow(OperationTimeoutError);
+      await expect(send()).rejects.toThrow(OperationTimeoutError);
+
+      await expect(send()).rejects.toThrow(BaileysNotConnectedError);
+      expect(connection.sendState).not.toBe("stalled");
+    });
+
     // The breaker counts refusals by ONE socket's keystore mutex, and a replacement
     // brings a new one. A streak that survives the swap accuses the wrong socket:
     // two stale timeouts plus one during the new handshake (safeSocket only needs a

--- a/src/baileys/connection.spec.ts
+++ b/src/baileys/connection.spec.ts
@@ -2017,6 +2017,60 @@ describe("BaileysConnection", () => {
       }
     });
 
+    // The other way a restart gets called off, and it undoes differently. This
+    // veto is issued by the handler AFTER it drains the per-number slot, so an
+    // explicit logout queued ahead of the restart is exactly what produces it:
+    // by then the session is gone and the coordinator has DELed the backoff key
+    // in its finally. Restoring the previous episode's value would recreate it
+    // for a session that no longer exists, and hand it to whatever is paired on
+    // this number next.
+    it("does not resurrect the backoff when a logout is what vetoed the restart", async () => {
+      const key = clusterKeys.sendStall("+5511999999999");
+      const stringData = (
+        redis as unknown as { __stringData: Map<string, string> }
+      ).__stringData;
+      // An earlier genuine episode, already past its backoff window.
+      stringData.set(
+        key,
+        JSON.stringify({ restarts: 1, nextRestartAllowedAt: Date.now() - 1 }),
+      );
+
+      const restarts: string[] = [];
+      connection = new BaileysConnection("+5511999999999", {
+        ...defaultOptions,
+        requestRestart: (reason: string) => restarts.push(reason),
+      });
+      config.baileys.sendStallRestartEnabled = true;
+      await connectOpen();
+      wedge();
+
+      try {
+        const start = Date.now();
+        await expect(send()).rejects.toThrow(OperationTimeoutError);
+        await expect(send()).rejects.toThrow(OperationTimeoutError);
+        setSystemTime(new Date(start + 120_000));
+        await expect(send()).rejects.toThrow(OperationTimeoutError);
+        await asyncSleep(0);
+
+        expect(restarts.length).toBe(1);
+        expect(JSON.parse(stringData.get(key) ?? "{}").restarts).toBe(2);
+
+        // The logout that was holding the handler's slot runs: it ends the
+        // session, and the coordinator DELs this key on the way out.
+        (connection as unknown as { isDiscarded: boolean }).isDiscarded = true;
+        stringData.delete(key);
+
+        // The handler drains, sees the connection is no longer registered, and
+        // vetoes the restart it had queued.
+        await connection.withdrawStallRestart();
+
+        expect(await redis.get(key)).toBe(null);
+      } finally {
+        setSystemTime();
+        await redis.del(key);
+      }
+    });
+
     // `action` is documented as whether the socket was recreated, and everything
     // after the decision can still call the restart off. Announcing "restart" up
     // front tells a consumer recovery is underway when it may never start.

--- a/src/baileys/connection.spec.ts
+++ b/src/baileys/connection.spec.ts
@@ -1025,6 +1025,27 @@ describe("BaileysConnection", () => {
     });
   });
 
+  // A later POST /connections reuses a live connection and mutates its options
+  // in place. Anything that rebuilds the socket has to read the current values,
+  // or connect() would persist the superseded ones back to Redis and revert a
+  // webhook reconfiguration.
+  describe("#currentOptions", () => {
+    it("reflects options updated after the connection was built", async () => {
+      await connection.connect();
+      await connection.updateOptions({
+        webhookUrl: "http://example.com/new",
+        webhookVerifyToken: "new-token",
+        leaseEpoch: 7,
+      });
+
+      expect(connection.currentOptions).toMatchObject({
+        webhookUrl: "http://example.com/new",
+        webhookVerifyToken: "new-token",
+        leaseEpoch: 7,
+      });
+    });
+  });
+
   describe("send stall watchdog", () => {
     const wedge = () =>
       mockSocket.sendMessage.mockImplementation(
@@ -1266,6 +1287,38 @@ describe("BaileysConnection", () => {
       });
 
       expect(connection.consecutiveSendTimeouts).toBe(0);
+      await expect(send()).resolves.toBeDefined();
+    });
+
+    // Media generation and upload run inside socket.sendMessage BEFORE the
+    // keystore mutex, so three slow uploads open the breaker with the mutex
+    // perfectly free. Without this the breaker could only ever open: once it is
+    // rejecting, no send reaches the socket, so the success that would close it
+    // can never happen and the connection answers 503 until it reconnects.
+    it("reopens the circuit when an abandoned send finally completes", async () => {
+      await connection.connect();
+      let release: ((value: { key: { id: string } }) => void) | undefined;
+      mockSocket.sendMessage.mockImplementation(
+        () =>
+          new Promise<{ key: { id: string } }>((resolve) => {
+            release = resolve;
+          }),
+      );
+
+      await expect(send()).rejects.toThrow(OperationTimeoutError);
+      await expect(send()).rejects.toThrow(OperationTimeoutError);
+      await expect(send()).rejects.toThrow(OperationTimeoutError);
+      expect(connection.sendState).toBe("stalled");
+
+      // The abandoned upload lands: the socket was never wedged.
+      release?.({ key: { id: "msg-id" } });
+      await asyncSleep(0);
+
+      expect(connection.consecutiveSendTimeouts).toBe(0);
+      expect(connection.sendState).toBe("ok");
+      mockSocket.sendMessage.mockImplementation(async () => ({
+        key: { id: "msg-id" },
+      }));
       await expect(send()).resolves.toBeDefined();
     });
 

--- a/src/baileys/connection.ts
+++ b/src/baileys/connection.ts
@@ -1281,6 +1281,18 @@ export class BaileysConnection {
 
     const { connection, qr, lastDisconnect, isNewLogin, isOnline } = data;
 
+    // Recorded here, before the branches below — several of which return early
+    // (reconnect, wrong number, lease yield) and never reach the assignment near
+    // the bottom of this method. Leaving it to that one means a socket that just
+    // closed keeps reporting `open`, and since the reconnect path creates a
+    // replacement socket on its way out, `isOpen` (and the health endpoint built
+    // on it) would answer `connected: true` for the whole handshake. The
+    // assignment below still runs: it applies the qr/isOnline rewrites, which
+    // describe what the client is told, not what the socket is doing.
+    if (connection) {
+      this.connectionState = connection;
+    }
+
     // WhatsApp's authoritative reach-out time-lock state (the restriction
     // behind error 463). It rides on connection.update — sometimes standalone
     // (no `connection` field), e.g. when emitted by fetchAccountReachoutTimelock

--- a/src/baileys/connection.ts
+++ b/src/baileys/connection.ts
@@ -898,7 +898,13 @@ export class BaileysConnection {
   async sendMessage(
     jid: string,
     messageContent: AnyMessageContent,
-    options?: { quoted?: WAMessage; messageId?: string },
+    options?: {
+      quoted?: WAMessage;
+      messageId?: string;
+      // See relayWithTimeout: fires when this send is later proved never to have
+      // reached WhatsApp, long after its caller was answered.
+      onLateDefinitiveFailure?: () => void;
+    },
   ) {
     this.safeSocket();
     // Before the audio work below, not only inside relayWithTimeout. An open breaker
@@ -976,12 +982,15 @@ export class BaileysConnection {
     if (options?.messageId) {
       this.trackSubmittedId(options.messageId);
     }
-    const sent = await this.relayWithTimeout("sendMessage", () =>
-      this.safeSocket().sendMessage(jid, messageContent, {
-        waveformProxy,
-        quoted: options?.quoted,
-        ...(options?.messageId ? { messageId: options.messageId } : {}),
-      }),
+    const sent = await this.relayWithTimeout(
+      "sendMessage",
+      () =>
+        this.safeSocket().sendMessage(jid, messageContent, {
+          waveformProxy,
+          quoted: options?.quoted,
+          ...(options?.messageId ? { messageId: options.messageId } : {}),
+        }),
+      options?.onLateDefinitiveFailure,
     );
     // Also on the way out, for the sends that let Baileys generate the id: without
     // a reservation this response is the first time we learn it, and an ack for it
@@ -1001,6 +1010,16 @@ export class BaileysConnection {
   // no webhook and no restart.
   private assertCanSend() {
     if (this.inFlightSends >= MAX_IN_FLIGHT_SENDS) {
+      // Same guard the breaker branch below carries, and for the same reason. A
+      // socket that closes with its sends still unresolved keeps every one of
+      // them holding a slot -- the slot belongs to the operation, not to our wait
+      // on it -- so the cap is exactly what a send lands on during an ordinary
+      // outage. Answering `stalled` there tells the caller the connection is up
+      // and must NOT be marked down, which is the opposite of true and costs it
+      // the reconnect it needed.
+      if (!this.isOpen) {
+        throw new BaileysNotConnectedError();
+      }
       logger.warn(
         "[%s] [sendStall] refusing send: %d already in flight",
         this.phoneNumber,
@@ -1036,6 +1055,11 @@ export class BaileysConnection {
   private async relayWithTimeout<T>(
     operation: string,
     fn: () => Promise<T>,
+    // Called when a send that already answered its caller is LATER proved never
+    // to have reached WhatsApp. Only the mutex-acquire timeout proves that: its
+    // waiter never entered txStorage.run, so it read nothing, wrote nothing and
+    // relayed nothing. Everything else that settles late is still ambiguous.
+    onLateDefinitiveFailure?: () => void,
   ): Promise<T> {
     this.assertCanSend();
     // Captured BEFORE the send starts, and carried into every callback below.
@@ -1051,6 +1075,14 @@ export class BaileysConnection {
         config.baileys.sendTimeoutMs,
         fn,
         (error, value) => {
+          // Before recordLateSettle, which drops a discarded or superseded
+          // connection on the way in. That guard is right for the breaker's
+          // bookkeeping and wrong here: "this send never entered the transaction"
+          // stays true whether or not the socket that made it still exists, and
+          // it is the caller's message that is waiting on the answer.
+          if (error !== undefined && isTxMutexTimeout(error)) {
+            onLateDefinitiveFailure?.();
+          }
           // The slot belongs to the OPERATION, not to our wait on it. A timed-out
           // send is still parked in the mutex and still the thing the cap exists
           // to bound, so its slot is only given back here, when the underlying

--- a/src/baileys/connection.ts
+++ b/src/baileys/connection.ts
@@ -275,7 +275,7 @@ export class BaileysConnection {
   // Serializes the send-stall verdicts against each other. See reportSendStall.
   private stallReportChain: Promise<unknown> = Promise.resolve();
   private stallStrikeRollback:
-    | { previous: SendStallState | null; ttlMs: number | null }
+    | { previous: SendStallState | null; ttlMs: number | null; wrote: string }
     | undefined;
   // When each keystore key last gave up acquiring, and when it last released.
   // Both are needed to tell "the wedge is still there" from "it let go while the
@@ -1517,16 +1517,15 @@ export class BaileysConnection {
         // Redis round trip old, and a takeover landing inside that round trip
         // would leave this rebuilding the old owner's socket against the new
         // one's.
-        const [{ previous, previousTtlMs }, ownedElsewhere] = await Promise.all(
-          [
+        const [{ previous, previousTtlMs, wrote }, ownedElsewhere] =
+          await Promise.all([
             recordStallRestart(this.phoneNumber),
             this.shouldYieldToLeaseOwner(),
-          ],
-        );
+          ]);
         // The expiry travels with the value: restoring with a fresh 24h would
         // hand an old history another full day on the strength of a restart that
         // never happened.
-        this.stallStrikeRollback = { previous, ttlMs: previousTtlMs };
+        this.stallStrikeRollback = { previous, ttlMs: previousTtlMs, wrote };
         // Re-checked after the write: all three of these can land inside it,
         // which the guard above cannot see. Undoing is the only way back, since
         // nothing in the store fences a write against a session that has already
@@ -1727,6 +1726,7 @@ export class BaileysConnection {
         this.phoneNumber,
         rollback.previous,
         rollback.ttlMs,
+        rollback.wrote,
       );
     } catch (error) {
       logger.error(

--- a/src/baileys/connection.ts
+++ b/src/baileys/connection.ts
@@ -260,6 +260,26 @@ export class BaileysConnection {
     this._lastTrafficAt = performance.now();
   }
 
+  // The connection's CURRENT options, which are not the ones it was built with:
+  // a later POST /connections reuses a live connection and mutates these in
+  // place via updateOptions. Anything that rebuilds the socket has to read them
+  // from here, because the options captured when it was spawned may since have
+  // been superseded — and persistMetadata would write the stale copy back to
+  // Redis, silently reverting a webhook reconfiguration.
+  get currentOptions(): BaileysConnectionOptions {
+    return {
+      clientName: this.clientName,
+      webhookUrl: this.webhookUrl,
+      webhookVerifyToken: this.webhookVerifyToken,
+      includeMedia: this.includeMedia,
+      syncFullHistory: this.syncFullHistory,
+      groupsEnabled: this.groupsEnabled,
+      autoPresenceSubscribe: this.autoPresenceSubscribe,
+      ...(this._apiKeyHash !== null && { apiKeyHash: this._apiKeyHash }),
+      leaseEpoch: this.leaseEpoch,
+    };
+  }
+
   get lastSendCompletedAt(): number | null {
     return this._lastSendCompletedAt;
   }
@@ -704,11 +724,9 @@ export class BaileysConnection {
         operation,
         config.baileys.sendTimeoutMs,
         fn,
+        () => this.recordLateSend(operation),
       );
-      this._consecutiveSendTimeouts = 0;
-      this.sendStallStreakStartedAt = null;
-      this.sendStallReported = false;
-      this._lastSendCompletedAt = Date.now();
+      this.recordSendSuccess();
       return result;
     } catch (error) {
       if (error instanceof OperationTimeoutError) {
@@ -716,6 +734,38 @@ export class BaileysConnection {
       }
       throw error;
     }
+  }
+
+  private recordSendSuccess() {
+    this._consecutiveSendTimeouts = 0;
+    this.sendStallStreakStartedAt = null;
+    this.sendStallReported = false;
+    // Also the restart request: a send going through proves the socket works, so a
+    // pending restart is moot. Leaving it set would latch the same way the breaker
+    // used to — if the restart never lands (the handler logs and gives up on a
+    // failed connect), this connection could never report a stall again.
+    this.restartRequested = false;
+    this._lastSendCompletedAt = Date.now();
+  }
+
+  // A send we already gave up on finally went through. This is the ONLY signal
+  // that can close the breaker without a new socket: once it is open no send
+  // reaches the socket, so the ordinary success path can never run again. It is
+  // also what keeps a slow-but-healthy connection out of a permanent 503 —
+  // media generation and upload happen inside socket.sendMessage BEFORE the
+  // keystore mutex, so three slow uploads can open the breaker with the mutex
+  // perfectly free, and this is what closes it when they land.
+  private recordLateSend(operation: string) {
+    if (this.isDiscarded) {
+      return;
+    }
+    logger.warn(
+      "[%s] [sendStall] late completion operation=%s afterTimeouts=%d",
+      this.phoneNumber,
+      operation,
+      this._consecutiveSendTimeouts,
+    );
+    this.recordSendSuccess();
   }
 
   private recordSendTimeout(operation: string) {

--- a/src/baileys/connection.ts
+++ b/src/baileys/connection.ts
@@ -957,7 +957,12 @@ export class BaileysConnection {
     }
     // Already closed or reconnecting: the timeouts are explained and recreating
     // the socket adds nothing.
-    if (!this.socket || this.isDiscarded || this.restartRequested) {
+    // isOpen, not "we hold a socket object": during a first connect or a slow
+    // reconnect the socket exists while the handshake is still running, and sends
+    // that time out in that window are an ordinary connection outage, not a wedged
+    // mutex. Reporting one as a stall would tear down a socket that was on its way
+    // up, and do it again on the replacement.
+    if (!this.isOpen || this.isDiscarded || this.restartRequested) {
       return;
     }
     // Silenced before the async work so concurrent rejections cannot each start
@@ -1061,7 +1066,24 @@ export class BaileysConnection {
       return;
     }
 
+    // Last gate before the socket is actually discarded, and the one that matters
+    // most: the webhook above only reports, this destroys a live connection.
+    if (!this.isStallEpisodeCurrent(generation)) {
+      this.sendStallSilentUntil = 0;
+      return;
+    }
     this.restartRequested = true;
+    // Through the handler, never inline: the replacement socket has to
+    // participate in the handler's per-number inFlightOps lock. See
+    // connectionsHandler.spawnConnection.
+    this.requestRestart?.(
+      `send stall: ${this._consecutiveSendTimeouts} consecutive timeouts over ${streakMs}ms`,
+    );
+    // The strike lands only once the restart has actually been asked for. Recorded
+    // before the final gate, a restart cancelled by a connection that recovered
+    // while Redis answered still counted: the backoff store then suppressed the
+    // next genuine stall for five minutes and handed it an inflated interval, on
+    // the strength of a restart that never happened.
     try {
       await recordStallRestart(this.phoneNumber);
     } catch (error) {
@@ -1071,19 +1093,6 @@ export class BaileysConnection {
         errorToString(error),
       );
     }
-    // Last gate before the socket is actually discarded, and the one that matters
-    // most: the webhook above only reports, this destroys a live connection.
-    if (!this.isStallEpisodeCurrent(generation)) {
-      this.restartRequested = false;
-      this.sendStallSilentUntil = 0;
-      return;
-    }
-    // Through the handler, never inline: the replacement socket has to
-    // participate in the handler's per-number inFlightOps lock. See
-    // connectionsHandler.spawnConnection.
-    this.requestRestart?.(
-      `send stall: ${this._consecutiveSendTimeouts} consecutive timeouts over ${streakMs}ms`,
-    );
   }
 
   // Process-wide, not per-connection: the point is to keep a fleet-wide stall

--- a/src/baileys/connection.ts
+++ b/src/baileys/connection.ts
@@ -22,7 +22,10 @@ import makeWASocket, {
 import { toDataURL } from "qrcode";
 import { downloadMediaFromMessages } from "@/baileys/helpers/downloadMediaFromMessages";
 import { fetchBaileysClientVersion } from "@/baileys/helpers/fetchBaileysClientVersion";
-import { isTxMutexTimeout } from "@/baileys/helpers/isTxMutexTimeout";
+import {
+  isTxMutexTimeout,
+  txMutexTimeoutKey,
+} from "@/baileys/helpers/isTxMutexTimeout";
 import { normalizeBrazilPhoneNumber } from "@/baileys/helpers/normalizeBrazilPhoneNumber";
 import { preprocessAudio } from "@/baileys/helpers/preprocessAudio";
 import { shouldIgnoreJid } from "@/baileys/helpers/shouldIgnoreJid";
@@ -336,6 +339,13 @@ export class BaileysConnection {
     return this._consecutiveSendTimeouts;
   }
 
+  // True between asking for a restart and any evidence of recovery. The handler
+  // re-reads it after draining the per-number slot: a restart that queued behind
+  // an unrelated operation must not kill a socket that recovered while it waited.
+  get restartPending(): boolean {
+    return this.restartRequested;
+  }
+
   get isOpen(): boolean {
     return this.connectionState === "open" && this.socket !== null;
   }
@@ -415,11 +425,13 @@ export class BaileysConnection {
       }
       return;
     }
-    // stalled | timeout: this key is the one holding everything up, and knowing
-    // WHICH key is what lets the release above count as evidence. Recorded from
-    // both phases because either can be the only one that fires: `timeout` needs
-    // BAILEYS_TX_ACQUIRE_TIMEOUT_MS enabled, `stalled` needs BAILEYS_TX_HOLD_WARN_MS.
-    this.wedgedTxKey = event.key;
+    // Deliberately NOT the source of wedgedTxKey. `stalled` fires for whatever
+    // key happens to be held past BAILEYS_TX_HOLD_WARN_MS, which is regularly an
+    // unrelated one -- a group transaction, a lid-mapping write. Letting it
+    // overwrite the key would make that transaction's release close the breaker
+    // while the send mutex is still wedged, readmitting a batch into the queue
+    // the breaker exists to bound. Only our own send's failure names the key
+    // that is actually blocking sends.
     logger.warn(
       "[%s] [keystoreTx] %s key=%s waitedMs=%d heldMs=%s stillLocked=%s stack=%s",
       this.phoneNumber,
@@ -919,6 +931,7 @@ export class BaileysConnection {
       if (error instanceof OperationTimeoutError) {
         this.recordSendTimeout(operation, generation);
       } else if (isTxMutexTimeout(error)) {
+        this.noteMutexWedge(error);
         this.recordSendTimeout(operation, generation, "mutex-wedge");
       }
       throw error;
@@ -928,6 +941,20 @@ export class BaileysConnection {
   // True while the argument still describes the live socket. A settlement from
   // an earlier generation is not wrong, it is about a keystore that has since
   // been thrown away, and the watchdog's whole subject is the current one.
+  // Records which keystore key our sends are blocked on, from the Boom the
+  // patched transaction throws. This arms the release-based recovery in
+  // handleTxEvent, and it arms it in exactly the configuration that needs it:
+  // with BAILEYS_TX_ACQUIRE_TIMEOUT_MS at 0 no send ever rejects this way, but
+  // then nothing converts a parked send into a rejection either, so the parked
+  // send eventually succeeds and the ordinary late-success path closes the
+  // breaker on its own.
+  private noteMutexWedge(error: unknown) {
+    const key = txMutexTimeoutKey(error);
+    if (key !== null) {
+      this.wedgedTxKey = key;
+    }
+  }
+
   private isCurrentGeneration(generation: number): boolean {
     return generation === this.socketGeneration;
   }
@@ -996,6 +1023,7 @@ export class BaileysConnection {
     // That burst is the failure this whole file is shaped around, and it is
     // BAILEYS_TX_ACQUIRE_TIMEOUT_MS=0 that reopens it.
     if (error !== undefined && isTxMutexTimeout(error)) {
+      this.noteMutexWedge(error);
       logger.warn(
         "[%s] [sendStall] late tx-mutex timeout operation=%s afterTimeouts=%d (breaker stays open)",
         this.phoneNumber,

--- a/src/baileys/connection.ts
+++ b/src/baileys/connection.ts
@@ -2390,12 +2390,19 @@ export class BaileysConnection {
   // reporting `ok` — the store's own phone answering customers by hand is exactly
   // the situation this signal is supposed to see through.
   private trackOutgoingAck(data: BaileysEventMap["messages.update"]) {
+    // Evidence first, ownership second, and the order is load-bearing:
+    // isOurSubmittedKey has a side effect. It parks an id it does not recognise
+    // so a send that had not yet learned its generated id can claim it
+    // retroactively -- and that claim is read as an acknowledgement. Running it
+    // ahead of the status check parks ids from updates that are not
+    // acknowledgements at all (an ERROR status, or an edit carrying none), and
+    // /health then reports end-to-end delivery for a message WhatsApp rejected.
     const acked = data.some(
       ({ key, update }) =>
-        this.isOurSubmittedKey(key) &&
         update?.status !== undefined &&
         update.status !== null &&
-        update.status >= WAMessageStatus.SERVER_ACK,
+        update.status >= WAMessageStatus.SERVER_ACK &&
+        this.isOurSubmittedKey(key),
     );
     if (acked) {
       this._lastOutgoingAckAt = Date.now();
@@ -2410,12 +2417,15 @@ export class BaileysConnection {
   private trackOutgoingReceiptAck(
     data: BaileysEventMap["message-receipt.update"],
   ) {
+    // Same ordering as trackOutgoingAck, and for the same reason: a receipt with
+    // no timestamp on it is not an acknowledgement, and must not park an id that
+    // a later send would then claim as one.
     const acked = data.some(
       ({ key, receipt }) =>
-        this.isOurSubmittedKey(key) &&
         (receipt?.receiptTimestamp != null ||
           receipt?.readTimestamp != null ||
-          receipt?.playedTimestamp != null),
+          receipt?.playedTimestamp != null) &&
+        this.isOurSubmittedKey(key),
     );
     if (acked) {
       this._lastOutgoingAckAt = Date.now();

--- a/src/baileys/connection.ts
+++ b/src/baileys/connection.ts
@@ -265,6 +265,13 @@ export class BaileysConnection {
   private inFlightSends = 0;
   // The backoff state as it was before this episode's strike, so a restart
   // cancelled after the fact can undo exactly its own increment.
+  // "The session stopped existing", as opposed to "this socket was replaced".
+  // isDiscarded conflates the two -- discard() sets it for an ordinary
+  // replacement (a forceRestart connect, the lease fence, a respawn) just as
+  // logout and close do for a teardown -- and the send-stall rollback has to
+  // tell them apart: a destroyed session's backoff key must go, a replaced
+  // socket's must keep whatever history the phone genuinely earned.
+  private sessionEnded = false;
   // Serializes the send-stall verdicts against each other. See reportSendStall.
   private stallReportChain: Promise<unknown> = Promise.resolve();
   private stallStrikeRollback:
@@ -790,6 +797,8 @@ export class BaileysConnection {
     // session that no longer has credentials: a fresh QR pairing conjured out of
     // a logout. Every other teardown path marks itself; this one has to as well.
     this.isDiscarded = true;
+    // Reached without logout() too, on a remote `loggedOut`.
+    this.sessionEnded = true;
     this.stopGroupActivityFlush();
     if (this.clearOnlinePresenceTimeout) {
       clearTimeout(this.clearOnlinePresenceTimeout);
@@ -817,6 +826,10 @@ export class BaileysConnection {
   }
 
   async logout() {
+    // Terminal for the SESSION, not just for this socket: close() below destroys
+    // the auth state. Marked before the first await so anything crossing it (the
+    // send-stall rollback is the one that bites) sees a session that is ending.
+    this.sessionEnded = true;
     // Mark as discarded up front so any close event the socket emits during
     // the logout flow (e.g. a connectionReplaced from another device while
     // we're awaiting the WhatsApp logout RPC) is treated as terminal by
@@ -1465,10 +1478,13 @@ export class BaileysConnection {
         // Three ways this write can be obsolete by the time it lands, and they
         // undo differently.
         //
-        // isDiscarded: logout began and the coordinator DELs this key in its
-        // finally, so restoring the previous episode's value would resurrect a
+        // sessionEnded: a logout began, and close() DELs this key on its way
+        // out, so restoring the previous episode's value would resurrect a
         // backoff for a session that no longer exists and hand it to whatever is
-        // paired on this number next. Clear instead.
+        // paired on this number next. Clear instead. Not isDiscarded, which a
+        // concurrent POST /restart also sets: that one replaces the socket and
+        // keeps the session, so wiping the phone's history there would hand it a
+        // clean slate an earlier genuine stall already spent.
         //
         // ownedElsewhere: another instance force-acquired the phone. Its socket
         // is the legitimate one, so ours is a duplicate that is still receiving
@@ -1482,9 +1498,16 @@ export class BaileysConnection {
         // and a strike that outlives the restart it stands for suppresses the
         // NEXT genuine stall on the strength of a recovery. The connection is
         // still ours, so only THIS episode's increment is wrong.
-        if (this.isDiscarded) {
+        if (this.sessionEnded) {
           this.stallStrikeRollback = undefined;
           await clearSendStall(this.phoneNumber).catch(() => {});
+          return;
+        }
+        if (this.isDiscarded) {
+          // Replaced, not ended: something else took this socket over while the
+          // strike was landing (a forceRestart connect, the lease fence). The
+          // restart is off, so only THIS episode's increment is wrong.
+          await this.rollBackStallStrike();
           return;
         }
         if (ownedElsewhere) {
@@ -1504,6 +1527,23 @@ export class BaileysConnection {
           this.phoneNumber,
           errorToString(error),
         );
+        // Suppressed, not restarted anyway. The strike is what turns "restarting
+        // is not curing this" into "give up and let the operator see it", so
+        // without one a phone that keeps stalling gets a restart every episode
+        // for as long as Redis is unreachable -- and a Redis outage is fleet-wide
+        // by nature, so that is every stalled inbox reconnecting on a loop while
+        // the system is already degraded. The READ side of the same outage
+        // already suppresses (the backoff-lookup catch above); a failed write is
+        // no different, and answering the same way keeps one outage from having
+        // two behaviours depending on which call it hit.
+        this.restartRequested = false;
+        // Re-armed on the cooldown rather than 0, for the same reason as the
+        // lookup catch: a Redis outage must not turn every rejected send into
+        // its own webhook, and leaving the silence at Infinity would mute this
+        // socket for its lifetime.
+        this.sendStallSilentUntil = Date.now() + SEND_STALL_RESTART_COOLDOWN_MS;
+        this.reportSendStall(streakMs, "suppressed", undefined);
+        return;
       }
     }
 
@@ -1549,10 +1589,23 @@ export class BaileysConnection {
     // reading this whole feature exists to prevent. The wait is bounded by the
     // retry policy, and a retraction arriving late in the right order beats one
     // arriving on time in the wrong one.
+    //
+    // The reservation is taken HERE, synchronously, and not left to
+    // sendToWebhook: the chain does not enter it until a microtask, while
+    // requestRestart discards this connection synchronously on the way out. The
+    // handler reads inFlightWebhooks at exactly that moment to decide whether to
+    // keep the old connection in drainingWebhooks, so a queued verdict that has
+    // not started yet reads as nothing pending -- and a graceful shutdown landing
+    // mid-restart exits without ever delivering the message that says recovery is
+    // underway.
+    this._inFlightWebhooks += 1;
     this.stallReportChain = this.stallReportChain
       .catch(() => {})
       .then(() => this.sendToWebhook(payload))
-      .catch(() => {});
+      .catch(() => {})
+      .finally(() => {
+        this._inFlightWebhooks -= 1;
+      });
   }
 
   // The handler drains its per-number slot before re-checking whether the
@@ -1588,13 +1641,18 @@ export class BaileysConnection {
       // reason: the two ways a restart gets called off undo differently. The
       // veto that lands here is issued by the handler AFTER it drains the
       // per-number slot, so an explicit logout queued ahead of the restart is
-      // exactly what produces it -- and by then the auth state is gone and the
-      // coordinator has DELed this key in its finally. Restoring a previous
-      // episode's value would recreate it for a session that no longer exists
-      // and hand it to whatever is paired on this number next, its watchdog
-      // suppressed on the strength of a socket nobody can reach. Only a
-      // connection that is still ours has an increment worth taking back.
-      if (this.isDiscarded) {
+      // exactly what produces it -- and by then the auth state is gone and
+      // close() has DELed this key. Restoring a previous episode's value would
+      // recreate it for a session that no longer exists and hand it to whatever
+      // is paired on this number next, its watchdog suppressed on the strength
+      // of a socket nobody can reach.
+      //
+      // sessionEnded, not isDiscarded: a concurrent POST /restart produces this
+      // same veto and also sets isDiscarded, but it replaced the socket and kept
+      // the session. Clearing there would hand the phone a clean backoff slate
+      // that an earlier genuine stall already spent, so only this episode's
+      // increment comes back.
+      if (this.sessionEnded) {
         await clearSendStall(this.phoneNumber);
         return;
       }

--- a/src/baileys/connection.ts
+++ b/src/baileys/connection.ts
@@ -632,7 +632,13 @@ export class BaileysConnection {
         errorToString(error),
       );
       this.onConnectionClose?.();
-      return;
+      // Rethrown, not swallowed. Resolving here reports a connect that built
+      // nothing as success: spawnConnection's cleanup never runs, an automatic
+      // restart never reports the failure so the lease is never released, and
+      // POST /restart answers 202 for a socket that does not exist. Every caller
+      // above already handles a rejection -- the claim cycle releases its lease
+      // on one, and the handler removes the entry it had just registered.
+      throw error;
     }
 
     this.addEventListeners({ saveCreds });

--- a/src/baileys/connection.ts
+++ b/src/baileys/connection.ts
@@ -1329,11 +1329,35 @@ export class BaileysConnection {
 
     if (config.baileys.sendStallRestartEnabled) {
       try {
-        const mayRestart = await canRestartAfterStall(this.phoneNumber);
+        // Both reads together, resolved by ONE currency check. Chaining them
+        // would put a second window between the checks in which the socket can
+        // be replaced, and every await on this path has cost us that once.
+        const [mayRestart, ownedElsewhere] = await Promise.all([
+          canRestartAfterStall(this.phoneNumber),
+          this.shouldYieldToLeaseOwner(),
+        ]);
         if (!this.isStallEpisodeCurrent(generation)) {
           // Recovered while Redis was answering. Lower the silence so a fresh
           // episode on the new socket can report itself.
           this.sendStallSilentUntil = 0;
+          return;
+        }
+        // The distributed fence, and this was the one socket-creating path
+        // without it. Every other one consults the lease: the claim cycle
+        // acquires, the explicit paths force-acquire behind a live-owner guard,
+        // and the connectionReplaced kick yields through this same call. The
+        // watchdog decided purely on local state, so a phone force-taken over
+        // while this handler awaited Redis -- another instance acting on a
+        // registry that briefly reported us dead -- would be rebuilt here under
+        // a lease that is no longer ours, fighting the legitimate owner for the
+        // identity until the next renew cycle noticed.
+        //
+        // abort() rather than a bare skip, and for the same reason the renew
+        // cycle discards on this evidence: a socket for a phone somebody else
+        // owns is a duplicate that is still receiving. It preserves the auth
+        // state, so the owner keeps serving the identity.
+        if (ownedElsewhere) {
+          this.abort();
           return;
         }
         if (mayRestart) {

--- a/src/baileys/connection.ts
+++ b/src/baileys/connection.ts
@@ -116,6 +116,11 @@ const SEND_STALL_RESTART_COOLDOWN_MS = 30_000;
 // follows its send within seconds, so this is generous; the cap is what keeps a
 // long-lived busy connection from growing the set without bound.
 const SUBMITTED_ID_HISTORY = 500;
+// Acknowledgements for `fromMe` ids we have not (yet) submitted. Smaller than the
+// submitted history because it only has to cover the gap between WhatsApp
+// acknowledging and socket.sendMessage resolving, and because most entries here
+// are genuinely not ours -- messages the operator sent from the phone.
+const UNMATCHED_ACK_HISTORY = 100;
 
 export class BaileysNotConnectedError extends Error {
   constructor() {
@@ -291,6 +296,7 @@ export class BaileysConnection {
   // an ack that matters arrives seconds after its send, so the oldest entries are
   // dead weight, and an unbounded set on a busy connection is a leak.
   private submittedMessageIds = new Set<string>();
+  private unmatchedAckIds = new Map<string, number>();
 
   constructor(phoneNumber: string, options: BaileysConnectionOptions) {
     this.phoneNumber = phoneNumber;
@@ -337,6 +343,14 @@ export class BaileysConnection {
       }
     }
     this.submittedMessageIds.add(messageId);
+    // The ack may have beaten the id here. Claiming it now is the difference
+    // between "we have never seen this connection deliver anything" and the
+    // truth, on the send whose own response was the slow part.
+    const ackedAt = this.unmatchedAckIds.get(messageId);
+    if (ackedAt !== undefined) {
+      this.unmatchedAckIds.delete(messageId);
+      this._lastOutgoingAckAt = ackedAt;
+    }
   }
 
   // The connection's CURRENT options, which are not the ones it was built with:
@@ -656,6 +670,7 @@ export class BaileysConnection {
       // lastOutgoingAckAt now, presenting end-to-end evidence about a
       // replacement that may itself be wedged and has sent nothing.
       this.submittedMessageIds.clear();
+      this.unmatchedAckIds.clear();
       this.inFlightSends = 0;
       // Both belong to the keystore that just went away.
       this.txTimeoutAt.clear();
@@ -1436,7 +1451,7 @@ export class BaileysConnection {
 
   private reportSendStall(
     streakMs: number,
-    action: "restart" | "suppressed" | "cancelled",
+    action: "restart" | "suppressed" | "cancelled" | "failed",
     until: string | undefined,
   ) {
     logger.warn(
@@ -1465,6 +1480,14 @@ export class BaileysConnection {
   // after this connection committed to it. Two things then have to be undone: the
   // strike, which would otherwise suppress the NEXT genuine stall on the strength
   // of a restart that never happened, and the verdict already sent to consumers.
+  // The restart was asked for and could not rebuild anything. The strike stands
+  // -- an attempt was made and it burned -- but consumers were told the socket
+  // was being recreated, and nothing else would ever correct that. This is the
+  // state where a human has to step in, so it has to be visible.
+  reportFailedStallRestart() {
+    this.reportSendStall(0, "failed", undefined);
+  }
+
   async withdrawStallRestart(streakMs = 0) {
     this.restartRequested = false;
     await this.rollBackStallStrike();
@@ -2177,12 +2200,31 @@ export class BaileysConnection {
   }
 
   private isOurSubmittedKey(key: WAMessageKey | undefined | null): boolean {
-    return (
-      key?.fromMe === true &&
-      key.id !== undefined &&
-      key.id !== null &&
-      this.submittedMessageIds.has(key.id)
-    );
+    if (key?.fromMe !== true || key.id === undefined || key.id === null) {
+      return false;
+    }
+    if (this.submittedMessageIds.has(key.id)) {
+      return true;
+    }
+    // Not ours yet, and it may never be: `fromMe` also covers messages the
+    // operator sent from the phone itself, which must not count as proof that
+    // OUR send path works. But when the caller reserved no messageId we only
+    // learn the generated one once socket.sendMessage resolves, and WhatsApp can
+    // acknowledge before that -- the node is on the wire while the enclosing
+    // keystore transaction is still committing. Held here so trackSubmittedId
+    // can claim it retroactively; if it never does, it decays with the socket.
+    this.rememberUnmatchedAck(key.id);
+    return false;
+  }
+
+  private rememberUnmatchedAck(messageId: string) {
+    if (this.unmatchedAckIds.size >= UNMATCHED_ACK_HISTORY) {
+      const oldest = this.unmatchedAckIds.keys().next().value;
+      if (oldest !== undefined) {
+        this.unmatchedAckIds.delete(oldest);
+      }
+    }
+    this.unmatchedAckIds.set(messageId, Date.now());
   }
 
   private hasAccountRestrictionError(

--- a/src/baileys/connection.ts
+++ b/src/baileys/connection.ts
@@ -549,7 +549,21 @@ export class BaileysConnection {
     // A reused connection may have been re-leased under a newer epoch (e.g. a
     // force-acquire on POST /connections); stale epochs would get the
     // webhooks discarded by the client.
-    if (options.leaseEpoch !== undefined) {
+    //
+    // Forward only, and that is the half that bites. The epoch is a global INCR
+    // per phone, so it only ever grows -- but an explicit operation that acquired
+    // an OLDER one can still be parked before the handler when a newer one
+    // replaces the socket, and it arrives here afterwards carrying its own. Let
+    // it through and a live connection stamps events the client discards as
+    // stale while the coordinator renews an epoch nobody publishes: the channel
+    // simply stops updating. The rest of its options still apply -- it is a real
+    // reconfiguration, just no longer the owner of record. A null carries no
+    // epoch information at all and must not erase one either.
+    if (
+      options.leaseEpoch !== undefined &&
+      (this.leaseEpoch === null ||
+        (options.leaseEpoch !== null && options.leaseEpoch >= this.leaseEpoch))
+    ) {
       this.leaseEpoch = options.leaseEpoch;
     }
     await this.persistMetadata();

--- a/src/baileys/connection.ts
+++ b/src/baileys/connection.ts
@@ -1536,6 +1536,20 @@ export class BaileysConnection {
       return;
     }
     try {
+      // The same fork handleSendStall makes after its own write, for the same
+      // reason: the two ways a restart gets called off undo differently. The
+      // veto that lands here is issued by the handler AFTER it drains the
+      // per-number slot, so an explicit logout queued ahead of the restart is
+      // exactly what produces it -- and by then the auth state is gone and the
+      // coordinator has DELed this key in its finally. Restoring a previous
+      // episode's value would recreate it for a session that no longer exists
+      // and hand it to whatever is paired on this number next, its watchdog
+      // suppressed on the strength of a socket nobody can reach. Only a
+      // connection that is still ours has an increment worth taking back.
+      if (this.isDiscarded) {
+        await clearSendStall(this.phoneNumber);
+        return;
+      }
       await restoreSendStallState(this.phoneNumber, previous);
     } catch (error) {
       logger.error(

--- a/src/baileys/connection.ts
+++ b/src/baileys/connection.ts
@@ -1785,9 +1785,16 @@ export class BaileysConnection {
       Object.assign(data, { connection: "open" });
     }
 
-    if (data.connection) {
-      this.connectionState = data.connection;
-    }
+    // Deliberately NOT re-derived from data.connection here. The two rewrites
+    // above describe what the CLIENT is told, not what the socket is doing:
+    // `isOnline` is a presence echo on the socket we already have, emitted by
+    // sendPresenceUpdate("available") -- which POST /connections calls whenever
+    // it reuses a live connection, i.e. every five minutes from the Chatwoot
+    // health check. Taking it as connectivity makes a socket still finishing its
+    // handshake report `connected: true` on /health, and makes isOpen true, which
+    // is the gate that decides whether a run of send timeouts is an ordinary
+    // reconnect outage or a send stall. The real field was already applied at the
+    // top of this method, before any of the early returns.
 
     if (data.connection === "open") {
       this.reconnectCount = 0;

--- a/src/baileys/connection.ts
+++ b/src/baileys/connection.ts
@@ -92,6 +92,21 @@ const REACHOUT_TIMELOCK_REFETCH_WINDOW_MS = 60_000;
 // sends started together all expire at sendTimeoutMs, which would otherwise let
 // one 45s hiccup with three sends in flight recreate a healthy socket.
 const SEND_STALL_THRESHOLD = 3;
+// Hard ceiling on sends in flight at once, and it is a queue bound rather than a
+// stall detector. The breaker only opens after three COMPLETED timeouts, which
+// is one whole BAILEYS_SEND_TIMEOUT_MS away: everything arriving inside that
+// first window passes an empty counter and parks behind the wedged mutex. Those
+// operations are not cancellable -- withTimeout stops us waiting, nothing stops
+// them running -- so if the mutex frees while the socket is still alive they all
+// fire at once, hours late, at a real customer, while their callers have long
+// since timed out and retried. That burst is the failure this whole file is
+// shaped around, and until this cap its size was "however many sends arrived in
+// 45 seconds", not three.
+//
+// Generous on purpose: the keystore transaction serialises the relay anyway, so
+// concurrency past a handful buys only parallel media uploads, and a healthy
+// connection to one WhatsApp account rarely has eight sends in the air.
+const MAX_IN_FLIGHT_SENDS = 8;
 const SEND_STALL_MIN_DURATION_MS = 90_000;
 // Spreads restarts across a fleet-wide event: with several inboxes stalled at
 // once, they recover over minutes instead of reconnecting simultaneously
@@ -189,6 +204,7 @@ export class BaileysConnection {
   private onConnectionClose: (() => void) | null;
   private requestLogout: (() => void) | null;
   private requestRestart: ((reason: string) => void) | null;
+  private onUnrecoverable: (() => void) | null;
   private socket: ReturnType<typeof makeWASocket> | null;
   private clearAuthState: AuthenticationState["keys"]["clear"] | null;
   private clearOnlinePresenceTimeout: ReturnType<typeof setTimeout> | null =
@@ -239,6 +255,9 @@ export class BaileysConnection {
   // is the only proof the mutex freed itself that arrives while the breaker is
   // open and nothing can reach the socket.
   private wedgedTxKey: string | null = null;
+  // Sends admitted to the current socket and not yet settled. Reset with the
+  // socket, because a parked send never settles and its decrement never comes.
+  private inFlightSends = 0;
   // The backoff state as it was before this episode's strike, so a restart
   // cancelled after the fact can undo exactly its own increment.
   private stallStrikeRollback: SendStallState | null | undefined;
@@ -281,6 +300,7 @@ export class BaileysConnection {
     this.onConnectionClose = options.onConnectionClose || null;
     this.requestLogout = options.requestLogout ?? null;
     this.requestRestart = options.requestRestart ?? null;
+    this.onUnrecoverable = options.onUnrecoverable ?? null;
     this.socket = null;
     this.clearAuthState = null;
     this.isReconnect = !!options.isReconnect;
@@ -636,6 +656,7 @@ export class BaileysConnection {
       // lastOutgoingAckAt now, presenting end-to-end evidence about a
       // replacement that may itself be wedged and has sent nothing.
       this.submittedMessageIds.clear();
+      this.inFlightSends = 0;
       // Both belong to the keystore that just went away.
       this.txTimeoutAt.clear();
       this.txReleasedAt.clear();
@@ -939,6 +960,18 @@ export class BaileysConnection {
   // the watchdog would stay disarmed for the life of the socket, answering 503 with
   // no webhook and no restart.
   private assertCanSend() {
+    if (this.inFlightSends >= MAX_IN_FLIGHT_SENDS) {
+      logger.warn(
+        "[%s] [sendStall] refusing send: %d already in flight",
+        this.phoneNumber,
+        this.inFlightSends,
+      );
+      // The same answer as an open breaker, and for the same reason: the
+      // connection is not accepting sends right now and must NOT be marked down.
+      // Deliberately without maybeReportSendStall -- a full queue is backpressure,
+      // not evidence of a wedge, and it must not spend a restart.
+      throw new BaileysSendStalledError();
+    }
     if (this._consecutiveSendTimeouts < SEND_STALL_THRESHOLD) {
       return;
     }
@@ -971,6 +1004,7 @@ export class BaileysConnection {
     // them expiring after the swap would open the breaker on a healthy
     // replacement that had not refused a single send.
     const generation = this.socketGeneration;
+    this.inFlightSends += 1;
     try {
       const result = await withTimeout(
         operation,
@@ -1003,6 +1037,13 @@ export class BaileysConnection {
         this.recordSendTimeout(operation, generation, "mutex-wedge");
       }
       throw error;
+    } finally {
+      // Only for the socket that admitted it. A parked send never settles, so a
+      // replacement inheriting those decrements would drift its own count
+      // downwards; the counter is reset with the socket instead.
+      if (this.isCurrentGeneration(generation)) {
+        this.inFlightSends -= 1;
+      }
     }
   }
 
@@ -1739,6 +1780,10 @@ export class BaileysConnection {
       if (!this.isDiscarded) {
         this.abort();
       }
+      // abort() gets us out of the handler's registry, but the lease is the
+      // coordinator's and the claim scan skips any phone that still has one.
+      // Same route a failed restart spawn takes, for the same reason.
+      this.onUnrecoverable?.();
     });
   }
 

--- a/src/baileys/connection.ts
+++ b/src/baileys/connection.ts
@@ -529,6 +529,18 @@ export class BaileysConnection {
       // (and only here) is what makes every stamped watchdog reading below
       // mean "observed on the socket that is live right now".
       this.socketGeneration += 1;
+      // The breaker counts refusals by ONE socket's keystore mutex, and this is a
+      // different mutex, so the streak dies with the socket that produced it. Two
+      // things go wrong when it survives. The count carries, so a single timeout
+      // during the new handshake (safeSocket only requires a socket object, and the
+      // replacement has one before `open` arrives) opens the breaker on a connection
+      // that was merely reconnecting, and every later request gets the stall-specific
+      // 503 that tells the caller NOT to mark the channel down. Worse, the streak
+      // CLOCK carries: sendStallStreakStartedAt still points at the old socket, so
+      // the 90s floor — the guard whose whole job is to stop one hiccup from
+      // recreating a healthy socket — is already satisfied and the watchdog restarts
+      // on the first timeout. Clearing on `open` alone is too late for both.
+      this.clearSendStallState();
       // The id history belongs to the socket that submitted them. A delayed
       // receipt for a message the PREVIOUS socket sent would otherwise stamp
       // lastOutgoingAckAt now, presenting end-to-end evidence about a
@@ -814,8 +826,17 @@ export class BaileysConnection {
       this.recordSendSuccess(generation);
       return result;
     } catch (error) {
+      // Both are refusals the breaker must count, and which one arrives first is
+      // decided by config, not by the failure: BAILEYS_TX_ACQUIRE_TIMEOUT_MS can be
+      // set below BAILEYS_SEND_TIMEOUT_MS, and then the wedge reports itself before
+      // our own deadline does. Counting only OperationTimeoutError there would leave
+      // the detector blind in exactly the configuration that detects the wedge
+      // fastest. recordLateSettle already reads this error as wedge evidence; this
+      // is the same reading on the path that runs first.
       if (error instanceof OperationTimeoutError) {
         this.recordSendTimeout(operation, generation);
+      } else if (isTxMutexTimeout(error)) {
+        this.recordSendTimeout(operation, generation, "mutex-wedge");
       }
       throw error;
     }
@@ -909,7 +930,11 @@ export class BaileysConnection {
     }
   }
 
-  private recordSendTimeout(operation: string, generation: number) {
+  private recordSendTimeout(
+    operation: string,
+    generation: number,
+    cause: "timeout" | "mutex-wedge" = "timeout",
+  ) {
     if (!this.isCurrentGeneration(generation)) {
       logger.warn(
         "[%s] [sendStall] ignoring timeout from a replaced socket operation=%s generation=%d current=%d",
@@ -925,8 +950,9 @@ export class BaileysConnection {
     const streakMs = Date.now() - this.sendStallStreakStartedAt;
 
     logger.warn(
-      "[%s] [sendStall] timeout operation=%s consecutive=%d streakMs=%d",
+      "[%s] [sendStall] %s operation=%s consecutive=%d streakMs=%d",
       this.phoneNumber,
+      cause,
       operation,
       this._consecutiveSendTimeouts,
       streakMs,

--- a/src/baileys/connection.ts
+++ b/src/baileys/connection.ts
@@ -214,10 +214,13 @@ export class BaileysConnection {
   private _consecutiveSendTimeouts = 0;
   private sendStallStreakStartedAt: number | null = null;
   private restartRequested = false;
-  // One report per stall episode. Without it the breaker-open path below would
-  // emit a webhook for every rejected send, since the breaker keeps rejecting
-  // for as long as the socket lives.
-  private sendStallReported = false;
+  // When this episode may be reported again. 0 means now; Infinity means never
+  // again on this socket. A finite timestamp is the middle case that matters:
+  // the report was DEFERRED, and the deferral has an expiry the connection
+  // already advertised to the client as `until`. Without it the breaker-open
+  // path would emit a webhook for every rejected send, since the breaker keeps
+  // rejecting for as long as the socket lives.
+  private sendStallSilentUntil = 0;
   // Wall-clock (not performance.now()) so it can be reported as an age to
   // clients and driven by setSystemTime in tests, matching
   // trackConnectionReplaced.
@@ -739,7 +742,7 @@ export class BaileysConnection {
   private recordSendSuccess() {
     this._consecutiveSendTimeouts = 0;
     this.sendStallStreakStartedAt = null;
-    this.sendStallReported = false;
+    this.sendStallSilentUntil = 0;
     // Also the restart request: a send going through proves the socket works, so a
     // pending restart is moot. Leaving it set would latch the same way the breaker
     // used to — if the restart never lands (the handler logs and gives up on a
@@ -789,7 +792,10 @@ export class BaileysConnection {
   // enough: concurrent sends all expire at the same instant, so depth alone
   // would let one 45s hiccup recreate a perfectly healthy socket.
   private maybeReportSendStall() {
-    if (this.sendStallReported || this.sendStallStreakStartedAt === null) {
+    if (
+      Date.now() < this.sendStallSilentUntil ||
+      this.sendStallStreakStartedAt === null
+    ) {
       return;
     }
     if (this._consecutiveSendTimeouts < SEND_STALL_THRESHOLD) {
@@ -806,10 +812,10 @@ export class BaileysConnection {
     if (!this.socket || this.isDiscarded || this.restartRequested) {
       return;
     }
-    // Latched before the async work so concurrent rejections cannot each start
-    // their own episode. Released again only if the restart turns out to be
-    // merely deferred (see the cooldown branch below).
-    this.sendStallReported = true;
+    // Silenced before the async work so concurrent rejections cannot each start
+    // their own episode. handleSendStall lowers this again when the restart
+    // turns out to be merely deferred rather than decided.
+    this.sendStallSilentUntil = Number.POSITIVE_INFINITY;
     void this.handleSendStall(Date.now() - this.sendStallStreakStartedAt);
   }
 
@@ -826,13 +832,18 @@ export class BaileysConnection {
             // neither reported nor closed — the next send attempt re-evaluates
             // once the slot frees. Reporting "suppressed" here would turn a
             // fleet-wide stall into 8 alerts and 1 recovery.
-            this.sendStallReported = false;
+            this.sendStallSilentUntil = 0;
             return;
           }
           action = "restart";
         } else {
           const allowedAt = await nextRestartAllowedAt(this.phoneNumber);
           until = allowedAt ? new Date(allowedAt).toISOString() : undefined;
+          // Reconsider once the backoff we just advertised as `until` expires.
+          // Staying silent past it would make that timestamp a lie: the breaker
+          // rejects every send without touching the socket, so nothing else
+          // would ever bring this connection back up for review.
+          this.sendStallSilentUntil = allowedAt ?? 0;
         }
       } catch (error) {
         logger.error(
@@ -1353,7 +1364,7 @@ export class BaileysConnection {
       // at least cleared itself when WhatsApp dropped the socket.
       this._consecutiveSendTimeouts = 0;
       this.sendStallStreakStartedAt = null;
-      this.sendStallReported = false;
+      this.sendStallSilentUntil = 0;
       this.restartRequested = false;
       // Any healthy open wipes the quarantine strike history — the backoff
       // must reflect CONSECUTIVE failed cycles, not lifetime totals. Not

--- a/src/baileys/connection.ts
+++ b/src/baileys/connection.ts
@@ -741,14 +741,29 @@ export class BaileysConnection {
       if ("audio" in messageContent && Buffer.isBuffer(messageContent.audio)) {
         const originalAudio = messageContent.audio;
         // NOTE: Due to limitations in internal Baileys logic used to generate waveform, we use a wav proxy.
-        [messageContent.audio, waveformProxy] = await Promise.all([
-          preprocessAudio(
-            originalAudio,
-            // NOTE: Use lower quality for ptt messages for more realistic quality.
-            messageContent.ptt ? "ogg-low" : "mp3-high",
-          ),
-          messageContent.ptt ? preprocessAudio(originalAudio, "wav") : null,
-        ]);
+        //
+        // Bounded, and deliberately NOT by the send deadline. This work is local
+        // and legitimately slow, so charging it to the send budget would open the
+        // breaker and recreate a socket that never refused anything. But it runs
+        // BEFORE that deadline is armed, so unbounded it defeats the guarantee
+        // sendTimeoutMs < PROXY_REQUEST_TIMEOUT_MS exists to give: the proxy would
+        // cut first and answer its own generic 504, and the worker would never
+        // reach the code that releases the idempotency lock or counts the stall.
+        // On expiry the catch below sends the original buffer, which is exactly
+        // what already happens when ffmpeg is missing.
+        [messageContent.audio, waveformProxy] = await withTimeout(
+          "preprocessAudio",
+          config.baileys.audioPreprocessTimeoutMs,
+          () =>
+            Promise.all([
+              preprocessAudio(
+                originalAudio,
+                // NOTE: Use lower quality for ptt messages for more realistic quality.
+                messageContent.ptt ? "ogg-low" : "mp3-high",
+              ),
+              messageContent.ptt ? preprocessAudio(originalAudio, "wav") : null,
+            ]),
+        );
         messageContent.mimetype = messageContent.ptt
           ? "audio/ogg; codecs=opus"
           : "audio/mpeg";

--- a/src/baileys/connection.ts
+++ b/src/baileys/connection.ts
@@ -930,7 +930,14 @@ export class BaileysConnection {
       // is the same reading on the path that runs first.
       if (error instanceof OperationTimeoutError) {
         this.recordSendTimeout(operation, generation);
-      } else if (isTxMutexTimeout(error)) {
+      } else if (
+        isTxMutexTimeout(error) &&
+        this.isCurrentGeneration(generation)
+      ) {
+        // Gated together, and the gate has to come first. recordSendTimeout drops
+        // a stale generation on its own, but noteMutexWedge would already have
+        // stamped a replaced socket's key onto the live watchdog -- the same
+        // ordering the late-settlement path gets right.
         this.noteMutexWedge(error);
         this.recordSendTimeout(operation, generation, "mutex-wedge");
       }

--- a/src/baileys/connection.ts
+++ b/src/baileys/connection.ts
@@ -922,7 +922,8 @@ export class BaileysConnection {
         operation,
         config.baileys.sendTimeoutMs,
         fn,
-        (error) => this.recordLateSettle(operation, generation, error),
+        (error, value) =>
+          this.recordLateSettle(operation, generation, error, value),
       );
       this.recordSendSuccess(generation);
       return result;
@@ -1014,6 +1015,7 @@ export class BaileysConnection {
     operation: string,
     generation: number,
     error?: unknown,
+    value?: unknown,
   ) {
     if (this.isDiscarded || !this.isCurrentGeneration(generation)) {
       return;
@@ -1053,6 +1055,18 @@ export class BaileysConnection {
       this._consecutiveSendTimeouts,
     );
     if (error === undefined) {
+      // The id Baileys generated for this message, which the success path would
+      // have recorded and never got to. Without it every receipt for this
+      // message is rejected by isOurSubmittedKey, so lastOutgoingAckAt -- the
+      // only end-to-end evidence there is, and the only one that does not come
+      // from us -- stays null for precisely the send whose outcome was unknown.
+      // Only reachable when the caller reserved no messageId; with one, the
+      // same id was already tracked before the send left.
+      const sentId = (value as { key?: { id?: string | null } } | undefined)
+        ?.key?.id;
+      if (sentId) {
+        this.trackSubmittedId(sentId);
+      }
       this.recordSendSuccess(generation);
       return;
     }
@@ -1268,7 +1282,14 @@ export class BaileysConnection {
         // Re-read after the write: the DEL can land inside it, which the check
         // above cannot see. Undoing is the only way back, since nothing in the
         // store fences a write against a session that has already ended.
-        if (this.isDiscarded) {
+        // Two ways this write can be obsolete by the time it lands, and both
+        // end the same way. isDiscarded: logout began, and the coordinator's DEL
+        // may have already run. !restartRequested: a late send completion or the
+        // wedged key releasing cleared the stall, so the handler's own guard will
+        // veto the restart -- and a strike that outlives the restart it stands
+        // for suppresses the NEXT genuine stall for five minutes on the strength
+        // of a recovery.
+        if (this.isDiscarded || !this.restartRequested) {
           await clearSendStall(this.phoneNumber);
           return;
         }

--- a/src/baileys/connection.ts
+++ b/src/baileys/connection.ts
@@ -360,7 +360,13 @@ export class BaileysConnection {
     const ackedAt = this.unmatchedAckIds.get(messageId);
     if (ackedAt !== undefined) {
       this.unmatchedAckIds.delete(messageId);
-      this._lastOutgoingAckAt = ackedAt;
+      // Never backwards. A parked ack can be claimed long after it arrived --
+      // the send it belongs to may have taken hours to resolve -- and other
+      // sends acknowledge in the meantime. Writing the older timestamp over the
+      // newer one makes /health report a send path staler than it is, which for
+      // a signal whose whole job is "when did WhatsApp last confirm anything"
+      // is the one direction that raises a false alarm.
+      this._lastOutgoingAckAt = Math.max(this._lastOutgoingAckAt ?? 0, ackedAt);
     }
   }
 

--- a/src/baileys/connection.ts
+++ b/src/baileys/connection.ts
@@ -189,6 +189,11 @@ export class BaileysConnection {
   // Noise candidates only while they have never opened; a close after opening
   // is a normal disconnect, not a wrong-key handshake failure.
   private hasOpened = false;
+  // The socket's actual state, as WhatsApp last reported it. Registration in the
+  // handler is NOT connectivity: a connection is registered before it ever opens
+  // (QR pairing) and stays registered while its socket is closed and backing off,
+  // which is exactly when a health check must not claim it is connected.
+  private connectionState: WAConnectionState = "connecting";
   private _inFlightWebhooks = 0;
   private leaseEpoch: number | null = null;
   // Monotonic timestamp of the last message-level traffic (received message,
@@ -293,6 +298,10 @@ export class BaileysConnection {
 
   get consecutiveSendTimeouts(): number {
     return this._consecutiveSendTimeouts;
+  }
+
+  get isOpen(): boolean {
+    return this.connectionState === "open" && this.socket !== null;
   }
 
   // "unknown" is a first-class answer, not a fallback: a connection nobody
@@ -1352,6 +1361,10 @@ export class BaileysConnection {
 
     if (isOnline) {
       Object.assign(data, { connection: "open" });
+    }
+
+    if (data.connection) {
+      this.connectionState = data.connection;
     }
 
     if (data.connection === "open") {

--- a/src/baileys/connection.ts
+++ b/src/baileys/connection.ts
@@ -1461,6 +1461,17 @@ export class BaileysConnection {
         // the life of the socket with the restart it needed never requested.
         // A cooldown rather than 0, so a Redis outage cannot turn every
         // rejected send into its own webhook.
+        //
+        // Guarded like every other path out of an await here. A Redis lookup can
+        // outlive the episode that started it, and an in-place reconnect keeps
+        // THIS object and only bumps the generation -- so the cooldown would land
+        // on the new socket's detector and mute it for a stall it never had,
+        // while the `suppressed` verdict below would describe an episode that is
+        // over.
+        if (!this.isStallEpisodeCurrent(generation)) {
+          this.sendStallSilentUntil = 0;
+          return;
+        }
         this.sendStallSilentUntil = Date.now() + SEND_STALL_RESTART_COOLDOWN_MS;
       }
     }
@@ -1582,7 +1593,17 @@ export class BaileysConnection {
         // already suppresses (the backoff-lookup catch above); a failed write is
         // no different, and answering the same way keeps one outage from having
         // two behaviours depending on which call it hit.
+        // Cleared unconditionally: this handler set it for an episode that is
+        // now over either way, and leaving it would report restartPending on a
+        // connection nobody is restarting.
         this.restartRequested = false;
+        // Same guard as the lookup catch above, and for the same reason: the
+        // write we were waiting on can outlive the episode, and everything below
+        // belongs to that episode.
+        if (!this.isStallEpisodeCurrent(generation)) {
+          this.sendStallSilentUntil = 0;
+          return;
+        }
         // Re-armed on the cooldown rather than 0, for the same reason as the
         // lookup catch: a Redis outage must not turn every rejected send into
         // its own webhook, and leaving the silence at Infinity would mute this

--- a/src/baileys/connection.ts
+++ b/src/baileys/connection.ts
@@ -631,7 +631,11 @@ export class BaileysConnection {
         this.phoneNumber,
         errorToString(error),
       );
-      this.onConnectionClose?.();
+      // Not onConnectionClose here any more: every caller now handles the
+      // rejection and does its own, better cleanup (spawnConnection removes the
+      // entry it just registered and discards; the reconnect path below aborts).
+      // Firing it as well would double-notify and, on the reconnect path, evict
+      // through two routes at once.
       // Rethrown, not swallowed. Resolving here reports a connect that built
       // nothing as success: spawnConnection's cleanup never runs, an automatic
       // restart never reports the failure so the lease is never released, and
@@ -1598,6 +1602,28 @@ export class BaileysConnection {
     return this.socket;
   }
 
+  // Reconnects are fire-and-forget by design -- handleConnectionUpdate must not
+  // block on a handshake -- but connect() rejects when it cannot build a socket
+  // at all (Redis down inside useRedisAuthState, makeWASocket throwing). An
+  // unhandled rejection is fatal in Bun, so one failed reconnect would take the
+  // whole worker down and every other connection with it. Aborting rather than
+  // only logging because a connection left registered with no socket is the dark
+  // phone this change exists to eliminate: abort preserves the auth state and
+  // fires onConnectionClose, so the handler evicts us and the number becomes
+  // claimable again.
+  private reconnectInBackground() {
+    void this.connect().catch((error) => {
+      logger.error(
+        "[%s] [reconnect] could not rebuild socket: %s",
+        this.phoneNumber,
+        errorToString(error),
+      );
+      if (!this.isDiscarded) {
+        this.abort();
+      }
+    });
+  }
+
   private async handleConnectionUpdate(data: Partial<ConnectionState>) {
     // A discarded connection must be inert. `socket.end()` fires a final
     // connection.update before the listeners are torn down; without this
@@ -1715,7 +1741,7 @@ export class BaileysConnection {
           this.reconnectCount = 0;
           await this.handleReconnecting();
           this.socket = null;
-          this.connect();
+          this.reconnectInBackground();
           return;
         }
         // Distributed fence: a conflict/replaced kick may mean another
@@ -1757,7 +1783,7 @@ export class BaileysConnection {
           }
         }
 
-        this.connect();
+        this.reconnectInBackground();
         return;
       }
       await this.close();

--- a/src/baileys/connection.ts
+++ b/src/baileys/connection.ts
@@ -49,6 +49,7 @@ import {
 } from "@/cluster/quarantineStore";
 import {
   canRestart as canRestartAfterStall,
+  clearSendStall,
   nextRestartAllowedAt,
   recordRestart as recordStallRestart,
 } from "@/cluster/sendStallStore";
@@ -820,21 +821,26 @@ export class BaileysConnection {
         // sendTimeoutMs < PROXY_REQUEST_TIMEOUT_MS exists to give: the proxy would
         // cut first and answer its own generic 504, and the worker would never
         // reach the code that releases the idempotency lock or counts the stall.
-        // On expiry the catch below sends the original buffer, which is exactly
-        // what already happens when ffmpeg is missing.
-        [messageContent.audio, waveformProxy] = await withTimeout(
-          "preprocessAudio",
+        //
+        // Expressed as a signal rather than a race, because a race only stops us
+        // waiting: the abandoned conversion would keep its slot in the worker
+        // pool's pending map with a promise nobody can ever settle. On expiry the
+        // catch below sends the original buffer, which is exactly what already
+        // happens when ffmpeg is missing.
+        const preprocessDeadline = AbortSignal.timeout(
           config.baileys.audioPreprocessTimeoutMs,
-          () =>
-            Promise.all([
-              preprocessAudio(
-                originalAudio,
-                // NOTE: Use lower quality for ptt messages for more realistic quality.
-                messageContent.ptt ? "ogg-low" : "mp3-high",
-              ),
-              messageContent.ptt ? preprocessAudio(originalAudio, "wav") : null,
-            ]),
         );
+        [messageContent.audio, waveformProxy] = await Promise.all([
+          preprocessAudio(
+            originalAudio,
+            // NOTE: Use lower quality for ptt messages for more realistic quality.
+            messageContent.ptt ? "ogg-low" : "mp3-high",
+            preprocessDeadline,
+          ),
+          messageContent.ptt
+            ? preprocessAudio(originalAudio, "wav", preprocessDeadline)
+            : null,
+        ]);
         messageContent.mimetype = messageContent.ptt
           ? "audio/ogg; codecs=opus"
           : "audio/mpeg";
@@ -1253,8 +1259,23 @@ export class BaileysConnection {
     // while Redis answered still counted: the backoff store then suppressed the
     // next genuine stall for five minutes and handed it an inflated interval, on
     // the strength of a restart that never happened.
+    // Not while this connection is being torn down. logout() sets isDiscarded
+    // before its first await, and the coordinator DELs the send-stall backoff in
+    // its finally; the store is a plain read-modify-write, so a strike written
+    // across that DEL recreates the state it just removed. The NEXT session
+    // paired on this number then inherits an escalating restart suppression --
+    // up to 24h of it -- on the strength of a socket that no longer exists.
+    if (this.isDiscarded) {
+      return;
+    }
     try {
       await recordStallRestart(this.phoneNumber);
+      // Re-read after the write, because the DEL can land during it and the
+      // check above cannot see that. Undoing is the only way back: nothing in
+      // the store fences a write against a session that has already ended.
+      if (this.isDiscarded) {
+        await clearSendStall(this.phoneNumber);
+      }
     } catch (error) {
       logger.error(
         "[%s] [sendStall] failed to record restart: %s",

--- a/src/baileys/connection.ts
+++ b/src/baileys/connection.ts
@@ -237,6 +237,12 @@ export class BaileysConnection {
   // is the only proof the mutex freed itself that arrives while the breaker is
   // open and nothing can reach the socket.
   private wedgedTxKey: string | null = null;
+  // When each keystore key last gave up acquiring, and when it last released.
+  // Both are needed to tell "the wedge is still there" from "it let go while the
+  // failure was still on its way to us". Keyed by the handful of distinct
+  // keystore keys a socket ever uses, and reset with the socket.
+  private txTimeoutAt = new Map<string, number>();
+  private txReleasedAt = new Map<string, number>();
   // Send-stall watchdog state. Deliberately in memory and never in Redis: a
   // restart gives a new socket, hence a new keystore and a new mutex map, so
   // the count must die with the socket. Persisted state would survive the
@@ -400,6 +406,10 @@ export class BaileysConnection {
       return;
     }
     if (event.phase === "released") {
+      // Recorded for every key, armed or not: the release that matters most is
+      // the one that arrives BEFORE we know which key to watch, while the
+      // acquisition's Boom is still travelling up the send path.
+      this.txReleasedAt.set(event.key, Date.now());
       // The one signal that can close the breaker without a new socket once the
       // wedge starts reporting itself through mutex timeouts. Every abandoned
       // send then rejects with E_TX_MUTEX_TIMEOUT, which recordLateSettle
@@ -425,6 +435,9 @@ export class BaileysConnection {
         this.clearSendStallState();
       }
       return;
+    }
+    if (event.phase === "timeout") {
+      this.txTimeoutAt.set(event.key, Date.now());
     }
     // Deliberately NOT the source of wedgedTxKey. `stalled` fires for whatever
     // key happens to be held past BAILEYS_TX_HOLD_WARN_MS, which is regularly an
@@ -618,6 +631,9 @@ export class BaileysConnection {
       // lastOutgoingAckAt now, presenting end-to-end evidence about a
       // replacement that may itself be wedged and has sent nothing.
       this.submittedMessageIds.clear();
+      // Both belong to the keystore that just went away.
+      this.txTimeoutAt.clear();
+      this.txReleasedAt.clear();
       // And the evidence itself, for the same reason and with more force: any
       // non-null value makes sendState read `ok`, so a replacement that has
       // never sent anything would inherit the previous socket's health report
@@ -871,6 +887,16 @@ export class BaileysConnection {
     // Spread it only when set: Baileys spreads our options over its own
     // `messageId: generateMessageIDV2(user)` default, so an explicit
     // `undefined` would downgrade that default to the user-less fallback.
+    // Again, here, and not only at the top of this method. The audio work above
+    // can await for up to the preprocessing budget, and a reconnect inside that
+    // window clears submittedMessageIds along with the socket that owned them --
+    // so this send would go out on the replacement carrying a reserved id the
+    // history no longer holds, and every ack for it would be rejected as not
+    // ours. Registering it against the socket that is about to carry it is what
+    // makes the history mean what it says.
+    if (options?.messageId) {
+      this.trackSubmittedId(options.messageId);
+    }
     const sent = await this.relayWithTimeout("sendMessage", () =>
       this.safeSocket().sendMessage(jid, messageContent, {
         waveformProxy,
@@ -974,9 +1000,27 @@ export class BaileysConnection {
   // breaker on its own.
   private noteMutexWedge(error: unknown) {
     const key = txMutexTimeoutKey(error);
-    if (key !== null) {
-      this.wedgedTxKey = key;
+    if (key === null) {
+      return;
     }
+    // The holder can let go in the gap between the acquisition giving up and the
+    // Boom reaching here -- a few awaits up the send path. handleTxEvent saw that
+    // release while wedgedTxKey was still null and rightly ignored it, and it was
+    // the ONLY one that key will ever emit. Arming on it now would wait forever
+    // for a second release, and with automatic restart off (the default) nothing
+    // else closes the breaker: 503 for the life of a socket whose mutex is free.
+    const releasedAt = this.txReleasedAt.get(key) ?? 0;
+    const timedOutAt = this.txTimeoutAt.get(key) ?? 0;
+    if (releasedAt >= timedOutAt && releasedAt > 0) {
+      logger.warn(
+        "[%s] [keystoreTx] key=%s released while its timeout was propagating; not arming",
+        this.phoneNumber,
+        key,
+      );
+      this.clearSendStallState();
+      return;
+    }
+    this.wedgedTxKey = key;
   }
 
   private isCurrentGeneration(generation: number): boolean {

--- a/src/baileys/connection.ts
+++ b/src/baileys/connection.ts
@@ -778,6 +778,14 @@ export class BaileysConnection {
   }
 
   private async close() {
+    // Inert from here on. close() is the terminal teardown -- logout, and a
+    // remote `loggedOut` -- and it is where the auth state is destroyed, but it
+    // was leaving isDiscarded false. Anything awaiting across it (the send-stall
+    // watchdog writing its strike is the one that bites) then read a connection
+    // that still looked live and asked the handler to rebuild a socket for a
+    // session that no longer has credentials: a fresh QR pairing conjured out of
+    // a logout. Every other teardown path marks itself; this one has to as well.
+    this.isDiscarded = true;
     this.stopGroupActivityFlush();
     if (this.clearOnlinePresenceTimeout) {
       clearTimeout(this.clearOnlinePresenceTimeout);

--- a/src/baileys/connection.ts
+++ b/src/baileys/connection.ts
@@ -43,9 +43,15 @@ import {
   type QuarantineState,
   recordStrike,
 } from "@/cluster/quarantineStore";
+import {
+  canRestart as canRestartAfterStall,
+  nextRestartAllowedAt,
+  recordRestart as recordStallRestart,
+} from "@/cluster/sendStallStore";
 import config from "@/config";
 import { asyncSleep } from "@/helpers/asyncSleep";
 import { errorToString } from "@/helpers/errorToString";
+import { OperationTimeoutError, withTimeout } from "@/helpers/withTimeout";
 import logger, { baileysLogger, deepSanitizeObject } from "@/lib/logger";
 
 // `connectionReplaced` (440 conflict/replaced) usually clears on the next attempt,
@@ -68,6 +74,23 @@ const MESSAGE_ACCOUNT_RESTRICTION_CODE = "463";
 // once per window per connection.
 const REACHOUT_TIMELOCK_REFETCH_WINDOW_MS = 60_000;
 
+// Send-stall watchdog. Six keystore operations serialize on a mutex keyed by
+// our own JID, so once one of them wedges, EVERY send on this connection times
+// out while receiving and health checks stay perfect -- the connection goes
+// mute without a single error, for minutes or for hours.
+//
+// Consecutive timeouts, not a sliding window: the failure is total, so one
+// success proves the mutex is free and a consecutive counter is the exact shape
+// of the signal. The minimum streak duration exists because three concurrent
+// sends started together all expire at sendTimeoutMs, which would otherwise let
+// one 45s hiccup with three sends in flight recreate a healthy socket.
+const SEND_STALL_THRESHOLD = 3;
+const SEND_STALL_MIN_DURATION_MS = 90_000;
+// Spreads restarts across a fleet-wide event: with several inboxes stalled at
+// once, they recover over minutes instead of reconnecting simultaneously
+// against the same IP.
+const SEND_STALL_RESTART_COOLDOWN_MS = 30_000;
+
 export class BaileysNotConnectedError extends Error {
   constructor() {
     super("Phone number not connected");
@@ -77,6 +100,16 @@ export class BaileysNotConnectedError extends Error {
 export class BaileysConnectionForbiddenError extends Error {
   constructor() {
     super("Connection not owned by this API key");
+  }
+}
+
+// Raised instead of attempting a send the connection is known to be unable to
+// complete. Queueing another operation behind a wedged mutex only grows the
+// burst that fires if the mutex ever releases while the socket is still open —
+// a burst of duplicate messages to real customers, hours late.
+export class BaileysSendStalledError extends Error {
+  constructor() {
+    super("Connection is not accepting sends");
   }
 }
 
@@ -144,6 +177,7 @@ export class BaileysConnection {
   private syncFullHistory: boolean;
   private onConnectionClose: (() => void) | null;
   private requestLogout: (() => void) | null;
+  private requestRestart: ((reason: string) => void) | null;
   private socket: ReturnType<typeof makeWASocket> | null;
   private clearAuthState: AuthenticationState["keys"]["clear"] | null;
   private clearOnlinePresenceTimeout: ReturnType<typeof setTimeout> | null =
@@ -173,6 +207,22 @@ export class BaileysConnection {
   // a 463 (see handleMessagesUpdate / fetchReachoutTimelockOn463).
   private reachoutTimelockFetchInFlight = false;
   private lastReachoutTimelockFetchAt = 0;
+  // Send-stall watchdog state. Deliberately in memory and never in Redis: a
+  // restart gives a new socket, hence a new keystore and a new mutex map, so
+  // the count must die with the socket. Persisted state would survive the
+  // restart and drive a restart loop.
+  private _consecutiveSendTimeouts = 0;
+  private sendStallStreakStartedAt: number | null = null;
+  private restartRequested = false;
+  // One report per stall episode. Without it the breaker-open path below would
+  // emit a webhook for every rejected send, since the breaker keeps rejecting
+  // for as long as the socket lives.
+  private sendStallReported = false;
+  // Wall-clock (not performance.now()) so it can be reported as an age to
+  // clients and driven by setSystemTime in tests, matching
+  // trackConnectionReplaced.
+  private _lastSendCompletedAt: number | null = null;
+  private _lastOutgoingAckAt: number | null = null;
 
   constructor(phoneNumber: string, options: BaileysConnectionOptions) {
     this.phoneNumber = phoneNumber;
@@ -181,6 +231,7 @@ export class BaileysConnection {
     this.webhookVerifyToken = options.webhookVerifyToken;
     this.onConnectionClose = options.onConnectionClose || null;
     this.requestLogout = options.requestLogout ?? null;
+    this.requestRestart = options.requestRestart ?? null;
     this.socket = null;
     this.clearAuthState = null;
     this.isReconnect = !!options.isReconnect;
@@ -207,6 +258,64 @@ export class BaileysConnection {
 
   private markTraffic() {
     this._lastTrafficAt = performance.now();
+  }
+
+  get lastSendCompletedAt(): number | null {
+    return this._lastSendCompletedAt;
+  }
+
+  get lastOutgoingAckAt(): number | null {
+    return this._lastOutgoingAckAt;
+  }
+
+  get consecutiveSendTimeouts(): number {
+    return this._consecutiveSendTimeouts;
+  }
+
+  // "unknown" is a first-class answer, not a fallback: a connection nobody
+  // writes to can be wedged for hours and still look perfect, and reporting it
+  // as healthy is worse than admitting we have not observed a send.
+  get sendState(): "unknown" | "ok" | "degraded" | "stalled" {
+    if (this._consecutiveSendTimeouts >= SEND_STALL_THRESHOLD) {
+      return "stalled";
+    }
+    if (this._consecutiveSendTimeouts > 0) {
+      return "degraded";
+    }
+    if (
+      this._lastSendCompletedAt === null &&
+      this._lastOutgoingAckAt === null
+    ) {
+      return "unknown";
+    }
+    return "ok";
+  }
+
+  // Reported by the patched addTransactionCapability. Logged here rather than
+  // inside the patch because the logger the lib holds is baileysLogger, whose
+  // level is BAILEYS_LOG_LEVEL (often `error` in production) — a warn from
+  // inside the patch would be invisible exactly where it matters.
+  private handleTxEvent(event: {
+    phase: "acquired" | "released" | "stalled" | "timeout";
+    key: string;
+    waitedMs: number;
+    heldMs?: number;
+    originStack?: string;
+    stillLocked?: boolean;
+  }) {
+    if (event.phase === "acquired" || event.phase === "released") {
+      return;
+    }
+    logger.warn(
+      "[%s] [keystoreTx] %s key=%s waitedMs=%d heldMs=%s stillLocked=%s stack=%s",
+      this.phoneNumber,
+      event.phase,
+      event.key,
+      event.waitedMs,
+      event.heldMs ?? "-",
+      event.stillLocked ?? "-",
+      event.originStack ?? "-",
+    );
   }
 
   // biome-ignore lint/suspicious/noExplicitAny: Typing this wrapper is not trivial.
@@ -337,6 +446,20 @@ export class BaileysConnection {
       syncFullHistory: this.syncFullHistory,
       shouldIgnoreJid,
       version,
+      // Deadline for the lib's own HTTP downloads. Read by the patched
+      // getHttpStream; without it an app-state blob download can park forever
+      // inside the keystore transaction and mute this connection's sends.
+      options: { timeoutMs: config.baileys.httpTimeoutMs },
+      // NOTE: The config merge in the lib is shallow, so supplying
+      // transactionOpts replaces the whole default object — maxCommitRetries
+      // and delayBetweenTriesMs must be restated at their upstream defaults.
+      transactionOpts: {
+        maxCommitRetries: 10,
+        delayBetweenTriesMs: 3000,
+        acquireTimeoutMs: config.baileys.txAcquireTimeoutMs,
+        holdWarnMs: config.baileys.txHoldWarnMs,
+        onTransactionEvent: (event) => this.handleTxEvent(event),
+      },
     };
 
     try {
@@ -548,11 +671,191 @@ export class BaileysConnection {
     // Spread it only when set: Baileys spreads our options over its own
     // `messageId: generateMessageIDV2(user)` default, so an explicit
     // `undefined` would downgrade that default to the user-less fallback.
-    return this.safeSocket().sendMessage(jid, messageContent, {
-      waveformProxy,
-      quoted: options?.quoted,
-      ...(options?.messageId ? { messageId: options.messageId } : {}),
+    return this.relayWithTimeout("sendMessage", () =>
+      this.safeSocket().sendMessage(jid, messageContent, {
+        waveformProxy,
+        quoted: options?.quoted,
+        ...(options?.messageId ? { messageId: options.messageId } : {}),
+      }),
+    );
+  }
+
+  // Bounds every path that goes through the socket's sendMessage, which is what
+  // takes the keystore transaction keyed by our own JID. `withTimeout` cannot
+  // cancel the underlying operation — it stays parked in that mutex — so a
+  // timeout means "outcome unknown", and the circuit breaker below is what
+  // keeps the parked queue from growing with every caller retry.
+  private async relayWithTimeout<T>(
+    operation: string,
+    fn: () => Promise<T>,
+  ): Promise<T> {
+    if (this._consecutiveSendTimeouts >= SEND_STALL_THRESHOLD) {
+      // Re-evaluate here, not only when a fresh timeout lands: once the breaker
+      // is open no send reaches the socket, so no further timeout is ever
+      // recorded. Three sends started together all expire at sendTimeoutMs with
+      // a streak near zero, which latches the breaker below the minimum
+      // duration — without this the watchdog would stay disarmed for the life
+      // of the socket, answering 503 with no webhook and no restart.
+      this.maybeReportSendStall();
+      throw new BaileysSendStalledError();
+    }
+    try {
+      const result = await withTimeout(
+        operation,
+        config.baileys.sendTimeoutMs,
+        fn,
+      );
+      this._consecutiveSendTimeouts = 0;
+      this.sendStallStreakStartedAt = null;
+      this.sendStallReported = false;
+      this._lastSendCompletedAt = Date.now();
+      return result;
+    } catch (error) {
+      if (error instanceof OperationTimeoutError) {
+        this.recordSendTimeout(operation);
+      }
+      throw error;
+    }
+  }
+
+  private recordSendTimeout(operation: string) {
+    this._consecutiveSendTimeouts += 1;
+    this.sendStallStreakStartedAt ??= Date.now();
+    const streakMs = Date.now() - this.sendStallStreakStartedAt;
+
+    logger.warn(
+      "[%s] [sendStall] timeout operation=%s consecutive=%d streakMs=%d",
+      this.phoneNumber,
+      operation,
+      this._consecutiveSendTimeouts,
+      streakMs,
+    );
+
+    this.maybeReportSendStall();
+  }
+
+  // The trigger, shared by the timeout path and the breaker-open path. A stall
+  // needs the streak to be both deep enough (consecutive timeouts) and long
+  // enough: concurrent sends all expire at the same instant, so depth alone
+  // would let one 45s hiccup recreate a perfectly healthy socket.
+  private maybeReportSendStall() {
+    if (this.sendStallReported || this.sendStallStreakStartedAt === null) {
+      return;
+    }
+    if (this._consecutiveSendTimeouts < SEND_STALL_THRESHOLD) {
+      return;
+    }
+    if (
+      Date.now() - this.sendStallStreakStartedAt <
+      SEND_STALL_MIN_DURATION_MS
+    ) {
+      return;
+    }
+    // Already closed or reconnecting: the timeouts are explained and recreating
+    // the socket adds nothing.
+    if (!this.socket || this.isDiscarded || this.restartRequested) {
+      return;
+    }
+    // Latched before the async work so concurrent rejections cannot each start
+    // their own episode. Released again only if the restart turns out to be
+    // merely deferred (see the cooldown branch below).
+    this.sendStallReported = true;
+    void this.handleSendStall(Date.now() - this.sendStallStreakStartedAt);
+  }
+
+  private async handleSendStall(streakMs: number) {
+    let action: "restart" | "suppressed" = "suppressed";
+    let until: string | undefined;
+
+    if (config.baileys.sendStallRestartEnabled) {
+      try {
+        if (await canRestartAfterStall(this.phoneNumber)) {
+          if (!BaileysConnection.claimStallRestartSlot()) {
+            // Process-wide cooldown: another connection restarted moments ago.
+            // That is a scheduling delay, not a verdict, so this episode is
+            // neither reported nor closed — the next send attempt re-evaluates
+            // once the slot frees. Reporting "suppressed" here would turn a
+            // fleet-wide stall into 8 alerts and 1 recovery.
+            this.sendStallReported = false;
+            return;
+          }
+          action = "restart";
+        } else {
+          const allowedAt = await nextRestartAllowedAt(this.phoneNumber);
+          until = allowedAt ? new Date(allowedAt).toISOString() : undefined;
+        }
+      } catch (error) {
+        logger.error(
+          "[%s] [sendStall] backoff lookup failed: %s",
+          this.phoneNumber,
+          errorToString(error),
+        );
+      }
+    }
+
+    logger.warn(
+      "[%s] [sendStall] detected consecutiveTimeouts=%d streakMs=%d action=%s",
+      this.phoneNumber,
+      this._consecutiveSendTimeouts,
+      streakMs,
+      action,
+    );
+
+    this.sendToWebhook({
+      event: "connection.update",
+      data: {
+        error: "send_stall_detected",
+        sendStall: {
+          consecutiveTimeouts: this._consecutiveSendTimeouts,
+          stalledForMs: streakMs,
+          action,
+          ...(until && { until }),
+        },
+      },
     });
+
+    if (action !== "restart") {
+      return;
+    }
+
+    this.restartRequested = true;
+    try {
+      await recordStallRestart(this.phoneNumber);
+    } catch (error) {
+      logger.error(
+        "[%s] [sendStall] failed to record restart: %s",
+        this.phoneNumber,
+        errorToString(error),
+      );
+    }
+    // Through the handler, never inline: the replacement socket has to
+    // participate in the handler's per-number inFlightOps lock. See
+    // connectionsHandler.spawnConnection.
+    this.requestRestart?.(
+      `send stall: ${this._consecutiveSendTimeouts} consecutive timeouts over ${streakMs}ms`,
+    );
+  }
+
+  // Process-wide, not per-connection: the point is to keep a fleet-wide stall
+  // from reconnecting every affected socket at the same instant.
+  //
+  // performance.now(), not Date.now(), for the same reason the coordinator uses
+  // it for lastRebalanceReleaseAt: this is a pure elapsed-time gate, and an NTP
+  // step backwards would otherwise suppress every restart until wall clock
+  // caught up. -Infinity because performance.now() starts near zero at boot, so
+  // a 0 sentinel would silently rate-limit the first restart away.
+  private static lastStallRestartAt = Number.NEGATIVE_INFINITY;
+
+  private static claimStallRestartSlot(): boolean {
+    const now = performance.now();
+    if (
+      now - BaileysConnection.lastStallRestartAt <
+      SEND_STALL_RESTART_COOLDOWN_MS
+    ) {
+      return false;
+    }
+    BaileysConnection.lastStallRestartAt = now;
+    return true;
   }
 
   sendPresenceUpdate(type: WAPresence, toJid?: string | undefined) {
@@ -669,7 +972,9 @@ export class BaileysConnection {
   }
 
   deleteMessage(jid: string, key: MessageKeyWithId) {
-    return this.safeSocket().sendMessage(jid, { delete: key });
+    return this.relayWithTimeout("deleteMessage", () =>
+      this.safeSocket().sendMessage(jid, { delete: key }),
+    );
   }
 
   editMessage(
@@ -677,10 +982,12 @@ export class BaileysConnection {
     key: proto.IMessageKey,
     messageContent: AnyMessageContent,
   ) {
-    return this.safeSocket().sendMessage(jid, {
-      ...messageContent,
-      edit: key,
-    } as AnyMessageContent);
+    return this.relayWithTimeout("editMessage", () =>
+      this.safeSocket().sendMessage(jid, {
+        ...messageContent,
+        edit: key,
+      } as AnyMessageContent),
+    );
   }
 
   async profilePictureUrl(jid: string, type?: "preview" | "image") {
@@ -988,6 +1295,16 @@ export class BaileysConnection {
 
     if (data.connection === "open") {
       this.reconnectCount = 0;
+      // A fresh socket means a fresh keystore and a fresh mutex map, so
+      // whatever was wedged is gone. Without this reset the circuit breaker
+      // stays open across an in-place reconnect (the connection object
+      // survives a socket drop) and the connection would answer 503 forever —
+      // worse than the stall it was built to contain, since the original bug
+      // at least cleared itself when WhatsApp dropped the socket.
+      this._consecutiveSendTimeouts = 0;
+      this.sendStallStreakStartedAt = null;
+      this.sendStallReported = false;
+      this.restartRequested = false;
       // Any healthy open wipes the quarantine strike history — the backoff
       // must reflect CONSECUTIVE failed cycles, not lifetime totals. Not
       // awaited (the open path must not block on it), rejection logged.
@@ -1089,6 +1406,8 @@ export class BaileysConnection {
       this.fetchReachoutTimelockOn463();
     }
 
+    this.trackOutgoingAck(data);
+
     this.sendToWebhook(
       {
         event: "messages.update",
@@ -1098,6 +1417,24 @@ export class BaileysConnection {
         awaitResponse: true,
       },
     );
+  }
+
+  // The only end-to-end proof that sending works, short of injecting a probe
+  // message: WhatsApp acknowledging one of OUR messages. markTraffic() fires
+  // before the send and on inbound traffic, so it stays fresh while sending is
+  // dead — it cannot serve as this signal. A resolved socket.sendMessage proves
+  // the keystore mutex was free, not that the server took the message.
+  private trackOutgoingAck(data: BaileysEventMap["messages.update"]) {
+    const acked = data.some(
+      ({ key, update }) =>
+        key?.fromMe === true &&
+        update?.status !== undefined &&
+        update.status !== null &&
+        update.status >= WAMessageStatus.SERVER_ACK,
+    );
+    if (acked) {
+      this._lastOutgoingAckAt = Date.now();
+    }
   }
 
   private hasAccountRestrictionError(

--- a/src/baileys/connection.ts
+++ b/src/baileys/connection.ts
@@ -529,6 +529,11 @@ export class BaileysConnection {
       // (and only here) is what makes every stamped watchdog reading below
       // mean "observed on the socket that is live right now".
       this.socketGeneration += 1;
+      // The id history belongs to the socket that submitted them. A delayed
+      // receipt for a message the PREVIOUS socket sent would otherwise stamp
+      // lastOutgoingAckAt now, presenting end-to-end evidence about a
+      // replacement that may itself be wedged and has sent nothing.
+      this.submittedMessageIds.clear();
     } catch (error) {
       logger.error(
         "[%s] [BaileysConnection.connect] Failed to create socket: %s",
@@ -1696,10 +1701,7 @@ export class BaileysConnection {
   private trackOutgoingAck(data: BaileysEventMap["messages.update"]) {
     const acked = data.some(
       ({ key, update }) =>
-        key?.fromMe === true &&
-        key.id !== undefined &&
-        key.id !== null &&
-        this.submittedMessageIds.has(key.id) &&
+        this.isOurSubmittedKey(key) &&
         update?.status !== undefined &&
         update.status !== null &&
         update.status >= WAMessageStatus.SERVER_ACK,
@@ -1707,6 +1709,35 @@ export class BaileysConnection {
     if (acked) {
       this._lastOutgoingAckAt = Date.now();
     }
+  }
+
+  // The group half of the same signal. A group message's delivery and read
+  // acknowledgements arrive on message-receipt.update, not messages.update, so a
+  // connection that only ever writes to groups would sit at `unknown` forever no
+  // matter how many recipients confirmed — an inbox whose send path is provably
+  // working, reported as never observed.
+  private trackOutgoingReceiptAck(
+    data: BaileysEventMap["message-receipt.update"],
+  ) {
+    const acked = data.some(
+      ({ key, receipt }) =>
+        this.isOurSubmittedKey(key) &&
+        (receipt?.receiptTimestamp != null ||
+          receipt?.readTimestamp != null ||
+          receipt?.playedTimestamp != null),
+    );
+    if (acked) {
+      this._lastOutgoingAckAt = Date.now();
+    }
+  }
+
+  private isOurSubmittedKey(key: WAMessageKey | undefined | null): boolean {
+    return (
+      key?.fromMe === true &&
+      key.id !== undefined &&
+      key.id !== null &&
+      this.submittedMessageIds.has(key.id)
+    );
   }
 
   private hasAccountRestrictionError(
@@ -1765,6 +1796,7 @@ export class BaileysConnection {
     data: BaileysEventMap["message-receipt.update"],
   ) {
     this.markTraffic();
+    this.trackOutgoingReceiptAck(data);
     this.sendToWebhook({
       event: "message-receipt.update",
       data,

--- a/src/baileys/connection.ts
+++ b/src/baileys/connection.ts
@@ -91,6 +91,10 @@ const SEND_STALL_MIN_DURATION_MS = 90_000;
 // once, they recover over minutes instead of reconnecting simultaneously
 // against the same IP.
 const SEND_STALL_RESTART_COOLDOWN_MS = 30_000;
+// How many recently submitted WhatsApp ids to remember for ack matching. An ack
+// follows its send within seconds, so this is generous; the cap is what keeps a
+// long-lived busy connection from growing the set without bound.
+const SUBMITTED_ID_HISTORY = 500;
 
 export class BaileysNotConnectedError extends Error {
   constructor() {
@@ -241,6 +245,11 @@ export class BaileysConnection {
   // trackConnectionReplaced.
   private _lastSendCompletedAt: number | null = null;
   private _lastOutgoingAckAt: number | null = null;
+  // WhatsApp ids this socket actually submitted, so an ack can be told apart from
+  // the same account's traffic on another device. Insertion-ordered and capped:
+  // an ack that matters arrives seconds after its send, so the oldest entries are
+  // dead weight, and an unbounded set on a busy connection is a leak.
+  private submittedMessageIds = new Set<string>();
 
   constructor(phoneNumber: string, options: BaileysConnectionOptions) {
     this.phoneNumber = phoneNumber;
@@ -276,6 +285,16 @@ export class BaileysConnection {
 
   private markTraffic() {
     this._lastTrafficAt = performance.now();
+  }
+
+  private trackSubmittedId(messageId: string) {
+    if (this.submittedMessageIds.size >= SUBMITTED_ID_HISTORY) {
+      const oldest = this.submittedMessageIds.values().next().value;
+      if (oldest !== undefined) {
+        this.submittedMessageIds.delete(oldest);
+      }
+    }
+    this.submittedMessageIds.add(messageId);
   }
 
   // The connection's CURRENT options, which are not the ones it was built with:
@@ -681,8 +700,17 @@ export class BaileysConnection {
     options?: { quoted?: WAMessage; messageId?: string },
   ) {
     this.safeSocket();
+    // Before the audio work below, not only inside relayWithTimeout. An open breaker
+    // means this request is already decided, and preprocessAudio runs up to two ffmpeg
+    // jobs for a PTT: a caller retrying into a stalled connection would burn that CPU
+    // on every attempt to be told 503 at the end. "Fails immediately" has to mean
+    // immediately.
+    this.assertCanSend();
     this.markTraffic();
     this.autoSubscribePresence(jid);
+    if (options?.messageId) {
+      this.trackSubmittedId(options.messageId);
+    }
 
     let waveformProxy: Buffer | null = null;
     try {
@@ -717,13 +745,35 @@ export class BaileysConnection {
     // Spread it only when set: Baileys spreads our options over its own
     // `messageId: generateMessageIDV2(user)` default, so an explicit
     // `undefined` would downgrade that default to the user-less fallback.
-    return this.relayWithTimeout("sendMessage", () =>
+    const sent = await this.relayWithTimeout("sendMessage", () =>
       this.safeSocket().sendMessage(jid, messageContent, {
         waveformProxy,
         quoted: options?.quoted,
         ...(options?.messageId ? { messageId: options.messageId } : {}),
       }),
     );
+    // Also on the way out, for the sends that let Baileys generate the id: without
+    // a reservation this response is the first time we learn it, and an ack for it
+    // still lands afterwards.
+    if (sent?.key?.id) {
+      this.trackSubmittedId(sent.key.id);
+    }
+    return sent;
+  }
+
+  // Throws when the breaker is open, and re-evaluates the episode on the way out.
+  // The re-evaluation belongs here, not only where a fresh timeout lands: once the
+  // breaker is open no send reaches the socket, so no further timeout is ever
+  // recorded. Three sends started together all expire at sendTimeoutMs with a streak
+  // near zero, which latches the breaker below the minimum duration — without this
+  // the watchdog would stay disarmed for the life of the socket, answering 503 with
+  // no webhook and no restart.
+  private assertCanSend() {
+    if (this._consecutiveSendTimeouts < SEND_STALL_THRESHOLD) {
+      return;
+    }
+    this.maybeReportSendStall();
+    throw new BaileysSendStalledError();
   }
 
   // Bounds every path that goes through the socket's sendMessage, which is what
@@ -735,16 +785,7 @@ export class BaileysConnection {
     operation: string,
     fn: () => Promise<T>,
   ): Promise<T> {
-    if (this._consecutiveSendTimeouts >= SEND_STALL_THRESHOLD) {
-      // Re-evaluate here, not only when a fresh timeout lands: once the breaker
-      // is open no send reaches the socket, so no further timeout is ever
-      // recorded. Three sends started together all expire at sendTimeoutMs with
-      // a streak near zero, which latches the breaker below the minimum
-      // duration — without this the watchdog would stay disarmed for the life
-      // of the socket, answering 503 with no webhook and no restart.
-      this.maybeReportSendStall();
-      throw new BaileysSendStalledError();
-    }
+    this.assertCanSend();
     // Captured BEFORE the send starts, and carried into every callback below.
     // A reconnect mid-send replaces the socket while these deadlines keep
     // running against a keystore that no longer exists: unstamped, three of
@@ -840,7 +881,20 @@ export class BaileysConnection {
       this.recordSendSuccess(generation);
       return;
     }
-    this.clearSendStallState();
+    // ONE slot, not the whole streak. A rejection proves this operation left the
+    // queue; it does not prove the mutex is free, because media generation and
+    // upload run BEFORE the transaction is taken — a failing upload can depart
+    // while other sends are still queued behind a wedged mutex. Clearing
+    // everything here would readmit a full batch into that queue and give up the
+    // bound the breaker exists to hold. A late SUCCESS is different, and that is
+    // why it clears: it proves the transaction was both acquired and released.
+    this._consecutiveSendTimeouts = Math.max(
+      0,
+      this._consecutiveSendTimeouts - 1,
+    );
+    if (this._consecutiveSendTimeouts === 0) {
+      this.clearSendStallState();
+    }
   }
 
   private recordSendTimeout(operation: string, generation: number) {
@@ -1632,10 +1686,20 @@ export class BaileysConnection {
   // before the send and on inbound traffic, so it stays fresh while sending is
   // dead — it cannot serve as this signal. A resolved socket.sendMessage proves
   // the keystore mutex was free, not that the server took the message.
+  //
+  // "Ours" means submitted through THIS socket, which `fromMe` does not say: the
+  // same account sending from the phone or another companion device produces
+  // `fromMe` keys too, and none of those went through this connection's keystore
+  // mutex. Accepting them would let a busy account keep a wedged connection
+  // reporting `ok` — the store's own phone answering customers by hand is exactly
+  // the situation this signal is supposed to see through.
   private trackOutgoingAck(data: BaileysEventMap["messages.update"]) {
     const acked = data.some(
       ({ key, update }) =>
         key?.fromMe === true &&
+        key.id !== undefined &&
+        key.id !== null &&
+        this.submittedMessageIds.has(key.id) &&
         update?.status !== undefined &&
         update.status !== null &&
         update.status >= WAMessageStatus.SERVER_ACK,

--- a/src/baileys/connection.ts
+++ b/src/baileys/connection.ts
@@ -52,6 +52,8 @@ import {
   clearSendStall,
   nextRestartAllowedAt,
   recordRestart as recordStallRestart,
+  restoreState as restoreSendStallState,
+  type SendStallState,
 } from "@/cluster/sendStallStore";
 import config from "@/config";
 import { asyncSleep } from "@/helpers/asyncSleep";
@@ -237,6 +239,9 @@ export class BaileysConnection {
   // is the only proof the mutex freed itself that arrives while the breaker is
   // open and nothing can reach the socket.
   private wedgedTxKey: string | null = null;
+  // The backoff state as it was before this episode's strike, so a restart
+  // cancelled after the fact can undo exactly its own increment.
+  private stallStrikeRollback: SendStallState | null | undefined;
   // When each keystore key last gave up acquiring, and when it last released.
   // Both are needed to tell "the wedge is still there" from "it let go while the
   // failure was still on its way to us". Keyed by the handful of distinct
@@ -1284,28 +1289,14 @@ export class BaileysConnection {
       }
     }
 
-    logger.warn(
-      "[%s] [sendStall] detected consecutiveTimeouts=%d streakMs=%d action=%s",
-      this.phoneNumber,
-      this._consecutiveSendTimeouts,
-      streakMs,
-      action,
-    );
-
-    this.sendToWebhook({
-      event: "connection.update",
-      data: {
-        error: "send_stall_detected",
-        sendStall: {
-          consecutiveTimeouts: this._consecutiveSendTimeouts,
-          stalledForMs: streakMs,
-          action,
-          ...(until && { until }),
-        },
-      },
-    });
-
+    // Reported here only when nothing more can cancel it. `action` is documented
+    // as whether the socket was recreated, and everything below can still call
+    // the restart off -- the final gate, the discard check, the recovery check --
+    // so announcing "restart" up front tells a consumer that recovery is underway
+    // when it may not be. The suppressed verdict is final the moment it is
+    // decided, so it goes out now.
     if (action !== "restart") {
+      this.reportSendStall(streakMs, action, until);
       return;
     }
 
@@ -1332,7 +1323,8 @@ export class BaileysConnection {
     // an escalating suppression from a socket that no longer exists.
     if (!this.isDiscarded) {
       try {
-        await recordStallRestart(this.phoneNumber);
+        const { previous } = await recordStallRestart(this.phoneNumber);
+        this.stallStrikeRollback = previous;
         // Re-read after the write: the DEL can land inside it, which the check
         // above cannot see. Undoing is the only way back, since nothing in the
         // store fences a write against a session that has already ended.
@@ -1344,7 +1336,7 @@ export class BaileysConnection {
         // for suppresses the NEXT genuine stall for five minutes on the strength
         // of a recovery.
         if (this.isDiscarded || !this.restartRequested) {
-          await clearSendStall(this.phoneNumber);
+          await this.rollBackStallStrike();
           return;
         }
       } catch (error) {
@@ -1359,9 +1351,67 @@ export class BaileysConnection {
     // Through the handler, never inline: the replacement socket has to
     // participate in the handler's per-number inFlightOps lock. See
     // connectionsHandler.spawnConnection.
+    this.reportSendStall(streakMs, action, until);
     this.requestRestart?.(
       `send stall: ${this._consecutiveSendTimeouts} consecutive timeouts over ${streakMs}ms`,
     );
+  }
+
+  private reportSendStall(
+    streakMs: number,
+    action: "restart" | "suppressed" | "cancelled",
+    until: string | undefined,
+  ) {
+    logger.warn(
+      "[%s] [sendStall] detected consecutiveTimeouts=%d streakMs=%d action=%s",
+      this.phoneNumber,
+      this._consecutiveSendTimeouts,
+      streakMs,
+      action,
+    );
+    this.sendToWebhook({
+      event: "connection.update",
+      data: {
+        error: "send_stall_detected",
+        sendStall: {
+          consecutiveTimeouts: this._consecutiveSendTimeouts,
+          stalledForMs: streakMs,
+          action,
+          ...(until && { until }),
+        },
+      },
+    });
+  }
+
+  // The handler drains its per-number slot before re-checking whether the
+  // restart is still wanted, so a recovery landing in that window vetoes it long
+  // after this connection committed to it. Two things then have to be undone: the
+  // strike, which would otherwise suppress the NEXT genuine stall on the strength
+  // of a restart that never happened, and the verdict already sent to consumers.
+  async withdrawStallRestart(streakMs = 0) {
+    this.restartRequested = false;
+    await this.rollBackStallStrike();
+    this.reportSendStall(streakMs, "cancelled", undefined);
+  }
+
+  // Restores exactly this episode's increment rather than deleting the key: the
+  // history is per phone and lives 24h, so a delete would also wipe an earlier
+  // genuine strike and hand the phone a clean slate it did not earn.
+  private async rollBackStallStrike() {
+    const previous = this.stallStrikeRollback;
+    this.stallStrikeRollback = undefined;
+    if (previous === undefined) {
+      return;
+    }
+    try {
+      await restoreSendStallState(this.phoneNumber, previous);
+    } catch (error) {
+      logger.error(
+        "[%s] [sendStall] failed to roll back strike: %s",
+        this.phoneNumber,
+        errorToString(error),
+      );
+    }
   }
 
   // Process-wide, not per-connection: the point is to keep a fleet-wide stall

--- a/src/baileys/connection.ts
+++ b/src/baileys/connection.ts
@@ -749,6 +749,19 @@ export class BaileysConnection {
     }
     await this.clearAuthState?.();
     this.clearAuthState = null;
+    // Here, not only in the coordinator's logout: this is where the session
+    // stops existing, and every destructive path goes through it -- admin
+    // logoutAll, the wrong-number requestLogout, a remote `loggedOut` close.
+    // The backoff key is per phone number and lives 24h, so without this the
+    // next pairing on that number inherits the discarded session's restart
+    // suppression and its watchdog is disarmed for a stall it never caused.
+    await clearSendStall(this.phoneNumber).catch((error) => {
+      logger.warn(
+        "[%s] [close] failed to clear send-stall backoff: %s",
+        this.phoneNumber,
+        errorToString(error),
+      );
+    });
     this.socket = null;
     this.reconnectCount = 0;
     this.connectionReplacedTimestamps = [];
@@ -1335,7 +1348,18 @@ export class BaileysConnection {
         // veto the restart -- and a strike that outlives the restart it stands
         // for suppresses the NEXT genuine stall for five minutes on the strength
         // of a recovery.
-        if (this.isDiscarded || !this.restartRequested) {
+        // Two ways to be obsolete, and they undo differently. Discarded means
+        // the session is being torn down and its logout has (or will) DELETE
+        // this key: restoring the previous episode's value here would resurrect
+        // a backoff for a session that no longer exists, and hand it to whatever
+        // is paired on this number next. Recovered means the connection is still
+        // ours and healed itself, so only THIS episode's increment is wrong.
+        if (this.isDiscarded) {
+          this.stallStrikeRollback = undefined;
+          await clearSendStall(this.phoneNumber).catch(() => {});
+          return;
+        }
+        if (!this.restartRequested) {
           await this.rollBackStallStrike();
           return;
         }

--- a/src/baileys/connection.ts
+++ b/src/baileys/connection.ts
@@ -226,6 +226,13 @@ export class BaileysConnection {
   // long after its deadlines stopped mattering. Every read and write of the
   // fields below is stamped with the generation it describes.
   private socketGeneration = 0;
+  // Identifies the keystore of the live socket, so events from a replaced one
+  // are ignored. Set only once makeWASocket has returned.
+  private currentTxToken: object | null = null;
+  // Which keystore key the patched transaction reported as wedged. Its release
+  // is the only proof the mutex freed itself that arrives while the breaker is
+  // open and nothing can reach the socket.
+  private wedgedTxKey: string | null = null;
   // Send-stall watchdog state. Deliberately in memory and never in Redis: a
   // restart gives a new socket, hence a new keystore and a new mutex map, so
   // the count must die with the socket. Persisted state would survive the
@@ -337,7 +344,11 @@ export class BaileysConnection {
   // writes to can be wedged for hours and still look perfect, and reporting it
   // as healthy is worse than admitting we have not observed a send.
   get sendState(): "unknown" | "ok" | "degraded" | "stalled" {
-    if (this._consecutiveSendTimeouts >= SEND_STALL_THRESHOLD) {
+    // Same gate as assertCanSend, and for the same reason: "stalled" is what
+    // stalledConnectionCount and the operator read as "up but mute". A socket
+    // that is not open yet is an ordinary outage, and its failing sends are
+    // honestly reported as `degraded` rather than as the fault they are not.
+    if (this._consecutiveSendTimeouts >= SEND_STALL_THRESHOLD && this.isOpen) {
       return "stalled";
     }
     if (this._consecutiveSendTimeouts > 0) {
@@ -356,17 +367,59 @@ export class BaileysConnection {
   // inside the patch because the logger the lib holds is baileysLogger, whose
   // level is BAILEYS_LOG_LEVEL (often `error` in production) — a warn from
   // inside the patch would be invisible exactly where it matters.
-  private handleTxEvent(event: {
-    phase: "acquired" | "released" | "stalled" | "timeout";
-    key: string;
-    waitedMs: number;
-    heldMs?: number;
-    originStack?: string;
-    stillLocked?: boolean;
-  }) {
-    if (event.phase === "acquired" || event.phase === "released") {
+  private handleTxEvent(
+    token: object,
+    event: {
+      phase: "acquired" | "released" | "stalled" | "timeout";
+      key: string;
+      waitedMs: number;
+      heldMs?: number;
+      originStack?: string;
+      stillLocked?: boolean;
+    },
+  ) {
+    // Each socket's keystore closes over its own token. A socket we replaced can
+    // still emit here -- its wedged transaction releases whenever the download it
+    // was waiting on finally dies -- and reading that as news about the live
+    // socket is the same mistake the generation stamp exists to prevent.
+    if (token !== this.currentTxToken) {
       return;
     }
+    if (event.phase === "acquired") {
+      return;
+    }
+    if (event.phase === "released") {
+      // The one signal that can close the breaker without a new socket once the
+      // wedge starts reporting itself through mutex timeouts. Every abandoned
+      // send then rejects with E_TX_MUTEX_TIMEOUT, which recordLateSettle
+      // deliberately refuses to read as recovery, and an open breaker means no
+      // send reaches the socket again -- so the ordinary success path that would
+      // clear it can never run. With BAILEYS_SEND_STALL_RESTART_ENABLED off (the
+      // default, and the whole of the diagnostic rollout) nothing else clears it
+      // either, and the connection answers 503 for the life of a socket whose
+      // mutex has been free for hours.
+      //
+      // Keyed, because a release on any other key proves nothing about the one
+      // that is wedged: the mutexes live in a per-key map.
+      if (this.wedgedTxKey !== null && event.key === this.wedgedTxKey) {
+        if (this._consecutiveSendTimeouts > 0) {
+          logger.warn(
+            "[%s] [keystoreTx] wedged key released, closing the breaker key=%s heldMs=%s afterTimeouts=%d",
+            this.phoneNumber,
+            event.key,
+            event.heldMs ?? "-",
+            this._consecutiveSendTimeouts,
+          );
+        }
+        this.clearSendStallState();
+      }
+      return;
+    }
+    // stalled | timeout: this key is the one holding everything up, and knowing
+    // WHICH key is what lets the release above count as evidence. Recorded from
+    // both phases because either can be the only one that fires: `timeout` needs
+    // BAILEYS_TX_ACQUIRE_TIMEOUT_MS enabled, `stalled` needs BAILEYS_TX_HOLD_WARN_MS.
+    this.wedgedTxKey = event.key;
     logger.warn(
       "[%s] [keystoreTx] %s key=%s waitedMs=%d heldMs=%s stillLocked=%s stack=%s",
       this.phoneNumber,
@@ -496,6 +549,11 @@ export class BaileysConnection {
       },
     };
 
+    // Identity for the keystore this socket is about to be built on, so a
+    // transaction event can be told from one emitted by a socket we replaced.
+    // A token rather than the generation counter because the counter is bumped
+    // only after makeWASocket succeeds, and this closure has to exist before it.
+    const txToken = {};
     const socketOptions: UserFacingSocketConfig = {
       auth: {
         creds: state.creds,
@@ -519,12 +577,13 @@ export class BaileysConnection {
         delayBetweenTriesMs: 3000,
         acquireTimeoutMs: config.baileys.txAcquireTimeoutMs,
         holdWarnMs: config.baileys.txHoldWarnMs,
-        onTransactionEvent: (event) => this.handleTxEvent(event),
+        onTransactionEvent: (event) => this.handleTxEvent(txToken, event),
       },
     };
 
     try {
       this.socket = makeWASocket(socketOptions);
+      this.currentTxToken = txToken;
       // The new socket carries a new keystore and a new mutex map. Bumping here
       // (and only here) is what makes every stamped watchdog reading below
       // mean "observed on the socket that is live right now".
@@ -811,6 +870,15 @@ export class BaileysConnection {
     if (this._consecutiveSendTimeouts < SEND_STALL_THRESHOLD) {
       return;
     }
+    // A stall is a claim about a socket that is UP, and maybeReportSendStall
+    // already refuses to report one otherwise. The refusal has to agree: the
+    // stall-specific 503 tells the caller the connection is up and must NOT be
+    // marked down, which is precisely wrong for a socket still handshaking, and
+    // it would cost the caller the reconnect it needed. Three concurrent sends
+    // expiring during a slow handshake is all it takes to reach the threshold.
+    if (!this.isOpen) {
+      throw new BaileysNotConnectedError();
+    }
     this.maybeReportSendStall();
     throw new BaileysSendStalledError();
   }
@@ -870,6 +938,7 @@ export class BaileysConnection {
   // so it must not touch the health timestamps.
   private clearSendStallState() {
     this._consecutiveSendTimeouts = 0;
+    this.wedgedTxKey = null;
     this.sendStallStreakStartedAt = null;
     this.sendStallSilentUntil = 0;
     // Also the restart request: a send going through proves the socket works, so a
@@ -909,6 +978,23 @@ export class BaileysConnection {
     if (this.isDiscarded || !this.isCurrentGeneration(generation)) {
       return;
     }
+    // And it does not free a queue slot either, which is the other half of why
+    // this branch exists. async-mutex@0.5's withTimeout rejects the wrapper on
+    // expiry but leaves the underlying acquire in the semaphore queue; it only
+    // releases the ticket once the holder finally unlocks (withTimeout.js, the
+    // `if (isTimeout) release()` path). So a timed-out waiter is still queued,
+    // and treating its rejection as "the queue emptied" would be false.
+    //
+    // Deliberately not worked around. Removing the waiter means replacing that
+    // acquisition with a cancellable queue of our own, inside the patch, which
+    // trades a bounded cost for a much larger patch to rebase on every bump. The
+    // cost is bounded: the retained waiters are a promise each, the breaker caps
+    // the send-side ones at three, and draining them is an acquire-then-release
+    // apiece with no work in between. It also buys something -- every drained
+    // ticket releases instead of sending, so an acquire timeout is precisely what
+    // stops a freed mutex from firing hours of queued sends at a real customer.
+    // That burst is the failure this whole file is shaped around, and it is
+    // BAILEYS_TX_ACQUIRE_TIMEOUT_MS=0 that reopens it.
     if (error !== undefined && isTxMutexTimeout(error)) {
       logger.warn(
         "[%s] [sendStall] late tx-mutex timeout operation=%s afterTimeouts=%d (breaker stays open)",

--- a/src/baileys/connection.ts
+++ b/src/baileys/connection.ts
@@ -22,6 +22,7 @@ import makeWASocket, {
 import { toDataURL } from "qrcode";
 import { downloadMediaFromMessages } from "@/baileys/helpers/downloadMediaFromMessages";
 import { fetchBaileysClientVersion } from "@/baileys/helpers/fetchBaileysClientVersion";
+import { isTxMutexTimeout } from "@/baileys/helpers/isTxMutexTimeout";
 import { normalizeBrazilPhoneNumber } from "@/baileys/helpers/normalizeBrazilPhoneNumber";
 import { preprocessAudio } from "@/baileys/helpers/preprocessAudio";
 import { shouldIgnoreJid } from "@/baileys/helpers/shouldIgnoreJid";
@@ -212,6 +213,15 @@ export class BaileysConnection {
   // a 463 (see handleMessagesUpdate / fetchReachoutTimelockOn463).
   private reachoutTimelockFetchInFlight = false;
   private lastReachoutTimelockFetchAt = 0;
+  // Identifies the socket the watchdog state below belongs to. Incremented once
+  // per makeWASocket, which is the ONLY event that gives a fresh keystore and a
+  // fresh mutex map — the two things the watchdog actually reasons about. It
+  // exists because neither side of that state can be trusted without it: an
+  // `isOnline` presence echo arrives as `connection: "open"` on the SAME wedged
+  // socket, and a timeout from a socket that has since been replaced settles
+  // long after its deadlines stopped mattering. Every read and write of the
+  // fields below is stamped with the generation it describes.
+  private socketGeneration = 0;
   // Send-stall watchdog state. Deliberately in memory and never in Redis: a
   // restart gives a new socket, hence a new keystore and a new mutex map, so
   // the count must die with the socket. Persisted state would survive the
@@ -496,6 +506,10 @@ export class BaileysConnection {
 
     try {
       this.socket = makeWASocket(socketOptions);
+      // The new socket carries a new keystore and a new mutex map. Bumping here
+      // (and only here) is what makes every stamped watchdog reading below
+      // mean "observed on the socket that is live right now".
+      this.socketGeneration += 1;
     } catch (error) {
       logger.error(
         "[%s] [BaileysConnection.connect] Failed to create socket: %s",
@@ -731,24 +745,41 @@ export class BaileysConnection {
       this.maybeReportSendStall();
       throw new BaileysSendStalledError();
     }
+    // Captured BEFORE the send starts, and carried into every callback below.
+    // A reconnect mid-send replaces the socket while these deadlines keep
+    // running against a keystore that no longer exists: unstamped, three of
+    // them expiring after the swap would open the breaker on a healthy
+    // replacement that had not refused a single send.
+    const generation = this.socketGeneration;
     try {
       const result = await withTimeout(
         operation,
         config.baileys.sendTimeoutMs,
         fn,
-        () => this.recordLateSend(operation),
+        (error) => this.recordLateSettle(operation, generation, error),
       );
-      this.recordSendSuccess();
+      this.recordSendSuccess(generation);
       return result;
     } catch (error) {
       if (error instanceof OperationTimeoutError) {
-        this.recordSendTimeout(operation);
+        this.recordSendTimeout(operation, generation);
       }
       throw error;
     }
   }
 
-  private recordSendSuccess() {
+  // True while the argument still describes the live socket. A settlement from
+  // an earlier generation is not wrong, it is about a keystore that has since
+  // been thrown away, and the watchdog's whole subject is the current one.
+  private isCurrentGeneration(generation: number): boolean {
+    return generation === this.socketGeneration;
+  }
+
+  // Clears the breaker without asserting anything about a send having landed.
+  // Split out because a late REJECTION proves the operation left the mutex
+  // queue (which is what the breaker counts) but proves nothing about delivery,
+  // so it must not touch the health timestamps.
+  private clearSendStallState() {
     this._consecutiveSendTimeouts = 0;
     this.sendStallStreakStartedAt = null;
     this.sendStallSilentUntil = 0;
@@ -757,30 +788,72 @@ export class BaileysConnection {
     // used to — if the restart never lands (the handler logs and gives up on a
     // failed connect), this connection could never report a stall again.
     this.restartRequested = false;
+  }
+
+  private recordSendSuccess(generation: number) {
+    if (!this.isCurrentGeneration(generation)) {
+      return;
+    }
+    this.clearSendStallState();
     this._lastSendCompletedAt = Date.now();
   }
 
-  // A send we already gave up on finally went through. This is the ONLY signal
-  // that can close the breaker without a new socket: once it is open no send
-  // reaches the socket, so the ordinary success path can never run again. It is
-  // also what keeps a slow-but-healthy connection out of a permanent 503 —
-  // media generation and upload happen inside socket.sendMessage BEFORE the
-  // keystore mutex, so three slow uploads can open the breaker with the mutex
-  // perfectly free, and this is what closes it when they land.
-  private recordLateSend(operation: string) {
-    if (this.isDiscarded) {
+  // A send we already gave up on finally settled. This is the ONLY signal that
+  // can close the breaker without a new socket: once it is open no send reaches
+  // the socket, so the ordinary success path can never run again. It is also
+  // what keeps a slow-but-healthy connection out of a permanent 503 — media
+  // generation and upload happen inside socket.sendMessage BEFORE the keystore
+  // mutex, so three slow uploads can open the breaker with the mutex perfectly
+  // free, and this is what closes it when they land.
+  //
+  // `error` present means the abandoned operation rejected. That still empties
+  // the mutex queue, so it still closes the breaker — with one exception, and
+  // it is the exception that matters: a rejection that IS the transaction-mutex
+  // timeout reports a wedged mutex, not a freed one. Closing the breaker on it
+  // would send the next batch straight back into the queue we are trying to
+  // keep bounded.
+  private recordLateSettle(
+    operation: string,
+    generation: number,
+    error?: unknown,
+  ) {
+    if (this.isDiscarded || !this.isCurrentGeneration(generation)) {
+      return;
+    }
+    if (error !== undefined && isTxMutexTimeout(error)) {
+      logger.warn(
+        "[%s] [sendStall] late tx-mutex timeout operation=%s afterTimeouts=%d (breaker stays open)",
+        this.phoneNumber,
+        operation,
+        this._consecutiveSendTimeouts,
+      );
       return;
     }
     logger.warn(
-      "[%s] [sendStall] late completion operation=%s afterTimeouts=%d",
+      "[%s] [sendStall] late %s operation=%s afterTimeouts=%d",
       this.phoneNumber,
+      error === undefined ? "completion" : "failure",
       operation,
       this._consecutiveSendTimeouts,
     );
-    this.recordSendSuccess();
+    if (error === undefined) {
+      this.recordSendSuccess(generation);
+      return;
+    }
+    this.clearSendStallState();
   }
 
-  private recordSendTimeout(operation: string) {
+  private recordSendTimeout(operation: string, generation: number) {
+    if (!this.isCurrentGeneration(generation)) {
+      logger.warn(
+        "[%s] [sendStall] ignoring timeout from a replaced socket operation=%s generation=%d current=%d",
+        this.phoneNumber,
+        operation,
+        generation,
+        this.socketGeneration,
+      );
+      return;
+    }
     this._consecutiveSendTimeouts += 1;
     this.sendStallStreakStartedAt ??= Date.now();
     const streakMs = Date.now() - this.sendStallStreakStartedAt;
@@ -1375,10 +1448,18 @@ export class BaileysConnection {
       // survives a socket drop) and the connection would answer 503 forever —
       // worse than the stall it was built to contain, since the original bug
       // at least cleared itself when WhatsApp dropped the socket.
-      this._consecutiveSendTimeouts = 0;
-      this.sendStallStreakStartedAt = null;
-      this.sendStallSilentUntil = 0;
-      this.restartRequested = false;
+      //
+      // Gated on the ORIGINAL event, not on `data.connection`: `isOnline` was
+      // rewritten into `data` a few lines above, and `isOnline` is a presence
+      // echo on the socket we already have. `sendPresenceUpdate("available")`
+      // emits one, and POST /connections calls exactly that when it reuses a
+      // live connection — which is what the Chatwoot health check does every
+      // five minutes. Resetting on that would hand a still-wedged socket a
+      // clean breaker on a timer, and every reset lets another batch of sends
+      // queue behind the same stuck mutex.
+      if (connection === "open") {
+        this.clearSendStallState();
+      }
       // Any healthy open wipes the quarantine strike history — the backoff
       // must reflect CONSECUTIVE failed cycles, not lifetime totals. Not
       // awaited (the open path must not block on it), rejection logged.

--- a/src/baileys/connection.ts
+++ b/src/baileys/connection.ts
@@ -265,7 +265,9 @@ export class BaileysConnection {
   private inFlightSends = 0;
   // The backoff state as it was before this episode's strike, so a restart
   // cancelled after the fact can undo exactly its own increment.
-  private stallStrikeRollback: SendStallState | null | undefined;
+  private stallStrikeRollback:
+    | { previous: SendStallState | null; ttlMs: number | null }
+    | undefined;
   // When each keystore key last gave up acquiring, and when it last released.
   // Both are needed to tell "the wedge is still there" from "it let go while the
   // failure was still on its way to us". Keyed by the handful of distinct
@@ -1436,27 +1438,58 @@ export class BaileysConnection {
     // an escalating suppression from a socket that no longer exists.
     if (!this.isDiscarded) {
       try {
-        const { previous } = await recordStallRestart(this.phoneNumber);
-        this.stallStrikeRollback = previous;
-        // Re-read after the write: the DEL can land inside it, which the check
-        // above cannot see. Undoing is the only way back, since nothing in the
-        // store fences a write against a session that has already ended.
-        // Two ways this write can be obsolete by the time it lands, and both
-        // end the same way. isDiscarded: logout began, and the coordinator's DEL
-        // may have already run. !restartRequested: a late send completion or the
-        // wedged key releasing cleared the stall, so the handler's own guard will
-        // veto the restart -- and a strike that outlives the restart it stands
-        // for suppresses the NEXT genuine stall for five minutes on the strength
-        // of a recovery.
-        // Two ways to be obsolete, and they undo differently. Discarded means
-        // the session is being torn down and its logout has (or will) DELETE
-        // this key: restoring the previous episode's value here would resurrect
-        // a backoff for a session that no longer exists, and hand it to whatever
-        // is paired on this number next. Recovered means the connection is still
-        // ours and healed itself, so only THIS episode's increment is wrong.
+        // The lease read rides along with the write rather than sitting before
+        // it, so the fence ends up at the last point before requestRestart with
+        // no await of ours after it. The check further up is what saves the
+        // restart slot and this strike in the common case, but by now it is a
+        // Redis round trip old, and a takeover landing inside that round trip
+        // would leave this rebuilding the old owner's socket against the new
+        // one's.
+        const [{ previous, previousTtlMs }, ownedElsewhere] = await Promise.all(
+          [
+            recordStallRestart(this.phoneNumber),
+            this.shouldYieldToLeaseOwner(),
+          ],
+        );
+        // The expiry travels with the value: restoring with a fresh 24h would
+        // hand an old history another full day on the strength of a restart that
+        // never happened.
+        this.stallStrikeRollback = { previous, ttlMs: previousTtlMs };
+        // Re-checked after the write: all three of these can land inside it,
+        // which the guard above cannot see. Undoing is the only way back, since
+        // nothing in the store fences a write against a session that has already
+        // ended.
+        //
+        // Three ways this write can be obsolete by the time it lands, and they
+        // undo differently.
+        //
+        // isDiscarded: logout began and the coordinator DELs this key in its
+        // finally, so restoring the previous episode's value would resurrect a
+        // backoff for a session that no longer exists and hand it to whatever is
+        // paired on this number next. Clear instead.
+        //
+        // ownedElsewhere: another instance force-acquired the phone. Its socket
+        // is the legitimate one, so ours is a duplicate that is still receiving
+        // and has to go -- and the strike goes back, because the backoff key is
+        // cluster-wide and charging one for a restart we are not performing
+        // would suppress the new owner's watchdog. Ranked above recovery: a
+        // socket we do not own has to be given up whether or not it healed.
+        //
+        // !restartRequested: a late send completion or the wedged key releasing
+        // cleared the stall, so the handler's own guard will veto the restart --
+        // and a strike that outlives the restart it stands for suppresses the
+        // NEXT genuine stall on the strength of a recovery. The connection is
+        // still ours, so only THIS episode's increment is wrong.
         if (this.isDiscarded) {
           this.stallStrikeRollback = undefined;
           await clearSendStall(this.phoneNumber).catch(() => {});
+          return;
+        }
+        if (ownedElsewhere) {
+          // Before the abort, which sets isDiscarded and would send the rollback
+          // down the clear-instead branch above.
+          await this.rollBackStallStrike();
+          this.abort();
           return;
         }
         if (!this.restartRequested) {
@@ -1530,9 +1563,9 @@ export class BaileysConnection {
   // history is per phone and lives 24h, so a delete would also wipe an earlier
   // genuine strike and hand the phone a clean slate it did not earn.
   private async rollBackStallStrike() {
-    const previous = this.stallStrikeRollback;
+    const rollback = this.stallStrikeRollback;
     this.stallStrikeRollback = undefined;
-    if (previous === undefined) {
+    if (rollback === undefined) {
       return;
     }
     try {
@@ -1550,7 +1583,11 @@ export class BaileysConnection {
         await clearSendStall(this.phoneNumber);
         return;
       }
-      await restoreSendStallState(this.phoneNumber, previous);
+      await restoreSendStallState(
+        this.phoneNumber,
+        rollback.previous,
+        rollback.ttlMs,
+      );
     } catch (error) {
       logger.error(
         "[%s] [sendStall] failed to roll back strike: %s",

--- a/src/baileys/connection.ts
+++ b/src/baileys/connection.ts
@@ -1010,9 +1010,16 @@ export class BaileysConnection {
         operation,
         config.baileys.sendTimeoutMs,
         fn,
-        (error, value) =>
-          this.recordLateSettle(operation, generation, error, value),
+        (error, value) => {
+          // The slot belongs to the OPERATION, not to our wait on it. A timed-out
+          // send is still parked in the mutex and still the thing the cap exists
+          // to bound, so its slot is only given back here, when the underlying
+          // promise actually settles.
+          this.releaseInFlight(generation);
+          this.recordLateSettle(operation, generation, error, value);
+        },
       );
+      this.releaseInFlight(generation);
       this.recordSendSuccess(generation);
       return result;
     } catch (error) {
@@ -1024,11 +1031,14 @@ export class BaileysConnection {
       // fastest. recordLateSettle already reads this error as wedge evidence; this
       // is the same reading on the path that runs first.
       if (error instanceof OperationTimeoutError) {
+        // Deliberately no release: onLateSettle above owns it now. Holding the
+        // slot is the whole correction -- an abandoned send keeps running, and
+        // admitting a replacement for it is how the queue grew past the ceiling.
         this.recordSendTimeout(operation, generation);
-      } else if (
-        isTxMutexTimeout(error) &&
-        this.isCurrentGeneration(generation)
-      ) {
+        throw error;
+      }
+      this.releaseInFlight(generation);
+      if (isTxMutexTimeout(error) && this.isCurrentGeneration(generation)) {
         // Gated together, and the gate has to come first. recordSendTimeout drops
         // a stale generation on its own, but noteMutexWedge would already have
         // stamped a replaced socket's key onto the live watchdog -- the same
@@ -1037,13 +1047,15 @@ export class BaileysConnection {
         this.recordSendTimeout(operation, generation, "mutex-wedge");
       }
       throw error;
-    } finally {
-      // Only for the socket that admitted it. A parked send never settles, so a
-      // replacement inheriting those decrements would drift its own count
-      // downwards; the counter is reset with the socket instead.
-      if (this.isCurrentGeneration(generation)) {
-        this.inFlightSends -= 1;
-      }
+    }
+  }
+
+  // Only for the socket that admitted it. A parked send may settle long after
+  // its socket was replaced, and letting that decrement land would drift the
+  // replacement's count downwards; the counter is reset with the socket instead.
+  private releaseInFlight(generation: number) {
+    if (this.isCurrentGeneration(generation)) {
+      this.inFlightSends -= 1;
     }
   }
 

--- a/src/baileys/connection.ts
+++ b/src/baileys/connection.ts
@@ -1248,41 +1248,45 @@ export class BaileysConnection {
       return;
     }
     this.restartRequested = true;
+    // BEFORE requesting the restart, not after. requestRestart hands off to
+    // connectionsHandler.connect, which runs synchronously up to its first await
+    // when the per-number slot is free -- and that stretch includes discard().
+    // So by the time the call returns, this connection is already discarded, and
+    // recording afterwards under an isDiscarded guard would record nothing at
+    // all: a phone that stalls repeatedly would bypass its own backoff and
+    // recreate its socket without limit. The final gate is above, so a strike
+    // here still implies a restart that was actually asked for.
+    //
+    // The guard stays, for the case it was written for: logout sets isDiscarded
+    // before its first await, and the coordinator DELs the backoff key in its
+    // finally. The store is a plain read-modify-write, so a strike straddling
+    // that DEL recreates it, and the next session paired on this number inherits
+    // an escalating suppression from a socket that no longer exists.
+    if (!this.isDiscarded) {
+      try {
+        await recordStallRestart(this.phoneNumber);
+        // Re-read after the write: the DEL can land inside it, which the check
+        // above cannot see. Undoing is the only way back, since nothing in the
+        // store fences a write against a session that has already ended.
+        if (this.isDiscarded) {
+          await clearSendStall(this.phoneNumber);
+          return;
+        }
+      } catch (error) {
+        logger.error(
+          "[%s] [sendStall] failed to record restart: %s",
+          this.phoneNumber,
+          errorToString(error),
+        );
+      }
+    }
+
     // Through the handler, never inline: the replacement socket has to
     // participate in the handler's per-number inFlightOps lock. See
     // connectionsHandler.spawnConnection.
     this.requestRestart?.(
       `send stall: ${this._consecutiveSendTimeouts} consecutive timeouts over ${streakMs}ms`,
     );
-    // The strike lands only once the restart has actually been asked for. Recorded
-    // before the final gate, a restart cancelled by a connection that recovered
-    // while Redis answered still counted: the backoff store then suppressed the
-    // next genuine stall for five minutes and handed it an inflated interval, on
-    // the strength of a restart that never happened.
-    // Not while this connection is being torn down. logout() sets isDiscarded
-    // before its first await, and the coordinator DELs the send-stall backoff in
-    // its finally; the store is a plain read-modify-write, so a strike written
-    // across that DEL recreates the state it just removed. The NEXT session
-    // paired on this number then inherits an escalating restart suppression --
-    // up to 24h of it -- on the strength of a socket that no longer exists.
-    if (this.isDiscarded) {
-      return;
-    }
-    try {
-      await recordStallRestart(this.phoneNumber);
-      // Re-read after the write, because the DEL can land during it and the
-      // check above cannot see that. Undoing is the only way back: nothing in
-      // the store fences a write against a session that has already ended.
-      if (this.isDiscarded) {
-        await clearSendStall(this.phoneNumber);
-      }
-    } catch (error) {
-      logger.error(
-        "[%s] [sendStall] failed to record restart: %s",
-        this.phoneNumber,
-        errorToString(error),
-      );
-    }
   }
 
   // Process-wide, not per-connection: the point is to keep a fleet-wide stall

--- a/src/baileys/connection.ts
+++ b/src/baileys/connection.ts
@@ -901,13 +901,34 @@ export class BaileysConnection {
     void this.handleSendStall(Date.now() - this.sendStallStreakStartedAt);
   }
 
+  // True while the episode this handler was launched for is still the live one.
+  // Every await below is a window in which WhatsApp can drop and remake the socket
+  // on its own: the replacement gets a fresh keystore and clears the breaker, and
+  // acting on the old verdict afterwards means reporting a stall on a healthy
+  // connection and asking the handler to discard it.
+  private isStallEpisodeCurrent(generation: number): boolean {
+    return (
+      !this.isDiscarded &&
+      this.isCurrentGeneration(generation) &&
+      this._consecutiveSendTimeouts >= SEND_STALL_THRESHOLD
+    );
+  }
+
   private async handleSendStall(streakMs: number) {
+    const generation = this.socketGeneration;
     let action: "restart" | "suppressed" = "suppressed";
     let until: string | undefined;
 
     if (config.baileys.sendStallRestartEnabled) {
       try {
-        if (await canRestartAfterStall(this.phoneNumber)) {
+        const mayRestart = await canRestartAfterStall(this.phoneNumber);
+        if (!this.isStallEpisodeCurrent(generation)) {
+          // Recovered while Redis was answering. Lower the silence so a fresh
+          // episode on the new socket can report itself.
+          this.sendStallSilentUntil = 0;
+          return;
+        }
+        if (mayRestart) {
           if (!BaileysConnection.claimStallRestartSlot()) {
             // Process-wide cooldown: another connection restarted moments ago.
             // That is a scheduling delay, not a verdict, so this episode is
@@ -920,6 +941,10 @@ export class BaileysConnection {
           action = "restart";
         } else {
           const allowedAt = await nextRestartAllowedAt(this.phoneNumber);
+          if (!this.isStallEpisodeCurrent(generation)) {
+            this.sendStallSilentUntil = 0;
+            return;
+          }
           until = allowedAt ? new Date(allowedAt).toISOString() : undefined;
           // Reconsider once the backoff we just advertised as `until` expires.
           // Staying silent past it would make that timestamp a lie: the breaker
@@ -979,6 +1004,13 @@ export class BaileysConnection {
         this.phoneNumber,
         errorToString(error),
       );
+    }
+    // Last gate before the socket is actually discarded, and the one that matters
+    // most: the webhook above only reports, this destroys a live connection.
+    if (!this.isStallEpisodeCurrent(generation)) {
+      this.restartRequested = false;
+      this.sendStallSilentUntil = 0;
+      return;
     }
     // Through the handler, never inline: the replacement socket has to
     // participate in the handler's per-number inFlightOps lock. See

--- a/src/baileys/connection.ts
+++ b/src/baileys/connection.ts
@@ -534,6 +534,13 @@ export class BaileysConnection {
       // lastOutgoingAckAt now, presenting end-to-end evidence about a
       // replacement that may itself be wedged and has sent nothing.
       this.submittedMessageIds.clear();
+      // And the evidence itself, for the same reason and with more force: any
+      // non-null value makes sendState read `ok`, so a replacement that has
+      // never sent anything would inherit the previous socket's health report
+      // and hold it indefinitely. `unknown` is the true answer for a socket
+      // nobody has written through yet.
+      this._lastSendCompletedAt = null;
+      this._lastOutgoingAckAt = null;
     } catch (error) {
       logger.error(
         "[%s] [BaileysConnection.connect] Failed to create socket: %s",

--- a/src/baileys/connection.ts
+++ b/src/baileys/connection.ts
@@ -933,6 +933,15 @@ export class BaileysConnection {
           this.phoneNumber,
           errorToString(error),
         );
+        // Re-arm. maybeReportSendStall raised the silence to Infinity before
+        // launching this, on the assumption that it would come back with a
+        // verdict; a Redis blip is not a verdict, and leaving it there means no
+        // later send can ever re-evaluate — the breaker rejects them all
+        // without touching the socket, so this connection would stay muted for
+        // the life of the socket with the restart it needed never requested.
+        // A cooldown rather than 0, so a Redis outage cannot turn every
+        // rejected send into its own webhook.
+        this.sendStallSilentUntil = Date.now() + SEND_STALL_RESTART_COOLDOWN_MS;
       }
     }
 

--- a/src/baileys/connection.ts
+++ b/src/baileys/connection.ts
@@ -979,6 +979,13 @@ export class BaileysConnection {
   // connection and asking the handler to discard it.
   private isStallEpisodeCurrent(generation: number): boolean {
     return (
+      // isOpen carries the entry gate across the awaits. The socket can emit
+      // `close` while Redis answers, and until the reconnect builds its
+      // replacement the generation and the streak both still match — so without
+      // this the handler reports a send stall, spends a backoff strike and asks
+      // for a restart, all for an ordinary disconnect that is already
+      // reconnecting on its own.
+      this.isOpen &&
       !this.isDiscarded &&
       this.isCurrentGeneration(generation) &&
       this._consecutiveSendTimeouts >= SEND_STALL_THRESHOLD

--- a/src/baileys/connection.ts
+++ b/src/baileys/connection.ts
@@ -265,6 +265,8 @@ export class BaileysConnection {
   private inFlightSends = 0;
   // The backoff state as it was before this episode's strike, so a restart
   // cancelled after the fact can undo exactly its own increment.
+  // Serializes the send-stall verdicts against each other. See reportSendStall.
+  private stallReportChain: Promise<unknown> = Promise.resolve();
   private stallStrikeRollback:
     | { previous: SendStallState | null; ttlMs: number | null }
     | undefined;
@@ -1526,7 +1528,7 @@ export class BaileysConnection {
       streakMs,
       action,
     );
-    this.sendToWebhook({
+    const payload: BaileysConnectionWebhookPayload = {
       event: "connection.update",
       data: {
         error: "send_stall_detected",
@@ -1537,7 +1539,20 @@ export class BaileysConnection {
           ...(until && { until }),
         },
       },
-    });
+    };
+    // Chained, not fired independently. These verdicts contradict each other --
+    // `failed` and `cancelled` exist to retract a `restart` already announced --
+    // and sendToWebhook offers no ordering: every payload runs its own retry loop
+    // with backoff, so a `restart` that needed two attempts lands AFTER a
+    // `failed` that went out on the first, and the consumer is left reading
+    // recovery as underway on a connection that never came back. That is the one
+    // reading this whole feature exists to prevent. The wait is bounded by the
+    // retry policy, and a retraction arriving late in the right order beats one
+    // arriving on time in the wrong one.
+    this.stallReportChain = this.stallReportChain
+      .catch(() => {})
+      .then(() => this.sendToWebhook(payload))
+      .catch(() => {});
   }
 
   // The handler drains its per-number slot before re-checking whether the

--- a/src/baileys/connectionsHandler.spec.ts
+++ b/src/baileys/connectionsHandler.spec.ts
@@ -71,6 +71,10 @@ class MockBaileysConnection {
   _apiKeyHash: string | null;
   inFlightWebhooks = 0;
   lastTrafficAt: number | null = null;
+  lastSendCompletedAt: number | null = null;
+  lastOutgoingAckAt: number | null = null;
+  consecutiveSendTimeouts = 0;
+  sendState: "unknown" | "ok" | "degraded" | "stalled" = "unknown";
 
   constructor(phoneNumber: string, options: any) {
     this.phoneNumber = phoneNumber;
@@ -1172,6 +1176,125 @@ describe("BaileysConnectionsHandler", () => {
         "user1@s.whatsapp.net",
         "user2@s.whatsapp.net",
       ]);
+    });
+  });
+
+  describe("#requestRestart", () => {
+    const restartOf = (phone: string) =>
+      mockConnectionInstances.get(phone)?.options?.requestRestart as (
+        reason: string,
+      ) => void;
+
+    // Regression guard for a deadlock that is silent when it happens: the
+    // obvious implementation wraps this in withInFlightOp, and spawnConnection
+    // takes the SAME per-number slot, so it would wait forever on a slot the
+    // callback itself holds. The race makes that hang a failure instead of a
+    // suite that never finishes.
+    it("recreates the connection without deadlocking on the in-flight slot", async () => {
+      await handler.connect("+5511999999999", defaultOptions);
+      const original = mockConnectionInstances.get("+5511999999999");
+      mockDiscard.mockClear();
+      mockConnect.mockClear();
+
+      restartOf("+5511999999999")?.("send stall");
+
+      await Promise.race([
+        (async () => {
+          while (mockConnectionInstances.get("+5511999999999") === original) {
+            await new Promise((resolve) => setTimeout(resolve, 5));
+          }
+        })(),
+        new Promise((_, reject) =>
+          setTimeout(
+            () => reject(new Error("requestRestart deadlocked")),
+            2000,
+          ),
+        ),
+      ]);
+
+      expect(mockDiscard).toHaveBeenCalled();
+      expect(mockConnect).toHaveBeenCalled();
+      expect(mockConnectionInstances.get("+5511999999999")).not.toBe(original);
+    });
+
+    it("carries the same options onto the replacement socket", async () => {
+      await handler.connect("+5511999999999", {
+        ...defaultOptions,
+        clientName: "My Client",
+      });
+      const original = mockConnectionInstances.get("+5511999999999");
+
+      restartOf("+5511999999999")?.("send stall");
+      await Promise.race([
+        (async () => {
+          while (mockConnectionInstances.get("+5511999999999") === original) {
+            await new Promise((resolve) => setTimeout(resolve, 5));
+          }
+        })(),
+        new Promise((_, reject) =>
+          setTimeout(
+            () => reject(new Error("requestRestart deadlocked")),
+            2000,
+          ),
+        ),
+      ]);
+
+      const replacement = mockConnectionInstances.get("+5511999999999");
+      expect(replacement.options.clientName).toBe("My Client");
+      expect(replacement.options.webhookUrl).toBe(defaultOptions.webhookUrl);
+    });
+
+    // A replacement may already hold the slot by the time a stalled socket asks
+    // to be restarted; only the instance that stalled should act.
+    it("is a no-op once a replacement already holds the slot", async () => {
+      await handler.connect("+5511999999999", defaultOptions);
+      const staleRestart = restartOf("+5511999999999");
+      await handler.connect("+5511999999999", {
+        ...defaultOptions,
+        forceRestart: true,
+      });
+      const current = mockConnectionInstances.get("+5511999999999");
+      mockDiscard.mockClear();
+
+      staleRestart?.("send stall");
+      await new Promise((resolve) => setTimeout(resolve, 20));
+
+      expect(mockDiscard).not.toHaveBeenCalled();
+      expect(mockConnectionInstances.get("+5511999999999")).toBe(current);
+    });
+  });
+
+  describe("#sendHealth", () => {
+    it("returns null for a phone with no connection", () => {
+      expect(handler.sendHealth("+5511000000000")).toBeNull();
+    });
+
+    it("reports ages, never raw timestamps", async () => {
+      await handler.connect("+5511999999999", defaultOptions);
+      const connection = mockConnectionInstances.get("+5511999999999");
+      connection.sendState = "degraded";
+      connection.consecutiveSendTimeouts = 2;
+      connection.lastSendCompletedAt = Date.now() - 5_000;
+
+      const health = handler.sendHealth("+5511999999999");
+
+      expect(health?.sendState).toBe("degraded");
+      expect(health?.consecutiveSendTimeouts).toBe(2);
+      expect(health?.lastSendCompletedAgoMs).toBeGreaterThanOrEqual(5_000);
+      expect(health?.lastOutgoingAckAgoMs).toBeNull();
+    });
+  });
+
+  describe("#stalledConnectionCount", () => {
+    it("counts only connections whose sends are wedged", async () => {
+      await handler.connect("+5511999999999", defaultOptions);
+      await handler.connect("+5511888888888", defaultOptions);
+      expect(handler.stalledConnectionCount()).toBe(0);
+
+      mockConnectionInstances.get("+5511999999999").sendState = "stalled";
+      mockConnectionInstances.get("+5511888888888").sendState = "degraded";
+
+      expect(handler.stalledConnectionCount()).toBe(1);
     });
   });
 });

--- a/src/baileys/connectionsHandler.spec.ts
+++ b/src/baileys/connectionsHandler.spec.ts
@@ -71,6 +71,7 @@ class MockBaileysConnection {
   _apiKeyHash: string | null;
   inFlightWebhooks = 0;
   lastTrafficAt: number | null = null;
+  isOpen = true;
   lastSendCompletedAt: number | null = null;
   lastOutgoingAckAt: number | null = null;
   consecutiveSendTimeouts = 0;
@@ -1289,6 +1290,39 @@ describe("BaileysConnectionsHandler", () => {
       expect(replacement.options.leaseEpoch).toBe(9);
     });
 
+    // The identity check the caller makes is not enough on its own: connect()
+    // drains the in-flight slot first, and logout() keeps its connection
+    // registered until its WhatsApp RPC returns. Proceeding anyway resurrects a
+    // phone an explicit DELETE just logged out — as an unpaired QR socket, with
+    // its metadata written back.
+    it("does not resurrect a connection an in-flight logout is removing", async () => {
+      await handler.connect("+5511999999999", defaultOptions);
+      const original = mockConnectionInstances.get("+5511999999999");
+
+      // A logout parked on the WhatsApp RPC: the connection is still registered.
+      let finishLogout: (() => void) | undefined;
+      mockLogout.mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            finishLogout = resolve;
+          }),
+      );
+      const logout = handler.logout("+5511999999999");
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      expect(mockConnectionInstances.get("+5511999999999")).toBe(original);
+
+      mockConnect.mockClear();
+      restartOf("+5511999999999")?.("send stall");
+      await new Promise((resolve) => setTimeout(resolve, 5));
+
+      finishLogout?.();
+      await logout;
+      await new Promise((resolve) => setTimeout(resolve, 20));
+
+      expect(handler.hasConnection("+5511999999999")).toBe(false);
+      expect(mockConnect).not.toHaveBeenCalled();
+    });
+
     // A replacement may already hold the slot by the time a stalled socket asks
     // to be restarted; only the instance that stalled should act.
     it("is a no-op once a replacement already holds the slot", async () => {
@@ -1327,6 +1361,20 @@ describe("BaileysConnectionsHandler", () => {
       expect(health?.consecutiveSendTimeouts).toBe(2);
       expect(health?.lastSendCompletedAgoMs).toBeGreaterThanOrEqual(5_000);
       expect(health?.lastOutgoingAckAgoMs).toBeNull();
+    });
+
+    // Being registered here is not connectivity: a connection is registered
+    // before it ever opens (QR pairing) and stays registered while its socket is
+    // closed and backing off — precisely when a health check must not claim it
+    // is connected.
+    it("reports the socket's own state, not the fact that we hold the object", async () => {
+      await handler.connect("+5511999999999", defaultOptions);
+      const connection = mockConnectionInstances.get("+5511999999999");
+
+      expect(handler.sendHealth("+5511999999999")?.connected).toBe(true);
+
+      connection.isOpen = false;
+      expect(handler.sendHealth("+5511999999999")?.connected).toBe(false);
     });
   });
 

--- a/src/baileys/connectionsHandler.spec.ts
+++ b/src/baileys/connectionsHandler.spec.ts
@@ -86,6 +86,12 @@ class MockBaileysConnection {
   get apiKeyHash() {
     return this._apiKeyHash;
   }
+  // Mirrors the real class: updateOptions mutates the live connection, so the
+  // options it reports are NOT the ones it was constructed with.
+  get currentOptions() {
+    return { ...this.options, ...this.updatedOptions };
+  }
+  updatedOptions: any = {};
   connect = mockConnect;
   logout = mockLogout;
   discard = mockDiscard;
@@ -98,7 +104,10 @@ class MockBaileysConnection {
   deleteMessage = mockDeleteMessage;
   editMessage = mockEditMessage;
   profilePictureUrl = mockProfilePictureUrl;
-  updateOptions = mockUpdateOptions;
+  updateOptions = (options: any) => {
+    this.updatedOptions = { ...this.updatedOptions, ...options };
+    return mockUpdateOptions(options);
+  };
   onWhatsApp = mockOnWhatsApp;
   getBusinessProfile = mockGetBusinessProfile;
   groupMetadata = mockGroupMetadata;
@@ -1242,6 +1251,42 @@ describe("BaileysConnectionsHandler", () => {
       const replacement = mockConnectionInstances.get("+5511999999999");
       expect(replacement.options.clientName).toBe("My Client");
       expect(replacement.options.webhookUrl).toBe(defaultOptions.webhookUrl);
+    });
+
+    // A POST /connections on a live connection updates it in place, so the
+    // options captured when it was spawned are stale from then on. Restarting
+    // from the stale copy would persist it back to Redis and silently revert
+    // the reconfiguration.
+    it("restarts from the connection's current options, not the ones it was built with", async () => {
+      await handler.connect("+5511999999999", defaultOptions);
+      const original = mockConnectionInstances.get("+5511999999999");
+      await handler.connect("+5511999999999", {
+        ...defaultOptions,
+        webhookUrl: "http://example.com/reconfigured",
+        leaseEpoch: 9,
+      });
+      expect(mockConnectionInstances.get("+5511999999999")).toBe(original);
+
+      restartOf("+5511999999999")?.("send stall");
+      await Promise.race([
+        (async () => {
+          while (mockConnectionInstances.get("+5511999999999") === original) {
+            await new Promise((resolve) => setTimeout(resolve, 5));
+          }
+        })(),
+        new Promise((_, reject) =>
+          setTimeout(
+            () => reject(new Error("requestRestart deadlocked")),
+            2000,
+          ),
+        ),
+      ]);
+
+      const replacement = mockConnectionInstances.get("+5511999999999");
+      expect(replacement.options.webhookUrl).toBe(
+        "http://example.com/reconfigured",
+      );
+      expect(replacement.options.leaseEpoch).toBe(9);
     });
 
     // A replacement may already hold the slot by the time a stalled socket asks

--- a/src/baileys/connectionsHandler.spec.ts
+++ b/src/baileys/connectionsHandler.spec.ts
@@ -76,6 +76,11 @@ class MockBaileysConnection {
   lastOutgoingAckAt: number | null = null;
   consecutiveSendTimeouts = 0;
   sendState: "unknown" | "ok" | "degraded" | "stalled" = "unknown";
+  // True by default because that is the only state from which the real
+  // connection ever calls requestRestart: handleSendStall sets it immediately
+  // before. Examples flip it to false to model recovery arriving while the
+  // restart waited on the per-number slot.
+  restartPending = true;
 
   constructor(phoneNumber: string, options: any) {
     this.phoneNumber = phoneNumber;
@@ -1213,6 +1218,27 @@ describe("BaileysConnectionsHandler", () => {
       mockConnectionInstances.get(phone)?.options?.requestRestart as (
         reason: string,
       ) => void;
+
+    // The restart queues behind whatever holds the per-number slot, and connect()
+    // re-checks the guard only after draining it. A late send completion or the
+    // wedged key releasing in that window clears the stall, and killing the
+    // socket then costs a live connection and a backoff strike for nothing.
+    it("abandons a queued restart once the connection has recovered", async () => {
+      await handler.connect("+5511999999999", defaultOptions);
+      const original = mockConnectionInstances.get("+5511999999999");
+      mockDiscard.mockClear();
+      mockConnect.mockClear();
+
+      // Recovery landed between asking for the restart and reaching the guard.
+      original.restartPending = false;
+      restartOf("+5511999999999")?.("send stall");
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(mockConnectionInstances.get("+5511999999999")).toBe(original);
+      expect(mockDiscard).not.toHaveBeenCalled();
+      expect(mockConnect).not.toHaveBeenCalled();
+    });
 
     // Regression guard for a deadlock that is silent when it happens: the
     // obvious implementation wraps this in withInFlightOp, and spawnConnection

--- a/src/baileys/connectionsHandler.spec.ts
+++ b/src/baileys/connectionsHandler.spec.ts
@@ -207,6 +207,25 @@ describe("BaileysConnectionsHandler", () => {
       expect(mockDiscard).not.toHaveBeenCalled();
     });
 
+    // A connection registered but never connected is worse than no entry: the
+    // registry answers "we own this number" to the claim and renew cycles while
+    // the socket is null, so the phone stays offline, leased to us, with nothing
+    // scheduled to retry. Reachable unattended now that the watchdog restarts
+    // sockets on its own, where the only thing downstream of the rejection is a
+    // log line.
+    it("does not leave a connection registered when its connect fails", async () => {
+      mockConnect.mockImplementationOnce(async () => {
+        throw new Error("redis down");
+      });
+
+      await expect(handler.connect("+5511999", defaultOptions)).rejects.toThrow(
+        "redis down",
+      );
+
+      expect(handler.hasConnection("+5511999")).toBe(false);
+      expect(mockDiscard).toHaveBeenCalled();
+    });
+
     it("keeps in-flight webhooks of a discarded connection visible until they drain", async () => {
       // The shutdown drain waits on inFlightWebhookCount() AFTER discarding
       // each phone — a discarded connection with a retrying webhook must

--- a/src/baileys/connectionsHandler.spec.ts
+++ b/src/baileys/connectionsHandler.spec.ts
@@ -1244,10 +1244,13 @@ describe("BaileysConnectionsHandler", () => {
     // fails to rebuild leaves the number dark until the TTL and the unclaimed
     // grace elapse, with every request routed here answering 404.
     it("reports a restart that could not rebuild its socket", async () => {
-      await handler.connect("+5511999999999", defaultOptions);
-      const failures: string[] = [];
-      handler.onSpawnFailed = (phone: string) => {
-        failures.push(phone);
+      await handler.connect("+5511999999999", {
+        ...defaultOptions,
+        leaseEpoch: 7,
+      });
+      const failures: Array<[string, number | null]> = [];
+      handler.onSpawnFailed = (phone: string, epoch: number | null) => {
+        failures.push([phone, epoch]);
       };
       mockConnect.mockImplementationOnce(async () => {
         throw new Error("redis down");
@@ -1259,7 +1262,11 @@ describe("BaileysConnectionsHandler", () => {
         await new Promise((resolve) => setTimeout(resolve, 5));
       }
 
-      expect(failures).toEqual(["+5511999999999"]);
+      // The epoch travels with it: releasing by whatever the coordinator
+      // currently holds would hand away a lease a concurrent explicit operation
+      // force-acquired while this restart was failing, leaving its live socket
+      // unowned.
+      expect(failures).toEqual([["+5511999999999", 7]]);
       expect(handler.hasConnection("+5511999999999")).toBe(false);
       handler.onSpawnFailed = null;
     });

--- a/src/baileys/connectionsHandler.spec.ts
+++ b/src/baileys/connectionsHandler.spec.ts
@@ -1240,6 +1240,30 @@ describe("BaileysConnectionsHandler", () => {
       expect(mockConnect).not.toHaveBeenCalled();
     });
 
+    // The claim scan skips any phone that already has a lease, so a restart that
+    // fails to rebuild leaves the number dark until the TTL and the unclaimed
+    // grace elapse, with every request routed here answering 404.
+    it("reports a restart that could not rebuild its socket", async () => {
+      await handler.connect("+5511999999999", defaultOptions);
+      const failures: string[] = [];
+      handler.onSpawnFailed = (phone: string) => {
+        failures.push(phone);
+      };
+      mockConnect.mockImplementationOnce(async () => {
+        throw new Error("redis down");
+      });
+
+      restartOf("+5511999999999")?.("send stall");
+
+      for (let i = 0; i < 50 && failures.length === 0; i += 1) {
+        await new Promise((resolve) => setTimeout(resolve, 5));
+      }
+
+      expect(failures).toEqual(["+5511999999999"]);
+      expect(handler.hasConnection("+5511999999999")).toBe(false);
+      handler.onSpawnFailed = null;
+    });
+
     // Regression guard for a deadlock that is silent when it happens: the
     // obvious implementation wraps this in withInFlightOp, and spawnConnection
     // takes the SAME per-number slot, so it would wait forever on a slot the

--- a/src/baileys/connectionsHandler.spec.ts
+++ b/src/baileys/connectionsHandler.spec.ts
@@ -81,6 +81,13 @@ class MockBaileysConnection {
   // before. Examples flip it to false to model recovery arriving while the
   // restart waited on the per-number slot.
   restartPending = true;
+  reportedFailures = 0;
+
+  reportFailedStallRestart() {
+    this.reportedFailures += 1;
+  }
+
+  async withdrawStallRestart() {}
 
   constructor(phoneNumber: string, options: any) {
     this.phoneNumber = phoneNumber;
@@ -1248,6 +1255,10 @@ describe("BaileysConnectionsHandler", () => {
         ...defaultOptions,
         leaseEpoch: 7,
       });
+      // Captured before the restart: spawnConnection registers a replacement
+      // under the same phone, and it is the ORIGINAL that observed the stall and
+      // announced the restart, so it is the one that has to correct it.
+      const original = mockConnectionInstances.get("+5511999999999");
       const failures: Array<[string, number | null]> = [];
       handler.onSpawnFailed = (phone: string, epoch: number | null) => {
         failures.push([phone, epoch]);
@@ -1267,6 +1278,9 @@ describe("BaileysConnectionsHandler", () => {
       // force-acquired while this restart was failing, leaving its live socket
       // unowned.
       expect(failures).toEqual([["+5511999999999", 7]]);
+      // And the consumers who were told the socket was being recreated hear
+      // that it was not. Nothing else would ever correct that verdict.
+      expect(original.reportedFailures).toBe(1);
       expect(handler.hasConnection("+5511999999999")).toBe(false);
       handler.onSpawnFailed = null;
     });

--- a/src/baileys/connectionsHandler.spec.ts
+++ b/src/baileys/connectionsHandler.spec.ts
@@ -1295,6 +1295,27 @@ describe("BaileysConnectionsHandler", () => {
       expect(withdrawals).toEqual(["withdrawn"]);
     });
 
+    // A background reconnect that gives up aborts, which evicts it from the
+    // handler -- but the lease is the coordinator's, and the claim scan skips any
+    // phone that still has one. Without this the number stays dark until the TTL
+    // and the unclaimed grace expire, with requests routing here and 404ing.
+    it("reports a background reconnect that gave up rebuilding", async () => {
+      await handler.connect("+5511999999999", {
+        ...defaultOptions,
+        leaseEpoch: 4,
+      });
+      const connection = mockConnectionInstances.get("+5511999999999");
+      const failures: Array<[string, number | null]> = [];
+      handler.onSpawnFailed = (phone: string, epoch: number | null) => {
+        failures.push([phone, epoch]);
+      };
+
+      connection.options.onUnrecoverable();
+
+      expect(failures).toEqual([["+5511999999999", 4]]);
+      handler.onSpawnFailed = null;
+    });
+
     // Regression guard for a deadlock that is silent when it happens: the
     // obvious implementation wraps this in withInFlightOp, and spawnConnection
     // takes the SAME per-number slot, so it would wait forever on a slot the

--- a/src/baileys/connectionsHandler.spec.ts
+++ b/src/baileys/connectionsHandler.spec.ts
@@ -1271,6 +1271,30 @@ describe("BaileysConnectionsHandler", () => {
       handler.onSpawnFailed = null;
     });
 
+    // connect() drains the per-number slot before re-checking, so a recovery in
+    // that window vetoes a restart this connection had already committed to: a
+    // strike is written and consumers have been told the socket is being
+    // recreated. Both have to be taken back, or the next genuine stall is
+    // suppressed on the strength of a restart that never happened.
+    it("tells the connection to withdraw a restart that got vetoed", async () => {
+      await handler.connect("+5511999999999", defaultOptions);
+      const connection = mockConnectionInstances.get("+5511999999999");
+      const withdrawals: string[] = [];
+      connection.withdrawStallRestart = async () => {
+        withdrawals.push("withdrawn");
+      };
+      // Recovery lands after the commit but before connect() re-checks.
+      connection.restartPending = false;
+
+      restartOf("+5511999999999")?.("send stall");
+
+      for (let i = 0; i < 50 && withdrawals.length === 0; i += 1) {
+        await new Promise((resolve) => setTimeout(resolve, 5));
+      }
+
+      expect(withdrawals).toEqual(["withdrawn"]);
+    });
+
     // Regression guard for a deadlock that is silent when it happens: the
     // obvious implementation wraps this in withInFlightOp, and spawnConnection
     // takes the SAME per-number slot, so it would wait forever on a slot the

--- a/src/baileys/connectionsHandler.ts
+++ b/src/baileys/connectionsHandler.ts
@@ -35,6 +35,13 @@ export class BaileysConnectionsHandler {
   // must keep seeing their in-flight count until it reaches zero.
   private drainingWebhooks = new Set<BaileysConnection>();
   private createConnection: ConnectionFactory;
+  // Set by the coordinator. A restart whose replacement never comes up leaves
+  // this number with no socket while the lease is still held, and the claim scan
+  // skips anything that already has a lease -- so nothing retries until the TTL
+  // and the unclaimed grace expire, and every request routed here 404s. The
+  // claim cycle's own reconnect failure already handles this the same way:
+  // do not sit on a lease we cannot service.
+  onSpawnFailed: ((phoneNumber: string) => void | Promise<void>) | null = null;
 
   constructor(createConnection?: ConnectionFactory) {
     this.createConnection =
@@ -280,12 +287,18 @@ export class BaileysConnectionsHandler {
               forceRestart: true,
             },
             stillOurs,
-          ).catch((error) => {
+          ).catch(async (error) => {
             logger.error(
               "[%s] [requestRestart] %s",
               phoneNumber,
               errorToString(error),
             );
+            // Only when nothing came up in the meantime: a later connect may
+            // have succeeded while this one was failing.
+            if (this.connections[phoneNumber]) {
+              return;
+            }
+            await this.onSpawnFailed?.(phoneNumber);
           });
         },
       });

--- a/src/baileys/connectionsHandler.ts
+++ b/src/baileys/connectionsHandler.ts
@@ -293,11 +293,16 @@ export class BaileysConnectionsHandler {
   // no-op. Used by the send-stall restart, where proceeding anyway would
   // resurrect a phone an explicit DELETE had just logged out — as an unpaired
   // QR socket, with its metadata written back.
+  // Returns whether it actually did anything. `false` means only one thing —
+  // shouldProceed vetoed it after a drain — and callers that answer a client need
+  // it: a restart that silently skipped is otherwise indistinguishable from one
+  // that rebuilt the socket, and the client is told 202 for a session that was
+  // deleted while it queued.
   async connect(
     phoneNumber: string,
     options: BaileysConnectionOptions,
     shouldProceed?: () => boolean,
-  ) {
+  ): Promise<boolean> {
     // Loops because every decision must be re-validated after an await:
     //   1. Drain any in-flight connect for this number (multiple callers can
     //      have parked on the same slot).
@@ -317,7 +322,7 @@ export class BaileysConnectionsHandler {
       // Before reading `existing`, and after every drain: whatever ran while we
       // waited may have made this connect the wrong thing to do.
       if (shouldProceed && !shouldProceed()) {
-        return;
+        return false;
       }
 
       const existing = this.connections[phoneNumber];
@@ -336,19 +341,19 @@ export class BaileysConnectionsHandler {
           this.drainingWebhooks.add(existing);
         }
         await this.spawnConnection(phoneNumber, connectOptions);
-        return;
+        return true;
       }
 
       if (!existing) {
         await this.spawnConnection(phoneNumber, connectOptions);
-        return;
+        return true;
       }
 
       await existing.updateOptions(connectOptions);
       try {
         // NOTE: This triggers a `connection.update` event.
         await existing.sendPresenceUpdate("available");
-        return;
+        return true;
       } catch (error) {
         if (!(error instanceof BaileysNotConnectedError)) {
           throw error;
@@ -366,6 +371,22 @@ export class BaileysConnectionsHandler {
         );
       }
     }
+  }
+
+  // Hands a live connection the epoch of a lease that moved under it, without the
+  // reconnect dance connect() would run. For an explicit operation that
+  // force-acquires and then decides not to rebuild: the socket keeps serving, so
+  // its webhooks have to carry the epoch that now owns it or the client discards
+  // them as stale.
+  async updateLeaseEpoch(phoneNumber: string, leaseEpoch: number) {
+    const connection = this.connections[phoneNumber];
+    if (!connection) {
+      return;
+    }
+    await connection.updateOptions({
+      ...connection.currentOptions,
+      leaseEpoch,
+    });
   }
 
   async verifyConnectionAccess(phoneNumber: string, apiKeyHash: string | null) {

--- a/src/baileys/connectionsHandler.ts
+++ b/src/baileys/connectionsHandler.ts
@@ -258,7 +258,15 @@ export class BaileysConnectionsHandler {
           // in-flight slot first, and an in-flight logout keeps its connection
           // registered until its RPC returns. Hence the same check again, run
           // by connect() after the drain.
-          const stillOurs = () => this.connections[phoneNumber] === connection;
+          // Two conditions, and the second is not redundant. connect() drains the
+          // per-number slot first, and an unrelated POST or logout can hold it
+          // for a while; a late send completion or the wedged key releasing in
+          // that window clears the stall, which clears restartPending. Without
+          // it the watchdog kills a socket that has already recovered and spends
+          // a backoff strike doing so.
+          const stillOurs = () =>
+            this.connections[phoneNumber] === connection &&
+            connection.restartPending;
           // connection.currentOptions, never the captured `options`: a later
           // POST /connections reuses a live connection and updates its webhook
           // config and lease epoch in place, so the closure's copy can be

--- a/src/baileys/connectionsHandler.ts
+++ b/src/baileys/connectionsHandler.ts
@@ -516,16 +516,19 @@ export class BaileysConnectionsHandler {
       messageContent,
       quoted,
       messageId,
+      onLateDefinitiveFailure,
     }: {
       jid: string;
       messageContent: AnyMessageContent;
       quoted?: WAMessage;
       messageId?: string;
+      onLateDefinitiveFailure?: () => void;
     },
   ) {
     return this.getConnection(phoneNumber).sendMessage(jid, messageContent, {
       quoted,
       messageId,
+      onLateDefinitiveFailure,
     });
   }
 

--- a/src/baileys/connectionsHandler.ts
+++ b/src/baileys/connectionsHandler.ts
@@ -316,6 +316,9 @@ export class BaileysConnectionsHandler {
                 phoneNumber,
                 errorToString(error),
               );
+              // Consumers were told the socket was being recreated. Nothing
+              // rebuilt it, and nothing else would ever correct that.
+              connection.reportFailedStallRestart();
               // Only when nothing came up in the meantime: a later connect may
               // have succeeded while this one was failing.
               if (this.connections[phoneNumber]) {

--- a/src/baileys/connectionsHandler.ts
+++ b/src/baileys/connectionsHandler.ts
@@ -282,7 +282,28 @@ export class BaileysConnectionsHandler {
         },
       });
       this.connections[phoneNumber] = connection;
-      await connection.connect();
+      try {
+        await connection.connect();
+      } catch (error) {
+        // A registered connection that never connected is worse than no entry at
+        // all: hasConnection() reads true, so claim cycles skip this number while
+        // renew cycles keep its lease alive, and its socket is null with nothing
+        // scheduled to retry. The number stays offline, owned by us, until a human
+        // sends another request -- which is the silent outage this whole change
+        // exists to end, reintroduced by its own recovery path. Cheap to reach now
+        // that the watchdog restarts sockets unattended: a Redis blip inside
+        // useRedisAuthState is enough, and the only thing downstream of that
+        // rejection is a logger.error.
+        if (this.connections[phoneNumber] === connection) {
+          delete this.connections[phoneNumber];
+        }
+        connection.discard();
+        // Same drain accounting as discardConnection, for the same reason.
+        if (connection.inFlightWebhooks > 0) {
+          this.drainingWebhooks.add(connection);
+        }
+        throw error;
+      }
     });
   }
 

--- a/src/baileys/connectionsHandler.ts
+++ b/src/baileys/connectionsHandler.ts
@@ -297,23 +297,23 @@ export class BaileysConnectionsHandler {
           // that window clears the stall, which clears restartPending. Without
           // it the watchdog kills a socket that has already recovered and spends
           // a backoff strike doing so.
-          const stillOurs = () =>
-            this.connections[phoneNumber] === connection &&
-            connection.restartPending;
           // connection.currentOptions, never the captured `options`: a later
           // POST /connections reuses a live connection and updates its webhook
           // config and lease epoch in place, so the closure's copy can be
           // stale — and connect() would persist that stale copy back to Redis,
-          // reverting the reconfiguration.
-          void this.connect(
-            phoneNumber,
-            {
-              ...connection.currentOptions,
-              isReconnect: true,
-              forceRestart: true,
-            },
-            stillOurs,
-          )
+          // reverting the reconfiguration. Read inside the resolver rather than
+          // at the call, so it is read AFTER the drain: the reconfiguration can
+          // land while this restart is queued behind the slot.
+          const stillOurs = () =>
+            this.connections[phoneNumber] === connection &&
+            connection.restartPending
+              ? {
+                  ...connection.currentOptions,
+                  isReconnect: true,
+                  forceRestart: true,
+                }
+              : null;
+          void this.connect(phoneNumber, stillOurs)
             .then(async (started) => {
               // connect() resolves false when stillOurs vetoed it after draining
               // the slot -- i.e. the connection recovered while this restart was
@@ -385,8 +385,18 @@ export class BaileysConnectionsHandler {
   // deleted while it queued.
   async connect(
     phoneNumber: string,
-    options: BaileysConnectionOptions,
-    shouldProceed?: () => boolean,
+    // A value, or a resolver run after every drain that returns the options to
+    // spawn with (or null to veto). The resolver form exists because a caller's
+    // snapshot can be superseded while this connect queues: an explicit
+    // operation holding the per-phone slot updates the live connection's webhook
+    // config in place, and spawning from the older copy persists it back over
+    // the reconfiguration.
+    //
+    // A resolver must be SYNCHRONOUS, and that is load-bearing. Nothing may
+    // await between the drain exiting and spawnConnection assigning the slot --
+    // that stretch is what makes withInFlightOp's "nothing can run in between"
+    // true.
+    options: BaileysConnectionOptions | (() => BaileysConnectionOptions | null),
   ): Promise<boolean> {
     // Loops because every decision must be re-validated after an await:
     //   1. Drain any in-flight connect for this number (multiple callers can
@@ -398,17 +408,19 @@ export class BaileysConnectionsHandler {
     //      replacement (two callers hitting the same stale connection would
     //      otherwise both spawn parallel sockets with the same identity).
     //   3. Otherwise spawn a new connection.
-    const { forceRestart, ...connectOptions } = options;
     for (;;) {
       while (this.inFlightOps[phoneNumber]) {
         await this.inFlightOps[phoneNumber].catch(() => {});
       }
 
       // Before reading `existing`, and after every drain: whatever ran while we
-      // waited may have made this connect the wrong thing to do.
-      if (shouldProceed && !shouldProceed()) {
+      // waited may have made this connect the wrong thing to do, or changed what
+      // it should be done with.
+      const resolved = typeof options === "function" ? options() : options;
+      if (resolved === null) {
         return false;
       }
+      const { forceRestart, ...connectOptions } = resolved;
 
       const existing = this.connections[phoneNumber];
 

--- a/src/baileys/connectionsHandler.ts
+++ b/src/baileys/connectionsHandler.ts
@@ -85,6 +85,50 @@ export class BaileysConnectionsHandler {
     };
   }
 
+  // Send-side health for one connection. Ages, never absolute timestamps:
+  // lastTrafficAt is a performance.now() reading, which is monotonic and
+  // meaningless to a client.
+  sendHealth(phoneNumber: string): {
+    connected: boolean;
+    sendState: "unknown" | "ok" | "degraded" | "stalled";
+    consecutiveSendTimeouts: number;
+    lastTrafficAgoMs: number | null;
+    lastSendCompletedAgoMs: number | null;
+    lastOutgoingAckAgoMs: number | null;
+  } | null {
+    const connection = this.connections[phoneNumber];
+    if (!connection) {
+      return null;
+    }
+    const now = Date.now();
+    const age = (at: number | null) => (at === null ? null : now - at);
+    return {
+      connected: true,
+      sendState: connection.sendState,
+      consecutiveSendTimeouts: connection.consecutiveSendTimeouts,
+      lastTrafficAgoMs:
+        connection.lastTrafficAt === null
+          ? null
+          : Math.round(performance.now() - connection.lastTrafficAt),
+      lastSendCompletedAgoMs: age(connection.lastSendCompletedAt),
+      lastOutgoingAckAgoMs: age(connection.lastOutgoingAckAt),
+    };
+  }
+
+  // Connections that are registered and receiving but whose sends are wedged.
+  // Exposed for alerting only — never for container liveness: failing the
+  // container health check would restart the process and take every HEALTHY
+  // connection down with it.
+  stalledConnectionCount(): number {
+    let count = 0;
+    for (const connection of Object.values(this.connections)) {
+      if (connection.sendState === "stalled") {
+        count += 1;
+      }
+    }
+    return count;
+  }
+
   // Tears down the local socket WITHOUT touching the Redis auth state, so the
   // identity can be picked up elsewhere. Used by the cluster coordinator for
   // self-fencing (lease owned by another instance) and graceful handoff.
@@ -182,6 +226,36 @@ export class BaileysConnectionsHandler {
           }).catch((error) => {
             logger.error(
               "[%s] [requestLogout] %s",
+              phoneNumber,
+              errorToString(error),
+            );
+          });
+        },
+        requestRestart: (reason: string) => {
+          // NOTE: Do NOT wrap this in withInFlightOp. spawnConnection takes the
+          // same per-number slot, and its `while (this.inFlightOps[phone])`
+          // would wait on the slot this callback itself would be holding — a
+          // permanent, silent deadlock.
+          //
+          // connect() with forceRestart already does the right thing: it drains
+          // in-flight ops BEFORE taking a slot, discards the live socket, keeps
+          // the drainingWebhooks accounting, and spawns a replacement with the
+          // same identity and lease epoch. It is the path import-session
+          // already exercises in production. Do not reimplement it here.
+          if (this.connections[phoneNumber] !== connection) {
+            return;
+          }
+          logger.warn(
+            "[%s] [requestRestart] recreating socket reason=%s",
+            phoneNumber,
+            reason,
+          );
+          void this.connect(phoneNumber, {
+            ...options,
+            forceRestart: true,
+          }).catch((error) => {
+            logger.error(
+              "[%s] [requestRestart] %s",
               phoneNumber,
               errorToString(error),
             );

--- a/src/baileys/connectionsHandler.ts
+++ b/src/baileys/connectionsHandler.ts
@@ -293,22 +293,33 @@ export class BaileysConnectionsHandler {
               forceRestart: true,
             },
             stillOurs,
-          ).catch(async (error) => {
-            logger.error(
-              "[%s] [requestRestart] %s",
-              phoneNumber,
-              errorToString(error),
-            );
-            // Only when nothing came up in the meantime: a later connect may
-            // have succeeded while this one was failing.
-            if (this.connections[phoneNumber]) {
-              return;
-            }
-            await this.onSpawnFailed?.(
-              phoneNumber,
-              connection.currentOptions.leaseEpoch ?? null,
-            );
-          });
+          )
+            .then(async (started) => {
+              // connect() resolves false when stillOurs vetoed it after draining
+              // the slot -- i.e. the connection recovered while this restart was
+              // queued. It committed to the restart before that: a strike is
+              // written and consumers have been told the socket is being
+              // recreated, and both have to be taken back.
+              if (started === false) {
+                await connection.withdrawStallRestart();
+              }
+            })
+            .catch(async (error) => {
+              logger.error(
+                "[%s] [requestRestart] %s",
+                phoneNumber,
+                errorToString(error),
+              );
+              // Only when nothing came up in the meantime: a later connect may
+              // have succeeded while this one was failing.
+              if (this.connections[phoneNumber]) {
+                return;
+              }
+              await this.onSpawnFailed?.(
+                phoneNumber,
+                connection.currentOptions.leaseEpoch ?? null,
+              );
+            });
         },
       });
       this.connections[phoneNumber] = connection;

--- a/src/baileys/connectionsHandler.ts
+++ b/src/baileys/connectionsHandler.ts
@@ -103,7 +103,11 @@ export class BaileysConnectionsHandler {
     const now = Date.now();
     const age = (at: number | null) => (at === null ? null : now - at);
     return {
-      connected: true,
+      // The socket's own state, not the fact that we hold the object: it is
+      // registered here before it ever opens and stays registered while it is
+      // closed and backing off, which is precisely when a health check must not
+      // claim connectivity.
+      connected: connection.isOpen,
       sendState: connection.sendState,
       consecutiveSendTimeouts: connection.consecutiveSendTimeouts,
       lastTrafficAgoMs:
@@ -250,16 +254,25 @@ export class BaileysConnectionsHandler {
             phoneNumber,
             reason,
           );
+          // The guard above is not enough on its own: connect() drains the
+          // in-flight slot first, and an in-flight logout keeps its connection
+          // registered until its RPC returns. Hence the same check again, run
+          // by connect() after the drain.
+          const stillOurs = () => this.connections[phoneNumber] === connection;
           // connection.currentOptions, never the captured `options`: a later
           // POST /connections reuses a live connection and updates its webhook
           // config and lease epoch in place, so the closure's copy can be
           // stale — and connect() would persist that stale copy back to Redis,
           // reverting the reconfiguration.
-          void this.connect(phoneNumber, {
-            ...connection.currentOptions,
-            isReconnect: true,
-            forceRestart: true,
-          }).catch((error) => {
+          void this.connect(
+            phoneNumber,
+            {
+              ...connection.currentOptions,
+              isReconnect: true,
+              forceRestart: true,
+            },
+            stillOurs,
+          ).catch((error) => {
             logger.error(
               "[%s] [requestRestart] %s",
               phoneNumber,
@@ -273,7 +286,18 @@ export class BaileysConnectionsHandler {
     });
   }
 
-  async connect(phoneNumber: string, options: BaileysConnectionOptions) {
+  // `shouldProceed` is re-checked after every drain inside the loop, not once by
+  // the caller: logout() leaves its connection registered while it awaits the
+  // WhatsApp RPC, so a caller's check made before the drain still sees a
+  // connection the logout is about to delete. Returning false makes this a
+  // no-op. Used by the send-stall restart, where proceeding anyway would
+  // resurrect a phone an explicit DELETE had just logged out — as an unpaired
+  // QR socket, with its metadata written back.
+  async connect(
+    phoneNumber: string,
+    options: BaileysConnectionOptions,
+    shouldProceed?: () => boolean,
+  ) {
     // Loops because every decision must be re-validated after an await:
     //   1. Drain any in-flight connect for this number (multiple callers can
     //      have parked on the same slot).
@@ -288,6 +312,12 @@ export class BaileysConnectionsHandler {
     for (;;) {
       while (this.inFlightOps[phoneNumber]) {
         await this.inFlightOps[phoneNumber].catch(() => {});
+      }
+
+      // Before reading `existing`, and after every drain: whatever ran while we
+      // waited may have made this connect the wrong thing to do.
+      if (shouldProceed && !shouldProceed()) {
+        return;
       }
 
       const existing = this.connections[phoneNumber];

--- a/src/baileys/connectionsHandler.ts
+++ b/src/baileys/connectionsHandler.ts
@@ -41,7 +41,13 @@ export class BaileysConnectionsHandler {
   // and the unclaimed grace expire, and every request routed here 404s. The
   // claim cycle's own reconnect failure already handles this the same way:
   // do not sit on a lease we cannot service.
-  onSpawnFailed: ((phoneNumber: string) => void | Promise<void>) | null = null;
+  // The epoch travels with it: by the time this fires, a concurrent explicit
+  // connect or restart may have force-acquired its own lease, and releasing by
+  // "whatever we currently hold" would hand away that operation's lease and
+  // leave its live socket unowned.
+  onSpawnFailed:
+    | ((phoneNumber: string, leaseEpoch: number | null) => void | Promise<void>)
+    | null = null;
 
   constructor(createConnection?: ConnectionFactory) {
     this.createConnection =
@@ -298,7 +304,10 @@ export class BaileysConnectionsHandler {
             if (this.connections[phoneNumber]) {
               return;
             }
-            await this.onSpawnFailed?.(phoneNumber);
+            await this.onSpawnFailed?.(
+              phoneNumber,
+              connection.currentOptions.leaseEpoch ?? null,
+            );
           });
         },
       });

--- a/src/baileys/connectionsHandler.ts
+++ b/src/baileys/connectionsHandler.ts
@@ -250,8 +250,14 @@ export class BaileysConnectionsHandler {
             phoneNumber,
             reason,
           );
+          // connection.currentOptions, never the captured `options`: a later
+          // POST /connections reuses a live connection and updates its webhook
+          // config and lease epoch in place, so the closure's copy can be
+          // stale — and connect() would persist that stale copy back to Redis,
+          // reverting the reconfiguration.
           void this.connect(phoneNumber, {
-            ...options,
+            ...connection.currentOptions,
+            isReconnect: true,
             forceRestart: true,
           }).catch((error) => {
             logger.error(

--- a/src/baileys/connectionsHandler.ts
+++ b/src/baileys/connectionsHandler.ts
@@ -248,6 +248,12 @@ export class BaileysConnectionsHandler {
             );
           });
         },
+        onUnrecoverable: () => {
+          void this.onSpawnFailed?.(
+            phoneNumber,
+            connection.currentOptions.leaseEpoch ?? null,
+          );
+        },
         requestRestart: (reason: string) => {
           // NOTE: Do NOT wrap this in withInFlightOp. spawnConnection takes the
           // same per-number slot, and its `while (this.inFlightOps[phone])`

--- a/src/baileys/connectionsHandler.ts
+++ b/src/baileys/connectionsHandler.ts
@@ -132,6 +132,20 @@ export class BaileysConnectionsHandler {
     };
   }
 
+  // The live connection's CURRENT options, which are not the ones it was
+  // spawned with: a POST /connections reuses a live connection and mutates them
+  // in place via updateOptions, in memory first and only then to Redis. So
+  // anything that rebuilds this socket has to prefer these over a metadata
+  // snapshot it read earlier -- connect() would otherwise persist the older
+  // copy back and revert the reconfiguration. Same reason the watchdog's
+  // requestRestart reads connection.currentOptions rather than the options its
+  // closure captured.
+  currentConnectionOptions(
+    phoneNumber: string,
+  ): BaileysConnectionOptions | null {
+    return this.connections[phoneNumber]?.currentOptions ?? null;
+  }
+
   // Connections that are registered and receiving but whose sends are wedged.
   // Exposed for alerting only — never for container liveness: failing the
   // container health check would restart the process and take every HEALTHY

--- a/src/baileys/helpers/audioJobs.spec.ts
+++ b/src/baileys/helpers/audioJobs.spec.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, mock } from "bun:test";
 import {
   cancelAudioJob,
   completeAudioJob,
+  isAudioJobCancelled,
   registerAudioJob,
   runningAudioJobCount,
 } from "@/baileys/helpers/audioJobs";
@@ -41,5 +42,33 @@ describe("audioJobs", () => {
 
   it("is inert for a job it never saw", () => {
     expect(cancelAudioJob(3)).toBe(false);
+  });
+
+  // fluent-ffmpeg spawns asynchronously: during _prepare and its capability
+  // probing there is no ffmpegProc, and kill() only logs. A cancellation that
+  // lands in that window has nothing to act on, so it has to be remembered --
+  // otherwise the process starts afterwards and runs unbounded, which is exactly
+  // what the deadline exists to prevent.
+  it("kills a job that had not started when the cancel arrived", () => {
+    const kill = mock(() => {});
+
+    expect(cancelAudioJob(4)).toBe(false);
+    expect(isAudioJobCancelled(4)).toBe(true);
+
+    registerAudioJob(4, { kill });
+
+    expect(kill).toHaveBeenCalledWith("SIGKILL");
+    expect(runningAudioJobCount()).toBe(0);
+  });
+
+  // And the memory of it is bounded: a job that ends clears its own flag, so a
+  // later id reusing that number is not born cancelled.
+  it("forgets the cancellation once the job is done", () => {
+    cancelAudioJob(5);
+    expect(isAudioJobCancelled(5)).toBe(true);
+
+    completeAudioJob(5);
+
+    expect(isAudioJobCancelled(5)).toBe(false);
   });
 });

--- a/src/baileys/helpers/audioJobs.spec.ts
+++ b/src/baileys/helpers/audioJobs.spec.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+import {
+  cancelAudioJob,
+  completeAudioJob,
+  registerAudioJob,
+  runningAudioJobCount,
+} from "@/baileys/helpers/audioJobs";
+
+describe("audioJobs", () => {
+  beforeEach(() => {
+    // Ids are unique per process in the worker, so leaking across examples here
+    // would hide a registry that never empties.
+    for (let id = 0; id < 10; id++) {
+      completeAudioJob(id);
+    }
+  });
+
+  // The reason this registry exists: the worker's onmessage is async, so it has
+  // already started an ffmpeg child process and moved on to the next message.
+  // Abandoning the promise leaves that process running until it finishes on its
+  // own, which for the wedged conversion the deadline exists for is never.
+  it("kills the ffmpeg command behind an abandoned job", () => {
+    const kill = mock(() => {});
+    registerAudioJob(1, { kill });
+
+    expect(cancelAudioJob(1)).toBe(true);
+    expect(kill).toHaveBeenCalledWith("SIGKILL");
+    expect(runningAudioJobCount()).toBe(0);
+  });
+
+  // A job that finished normally is gone, so a cancel arriving late must be a
+  // no-op rather than reach into a command that has already been cleaned up.
+  it("is inert for a job that already completed", () => {
+    const kill = mock(() => {});
+    registerAudioJob(2, { kill });
+    completeAudioJob(2);
+
+    expect(cancelAudioJob(2)).toBe(false);
+    expect(kill).not.toHaveBeenCalled();
+  });
+
+  it("is inert for a job it never saw", () => {
+    expect(cancelAudioJob(3)).toBe(false);
+  });
+});

--- a/src/baileys/helpers/audioJobs.ts
+++ b/src/baileys/helpers/audioJobs.ts
@@ -1,0 +1,40 @@
+// The audio worker starts an independent ffmpeg child process per message it
+// receives -- its onmessage is async and does not serialise -- so a conversion
+// the caller has abandoned keeps a process, a temp file and its memory alive
+// until it finishes on its own, which for a wedged job is never. The worker pool
+// being fixed-size bounds the number of WORKERS, not the number of children.
+//
+// This is the bookkeeping that lets the worker kill an abandoned job. It lives
+// outside the worker file so it can be tested: importing that file requires a
+// Worker global and would register a message handler.
+export interface KillableJob {
+  kill(signal: string): void;
+}
+
+const running = new Map<number, KillableJob>();
+
+export function registerAudioJob(id: number, job: KillableJob): void {
+  running.set(id, job);
+}
+
+export function completeAudioJob(id: number): void {
+  running.delete(id);
+}
+
+// SIGKILL rather than SIGTERM: the case this exists for is a conversion that
+// stopped making progress, and a process in that state is the one least likely
+// to act on a polite signal. Killing makes the command emit `error`, so the
+// worker's own finally still removes the temp file.
+export function cancelAudioJob(id: number): boolean {
+  const job = running.get(id);
+  if (!job) {
+    return false;
+  }
+  running.delete(id);
+  job.kill("SIGKILL");
+  return true;
+}
+
+export function runningAudioJobCount(): number {
+  return running.size;
+}

--- a/src/baileys/helpers/audioJobs.ts
+++ b/src/baileys/helpers/audioJobs.ts
@@ -18,6 +18,13 @@ const running = new Map<number, KillableJob>();
 // cancellation there lets the process start afterwards and run unbounded, which
 // is the exact outcome the deadline exists to prevent.
 const cancelled = new Set<number>();
+// The tombstone only has to outlive fluent-ffmpeg's preparation, which is
+// milliseconds. It is expired rather than left in place because a cancel can
+// also lose the race to a job that already completed -- the worker finished and
+// posted, the caller's deadline fired before that message was handled -- and
+// nothing would ever clear THAT id. One narrow race per audio send is enough to
+// grow this set without bound over the life of a worker.
+const CANCEL_TOMBSTONE_MS = 60_000;
 
 export function registerAudioJob(id: number, job: KillableJob): void {
   running.set(id, job);
@@ -42,6 +49,8 @@ export function completeAudioJob(id: number): void {
 // worker's own finally still removes the temp file.
 export function cancelAudioJob(id: number): boolean {
   cancelled.add(id);
+  const expiry = setTimeout(() => cancelled.delete(id), CANCEL_TOMBSTONE_MS);
+  expiry.unref?.();
   const job = running.get(id);
   if (!job) {
     return false;

--- a/src/baileys/helpers/audioJobs.ts
+++ b/src/baileys/helpers/audioJobs.ts
@@ -12,13 +12,28 @@ export interface KillableJob {
 }
 
 const running = new Map<number, KillableJob>();
+// Cancellations that arrived before there was anything to kill. fluent-ffmpeg
+// spawns asynchronously: during _prepare and its capability probing there is no
+// ffmpegProc yet, and kill() is a no-op that only logs. Forgetting the
+// cancellation there lets the process start afterwards and run unbounded, which
+// is the exact outcome the deadline exists to prevent.
+const cancelled = new Set<number>();
 
 export function registerAudioJob(id: number, job: KillableJob): void {
   running.set(id, job);
+  // The cancel may already have been decided while this job was still preparing.
+  if (cancelled.has(id)) {
+    cancelAudioJob(id);
+  }
+}
+
+export function isAudioJobCancelled(id: number): boolean {
+  return cancelled.has(id);
 }
 
 export function completeAudioJob(id: number): void {
   running.delete(id);
+  cancelled.delete(id);
 }
 
 // SIGKILL rather than SIGTERM: the case this exists for is a conversion that
@@ -26,6 +41,7 @@ export function completeAudioJob(id: number): void {
 // to act on a polite signal. Killing makes the command emit `error`, so the
 // worker's own finally still removes the temp file.
 export function cancelAudioJob(id: number): boolean {
+  cancelled.add(id);
   const job = running.get(id);
   if (!job) {
     return false;

--- a/src/baileys/helpers/isTxMutexTimeout.ts
+++ b/src/baileys/helpers/isTxMutexTimeout.ts
@@ -22,3 +22,15 @@ export function isTxMutexTimeout(error: unknown): boolean {
     (error as { data: { code?: unknown } }).data.code === TX_MUTEX_TIMEOUT_CODE
   );
 }
+
+// The keystore key the timed-out acquisition was waiting on, straight from the
+// Boom the patch throws. Read from OUR OWN send's failure, this is the only
+// unambiguous statement of which mutex is blocking sends: a `stalled` event
+// names whatever key happened to be held long, which is often an unrelated one.
+export function txMutexTimeoutKey(error: unknown): string | null {
+  if (!isTxMutexTimeout(error)) {
+    return null;
+  }
+  const key = (error as { data: { key?: unknown } }).data.key;
+  return typeof key === "string" ? key : null;
+}

--- a/src/baileys/helpers/isTxMutexTimeout.ts
+++ b/src/baileys/helpers/isTxMutexTimeout.ts
@@ -1,0 +1,24 @@
+// The sentinel the patched `addTransactionCapability` puts on the Boom it
+// throws when a keystore transaction gives up waiting for its mutex. Kept as a
+// string constant rather than an imported class because the throw site lives
+// inside node_modules: there is no shared type to instanceof against, and the
+// spec that guards the patch (authTransactionTimeout.spec.ts) asserts on this
+// same literal appearing in the installed file.
+export const TX_MUTEX_TIMEOUT_CODE = "E_TX_MUTEX_TIMEOUT";
+
+// Distinguishes "the operation left the mutex queue" from "the operation left
+// because the mutex is wedged". Both are rejections and both mean nothing is
+// parked any more, but only the first is evidence the connection recovered:
+// this one reports the wedge that the send-stall watchdog exists to contain.
+export function isTxMutexTimeout(error: unknown): boolean {
+  if (typeof error !== "object" || error === null) {
+    return false;
+  }
+  const data = (error as { data?: unknown }).data;
+  if (typeof data !== "object" || data === null) {
+    return false;
+  }
+  return (
+    (error as { data: { code?: unknown } }).data.code === TX_MUTEX_TIMEOUT_CODE
+  );
+}

--- a/src/baileys/helpers/preprocessAudio.ts
+++ b/src/baileys/helpers/preprocessAudio.ts
@@ -7,6 +7,13 @@ interface PendingRequest {
   reject: (error: Error) => void;
 }
 
+export class AudioPreprocessAbortedError extends Error {
+  constructor() {
+    super("audio preprocessing aborted");
+    this.name = "AudioPreprocessAbortedError";
+  }
+}
+
 const POOL_SIZE =
   typeof navigator !== "undefined" && navigator.hardwareConcurrency
     ? navigator.hardwareConcurrency
@@ -62,10 +69,26 @@ function getWorkerPool(): Worker[] {
   return workers;
 }
 
+// `signal` is how a caller that has stopped waiting says so. Without it a
+// abandoned conversion leaves its entry in pendingRequests and its promise
+// pending for as long as the worker takes -- forever if the job is wedged, which
+// is exactly the case a deadline exists for.
+//
+// It deliberately does NOT terminate the worker. The pool is fixed-size and
+// round-robin, so several conversions share one worker: killing it to reclaim a
+// slot would take healthy jobs down with it. Nothing accumulates either way --
+// no process per request, and the reply handler already drops an entry it no
+// longer recognises. What remains is that a genuinely wedged ffmpeg costs a pool
+// slot, which is a property of the pool, not of this deadline.
 export async function preprocessAudio(
   audio: Buffer,
   format: AudioFormat,
+  signal?: AbortSignal,
 ): Promise<Buffer> {
+  if (signal?.aborted) {
+    throw new AudioPreprocessAbortedError();
+  }
+
   const pool = getWorkerPool();
   const worker = pool[nextWorkerIndex % pool.length];
   nextWorkerIndex++;
@@ -74,7 +97,23 @@ export async function preprocessAudio(
   const arrayBuffer = new Uint8Array(audio).buffer as ArrayBuffer;
 
   return new Promise<Buffer>((resolve, reject) => {
-    pendingRequests.set(id, { resolve, reject });
+    const onAbort = () => {
+      // Only if it is still ours: a reply that arrived first already removed it.
+      if (pendingRequests.delete(id)) {
+        reject(new AudioPreprocessAbortedError());
+      }
+    };
+    const settle = <T>(finish: (value: T) => void) => {
+      return (value: T) => {
+        signal?.removeEventListener("abort", onAbort);
+        finish(value);
+      };
+    };
+    pendingRequests.set(id, {
+      resolve: settle(resolve),
+      reject: settle(reject),
+    });
+    signal?.addEventListener("abort", onAbort, { once: true });
     worker.postMessage({ id, audio: arrayBuffer, format }, [arrayBuffer]);
   });
 }

--- a/src/baileys/helpers/preprocessAudio.ts
+++ b/src/baileys/helpers/preprocessAudio.ts
@@ -74,12 +74,11 @@ function getWorkerPool(): Worker[] {
 // pending for as long as the worker takes -- forever if the job is wedged, which
 // is exactly the case a deadline exists for.
 //
-// It deliberately does NOT terminate the worker. The pool is fixed-size and
-// round-robin, so several conversions share one worker: killing it to reclaim a
-// slot would take healthy jobs down with it. Nothing accumulates either way --
-// no process per request, and the reply handler already drops an entry it no
-// longer recognises. What remains is that a genuinely wedged ffmpeg costs a pool
-// slot, which is a property of the pool, not of this deadline.
+// It does not TERMINATE the worker, and does not need to: the pool is
+// round-robin, so several conversions share one worker and killing it to reclaim
+// a slot would take healthy jobs down with it. What the abort does instead is
+// tell that worker to kill the one job, which is the thing actually holding
+// resources -- the worker itself is idle between messages.
 export async function preprocessAudio(
   audio: Buffer,
   format: AudioFormat,
@@ -99,9 +98,16 @@ export async function preprocessAudio(
   return new Promise<Buffer>((resolve, reject) => {
     const onAbort = () => {
       // Only if it is still ours: a reply that arrived first already removed it.
-      if (pendingRequests.delete(id)) {
-        reject(new AudioPreprocessAbortedError());
+      if (!pendingRequests.delete(id)) {
+        return;
       }
+      // Dropping our callback is not enough. The worker's onmessage is async, so
+      // it started an ffmpeg CHILD PROCESS for this job and is already free to
+      // start another for the next one; abandoning it leaves that process, its
+      // temp file and its memory alive until it finishes on its own, which for
+      // the wedged job this deadline exists for is never.
+      worker.postMessage({ id, cancel: true });
+      reject(new AudioPreprocessAbortedError());
     };
     const settle = <T>(finish: (value: T) => void) => {
       return (value: T) => {

--- a/src/baileys/helpers/preprocessAudioWorker.ts
+++ b/src/baileys/helpers/preprocessAudioWorker.ts
@@ -3,6 +3,11 @@ import { promises as fs } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Readable } from "node:stream";
+import {
+  cancelAudioJob,
+  completeAudioJob,
+  registerAudioJob,
+} from "@/baileys/helpers/audioJobs";
 import ffmpeg from "@/bindings/ffmpeg";
 
 declare var self: Worker;
@@ -15,6 +20,7 @@ function bufferToStream(buffer: Buffer) {
 }
 
 async function processAudio(
+  id: number,
   audio: Buffer,
   format: "ogg-low" | "mp3-high" | "wav",
 ): Promise<Buffer> {
@@ -24,6 +30,9 @@ async function processAudio(
   );
   try {
     const command = ffmpeg(bufferToStream(audio));
+    // Registered before any option is set, so a cancel arriving in the same tick
+    // as the job still finds something to kill.
+    registerAudioJob(id, command);
 
     if (format === "wav") {
       command
@@ -56,6 +65,7 @@ async function processAudio(
     );
     return await fs.readFile(tmpFilename);
   } finally {
+    completeAudioJob(id);
     try {
       await fs.unlink(tmpFilename);
     } catch {
@@ -67,13 +77,23 @@ async function processAudio(
 self.onmessage = async (
   event: MessageEvent<{
     id: number;
-    audio: ArrayBuffer;
-    format: "ogg-low" | "mp3-high" | "wav";
+    audio?: ArrayBuffer;
+    format?: "ogg-low" | "mp3-high" | "wav";
+    cancel?: boolean;
   }>,
 ) => {
-  const { id, audio, format } = event.data;
+  const { id, audio, format, cancel } = event.data;
+  // The caller stopped waiting. Nothing is posted back: it already dropped its
+  // entry, and the reply handler discards ids it no longer recognises.
+  if (cancel) {
+    cancelAudioJob(id);
+    return;
+  }
+  if (!audio || !format) {
+    return;
+  }
   try {
-    const result = await processAudio(Buffer.from(audio), format);
+    const result = await processAudio(id, Buffer.from(audio), format);
     const arrayBuffer = new Uint8Array(result).buffer as ArrayBuffer;
     self.postMessage({ id, result: arrayBuffer }, [arrayBuffer]);
   } catch (error) {

--- a/src/baileys/helpers/preprocessAudioWorker.ts
+++ b/src/baileys/helpers/preprocessAudioWorker.ts
@@ -6,6 +6,7 @@ import { Readable } from "node:stream";
 import {
   cancelAudioJob,
   completeAudioJob,
+  isAudioJobCancelled,
   registerAudioJob,
 } from "@/baileys/helpers/audioJobs";
 import ffmpeg from "@/bindings/ffmpeg";
@@ -59,6 +60,14 @@ async function processAudio(
 
     await new Promise<void>((ffResolve, ffReject) =>
       command
+        // The only moment ffmpegProc is guaranteed to exist. A cancel decided
+        // while fluent-ffmpeg was still preparing found nothing to kill, so this
+        // is where that decision is finally carried out.
+        .on("start", () => {
+          if (isAudioJobCancelled(id)) {
+            command.kill("SIGKILL");
+          }
+        })
         .on("end", () => ffResolve())
         .on("error", (err) => ffReject(err))
         .save(tmpFilename),

--- a/src/baileys/linkPreviewTimeout.spec.ts
+++ b/src/baileys/linkPreviewTimeout.spec.ts
@@ -4,6 +4,7 @@ import { readFileSync } from "node:fs";
 // preload mocks "@whiskeysockets/baileys", and the package has no "exports"
 // map, so this path resolves the real, patched file.
 import { getUrlInfo } from "@whiskeysockets/baileys/lib/Utils/link-preview.js";
+import { getHttpStream } from "@whiskeysockets/baileys/lib/Utils/messages-media.js";
 
 const PATCHED_FILE =
   "node_modules/@whiskeysockets/baileys/lib/Utils/link-preview.js";
@@ -52,6 +53,38 @@ describe("patched link preview", () => {
       ]);
 
       expect(seenSignal).not.toBeNull();
+      expect(outcome).toBe("settled");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  // The thumbnail download that follows the oEmbed. messages-send.js hands it
+  // BOTH budgets -- `{ timeout: 3000, ...httpRequestOptions }` -- and taking the
+  // 120s one means a stalled thumbnail outlives the 45s send deadline, so the
+  // caller gets an unknown-outcome 504 and the connection a stall strike, for a
+  // keystore that was never touched. A thumbnail is worth 3s.
+  it("prefers the tighter link-preview budget for the thumbnail download", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = ((_url: unknown, init?: { signal?: AbortSignal }) =>
+      new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () =>
+          reject(new Error("aborted")),
+        );
+      })) as unknown as typeof fetch;
+
+    try {
+      const outcome = await Promise.race([
+        getHttpStream("https://example.com/thumb.jpg", {
+          timeout: 20,
+          timeoutMs: 120_000,
+        } as never).then(
+          () => "settled",
+          () => "settled",
+        ),
+        new Promise((resolve) => setTimeout(() => resolve("hung"), 500)),
+      ]);
+
       expect(outcome).toBe("settled");
     } finally {
       globalThis.fetch = originalFetch;

--- a/src/baileys/linkPreviewTimeout.spec.ts
+++ b/src/baileys/linkPreviewTimeout.spec.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+// Deep specifier on purpose, exactly as in authTransactionTimeout.spec.ts: the
+// preload mocks "@whiskeysockets/baileys", and the package has no "exports"
+// map, so this path resolves the real, patched file.
+import { getUrlInfo } from "@whiskeysockets/baileys/lib/Utils/link-preview.js";
+
+const PATCHED_FILE =
+  "node_modules/@whiskeysockets/baileys/lib/Utils/link-preview.js";
+
+describe("patched link preview", () => {
+  // The number-one failure mode of a fix delivered by patch is the patch
+  // silently not applying. Cheap guard, same as the transaction sentinel.
+  it("carries the abort signal into the installed file", () => {
+    expect(readFileSync(PATCHED_FILE, "utf8")).toContain("AbortSignal.timeout");
+  });
+
+  // The same shape as the bug this whole change is about: a fetch with no
+  // deadline, on the send path. This one does not sit inside the keystore mutex,
+  // so it does not mute the connection -- it holds the send until the app-level
+  // deadline gives up, counts a stall strike against a healthy keystore, and
+  // leaks the request. Three of those open the breaker on a connection whose
+  // mutex was never touched.
+  it("aborts a parked YouTube oEmbed request instead of holding the send", async () => {
+    const originalFetch = globalThis.fetch;
+    let seenSignal: AbortSignal | null = null;
+    globalThis.fetch = ((_url: unknown, init?: { signal?: AbortSignal }) => {
+      seenSignal = init?.signal ?? null;
+      // Never resolves on its own: only the signal can end this.
+      return new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () =>
+          reject(new Error("aborted")),
+        );
+      });
+    }) as unknown as typeof fetch;
+
+    try {
+      // Raced rather than awaited: without the signal this never settles, and a
+      // hung example is a worse CI failure than a failed assertion.
+      const outcome = await Promise.race([
+        getUrlInfo("https://www.youtube.com/watch?v=dQw4w9WgXcQ", {
+          thumbnailWidth: 192,
+          fetchOpts: { timeout: 20 },
+          // getUrlInfo rethrows anything that is not a "receive a valid" parse
+          // failure, so the abort surfaces as a rejection. Either way is a pass:
+          // the property under test is that it SETTLES.
+        } as never).then(
+          () => "settled",
+          () => "settled",
+        ),
+        new Promise((resolve) => setTimeout(() => resolve("hung"), 500)),
+      ]);
+
+      expect(seenSignal).not.toBeNull();
+      expect(outcome).toBe("settled");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});

--- a/src/baileys/types.ts
+++ b/src/baileys/types.ts
@@ -58,7 +58,7 @@ export interface BaileysConnectionWebhookPayload {
         sendStall?: {
           consecutiveTimeouts: number;
           stalledForMs: number;
-          action: "restart" | "suppressed";
+          action: "restart" | "suppressed" | "cancelled";
           until?: string;
         };
       };

--- a/src/baileys/types.ts
+++ b/src/baileys/types.ts
@@ -35,6 +35,12 @@ export interface BaileysConnectionOptions {
   // requestLogout: the restart has to participate in the handler's inFlightOps
   // lock rather than bypass it. See the send-stall watchdog in connection.ts.
   requestRestart?: (reason: string) => void;
+  // Invoked when this connection gives up rebuilding its own socket and aborts.
+  // The handler has evicted it by then, but the LEASE is the coordinator's: the
+  // claim scan skips any phone that already has one, so without this the number
+  // stays dark until the TTL and the unclaimed grace expire while requests route
+  // here and 404.
+  onUnrecoverable?: () => void;
 }
 
 export interface BaileysConnectionWebhookPayload {

--- a/src/baileys/types.ts
+++ b/src/baileys/types.ts
@@ -30,6 +30,11 @@ export interface BaileysConnectionOptions {
   // inFlightOps lock instead of bypassing it. Wired by the handler, mirroring
   // onConnectionClose. See issue #313.
   requestLogout?: () => void;
+  // Invoked by the connection when its sends keep timing out and the socket has
+  // to be recreated. Goes through the handler for the same reason as
+  // requestLogout: the restart has to participate in the handler's inFlightOps
+  // lock rather than bypass it. See the send-stall watchdog in connection.ts.
+  requestRestart?: (reason: string) => void;
 }
 
 export interface BaileysConnectionWebhookPayload {
@@ -45,6 +50,17 @@ export interface BaileysConnectionWebhookPayload {
         // quarantine: consecutive failed reconnect cycles and when background
         // claims will retry. Explicit POST /connections retries immediately.
         quarantine?: { strikes: number; until: string };
+        // Present on send_stall_detected: the connection is receiving and
+        // answering health checks but every send times out. `action` says
+        // whether the socket was recreated or the restart was held back (by
+        // config or by backoff), and `until` when a held-back restart may
+        // next run.
+        sendStall?: {
+          consecutiveTimeouts: number;
+          stalledForMs: number;
+          action: "restart" | "suppressed";
+          until?: string;
+        };
       };
   extra?: unknown;
 }

--- a/src/baileys/types.ts
+++ b/src/baileys/types.ts
@@ -64,7 +64,7 @@ export interface BaileysConnectionWebhookPayload {
         sendStall?: {
           consecutiveTimeouts: number;
           stalledForMs: number;
-          action: "restart" | "suppressed" | "cancelled";
+          action: "restart" | "suppressed" | "cancelled" | "failed";
           until?: string;
         };
       };

--- a/src/cluster/coordinator.spec.ts
+++ b/src/cluster/coordinator.spec.ts
@@ -386,6 +386,30 @@ describe("ClusterCoordinator", () => {
       // Released under the epoch acquired in this same cycle.
       expect(releaseLease).toHaveBeenCalledWith("+5511999", 1);
     });
+
+    // An explicit connect, import or restart can force-acquire its own lease
+    // while this spawn is awaiting. The pre-connect guard catches that race
+    // before the attempt, but nothing stops it landing during one -- and
+    // releasing by "whatever we hold now" would hand away that operation's lease,
+    // leaving its live socket with nobody renewing it and free for any claim loop
+    // to take.
+    it("releases the failed claim's own epoch, not a newer one", async () => {
+      const handler = makeHandlerMock();
+      const coordinator = makeCoordinator(handler);
+      handler.connect.mockImplementationOnce(async () => {
+        // A concurrent explicit operation force-acquires while we are awaiting.
+        (
+          coordinator as unknown as { heldLeaseEpochs: Map<string, number> }
+        ).heldLeaseEpochs.set("+5511999", 9);
+        throw new Error("boom");
+      });
+      getRedisSavedAuthStateIds.mockResolvedValue([savedEntry("+5511999")]);
+
+      await coordinator.runClaimCycle();
+
+      expect(releaseLease).toHaveBeenCalledWith("+5511999", 1);
+      expect(releaseLease).not.toHaveBeenCalledWith("+5511999", 9);
+    });
   });
 
   describe("#runRebalanceCycle", () => {

--- a/src/cluster/coordinator.spec.ts
+++ b/src/cluster/coordinator.spec.ts
@@ -868,12 +868,70 @@ describe("ClusterCoordinator", () => {
 
       expect(restarted).toBe(true);
       expect(forceAcquireLease).toHaveBeenCalledWith("+5511999");
-      expect(handler.connect).toHaveBeenCalledWith("+5511999", {
-        ...storedMetadata,
-        isReconnect: true,
-        leaseEpoch: 1,
-        forceRestart: true,
-      });
+      expect(handler.connect).toHaveBeenCalledWith(
+        "+5511999",
+        {
+          ...storedMetadata,
+          isReconnect: true,
+          leaseEpoch: 1,
+          forceRestart: true,
+        },
+        expect.any(Function),
+      );
+    });
+
+    // The checks above ran before this restart queued behind the handler's per-phone
+    // lock. A DELETE holding that lock clears the auth state and takes its own lease on
+    // the way in, so proceeding on the metadata read earlier would create fresh unpaired
+    // credentials and answer 202 for the phone the operator just removed.
+    it("stops before the socket is rebuilt when another operation took the lease", async () => {
+      const handler = makeHandlerMock();
+      const coordinator = makeCoordinator(handler);
+      getRedisAuthMetadata.mockResolvedValue(storedMetadata);
+
+      await coordinator.restartWithLease("+5511999", "stall");
+
+      const shouldProceed = (
+        handler.connect.mock.calls[0] as unknown as [
+          string,
+          Record<string, unknown>,
+          () => boolean,
+        ]
+      )[2];
+      expect(shouldProceed()).toBe(true);
+
+      // Whatever ran while we were parked force-acquired its own lease.
+      (
+        coordinator as unknown as { heldLeaseEpochs: Map<string, number> }
+      ).heldLeaseEpochs.set("+5511999", 2);
+      expect(shouldProceed()).toBe(false);
+    });
+
+    // heldLeaseEpochs is where releaseHeldLease reads the epoch from, and it stops
+    // describing THIS operation the moment a concurrent explicit one force-acquires its
+    // own. Unwinding by the current value hands away that operation's lease and leaves
+    // its live socket unowned, free for any claim loop to take.
+    it("releases only the epoch it acquired when it unwinds", async () => {
+      const handler = makeHandlerMock();
+      const coordinator = makeCoordinator(handler);
+      getRedisAuthMetadata.mockImplementation((async () => {
+        // Another explicit operation took over while we were reading.
+        (
+          coordinator as unknown as { heldLeaseEpochs: Map<string, number> }
+        ).heldLeaseEpochs.set("+5511999", 2);
+        return null;
+      }) as typeof redisAuthState.getRedisAuthMetadata);
+
+      const restarted = await coordinator.restartWithLease("+5511999");
+
+      expect(restarted).toBe(false);
+      expect(releaseLease).toHaveBeenCalledWith("+5511999", 1);
+      expect(releaseLease).not.toHaveBeenCalledWith("+5511999", 2);
+      expect(
+        (
+          coordinator as unknown as { heldLeaseEpochs: Map<string, number> }
+        ).heldLeaseEpochs.get("+5511999"),
+      ).toBe(2);
     });
 
     // Taking options from the request would let a restart overwrite good
@@ -892,6 +950,7 @@ describe("ClusterCoordinator", () => {
           webhookUrl: storedMetadata.webhookUrl,
           webhookVerifyToken: storedMetadata.webhookVerifyToken,
         }),
+        expect.any(Function),
       );
     });
 

--- a/src/cluster/coordinator.spec.ts
+++ b/src/cluster/coordinator.spec.ts
@@ -13,6 +13,7 @@ import * as redisAuthState from "@/baileys/redisAuthState";
 import * as registry from "@/cluster/instanceRegistry";
 import * as leaseStore from "@/cluster/leaseStore";
 import * as quarantineStore from "@/cluster/quarantineStore";
+import * as sendStallStore from "@/cluster/sendStallStore";
 import config from "@/config";
 import {
   BaileysConnectionOwnedElsewhereError,
@@ -28,6 +29,7 @@ const getRedisSavedAuthStateIds = spyOn(
 const isRedisAuthStatePaired = spyOn(redisAuthState, "isRedisAuthStatePaired");
 const seedImportedSession = spyOn(redisAuthState, "seedImportedSession");
 const clearRedisAuthState = spyOn(redisAuthState, "clearRedisAuthState");
+const getRedisAuthMetadata = spyOn(redisAuthState, "getRedisAuthMetadata");
 const listLiveInstances = spyOn(registry, "listLiveInstances");
 const heartbeat = spyOn(registry, "heartbeat");
 const deregister = spyOn(registry, "deregister");
@@ -43,12 +45,14 @@ const setHandoffTarget = spyOn(leaseStore, "setHandoffTarget");
 const getHandoffTarget = spyOn(leaseStore, "getHandoffTarget");
 const isQuarantined = spyOn(quarantineStore, "isQuarantined");
 const clearQuarantine = spyOn(quarantineStore, "clearQuarantine");
+const clearSendStall = spyOn(sendStallStore, "clearSendStall");
 
 afterAll(() => {
   getRedisSavedAuthStateIds.mockRestore();
   isRedisAuthStatePaired.mockRestore();
   seedImportedSession.mockRestore();
   clearRedisAuthState.mockRestore();
+  getRedisAuthMetadata.mockRestore();
   listLiveInstances.mockRestore();
   heartbeat.mockRestore();
   deregister.mockRestore();
@@ -64,6 +68,7 @@ afterAll(() => {
   getHandoffTarget.mockRestore();
   isQuarantined.mockRestore();
   clearQuarantine.mockRestore();
+  clearSendStall.mockRestore();
 });
 
 function makeHandlerMock() {
@@ -143,7 +148,9 @@ describe("ClusterCoordinator", () => {
     getHandoffTarget.mockReset();
     isQuarantined.mockReset();
     clearQuarantine.mockReset();
+    clearSendStall.mockReset();
     clearRedisAuthState.mockReset();
+    getRedisAuthMetadata.mockReset();
 
     getRedisSavedAuthStateIds.mockResolvedValue([]);
     isRedisAuthStatePaired.mockResolvedValue(true);
@@ -166,7 +173,9 @@ describe("ClusterCoordinator", () => {
     getHandoffTarget.mockResolvedValue(null);
     isQuarantined.mockResolvedValue(false);
     clearQuarantine.mockResolvedValue(undefined);
+    clearSendStall.mockResolvedValue(undefined);
     clearRedisAuthState.mockResolvedValue(true);
+    getRedisAuthMetadata.mockResolvedValue(null);
   });
 
   describe("#runClaimCycle", () => {
@@ -843,6 +852,72 @@ describe("ClusterCoordinator", () => {
     });
   });
 
+  describe("#restartWithLease", () => {
+    const storedMetadata = {
+      webhookUrl: "https://stored.example/hook",
+      webhookVerifyToken: "stored-token",
+      clientName: "Stored Client",
+    };
+
+    it("rebuilds the socket from the stored metadata", async () => {
+      const handler = makeHandlerMock();
+      const coordinator = makeCoordinator(handler);
+      getRedisAuthMetadata.mockResolvedValue(storedMetadata);
+
+      const restarted = await coordinator.restartWithLease("+5511999", "stall");
+
+      expect(restarted).toBe(true);
+      expect(forceAcquireLease).toHaveBeenCalledWith("+5511999");
+      expect(handler.connect).toHaveBeenCalledWith("+5511999", {
+        ...storedMetadata,
+        isReconnect: true,
+        leaseEpoch: 1,
+        forceRestart: true,
+      });
+    });
+
+    // Taking options from the request would let a restart overwrite good
+    // webhook config with whatever the caller happened to send, which is why
+    // the route has no connection-options body at all.
+    it("takes no connection options from the caller", async () => {
+      const handler = makeHandlerMock();
+      const coordinator = makeCoordinator(handler);
+      getRedisAuthMetadata.mockResolvedValue(storedMetadata);
+
+      await coordinator.restartWithLease("+5511999");
+
+      expect(handler.connect).toHaveBeenCalledWith(
+        "+5511999",
+        expect.objectContaining({
+          webhookUrl: storedMetadata.webhookUrl,
+          webhookVerifyToken: storedMetadata.webhookVerifyToken,
+        }),
+      );
+    });
+
+    it("reports false when there is no stored session", async () => {
+      const handler = makeHandlerMock();
+      const coordinator = makeCoordinator(handler);
+      getRedisAuthMetadata.mockResolvedValue(null);
+
+      const restarted = await coordinator.restartWithLease("+5511999");
+
+      expect(restarted).toBe(false);
+      expect(forceAcquireLease).not.toHaveBeenCalled();
+      expect(handler.connect).not.toHaveBeenCalled();
+    });
+
+    it("clears quarantine — an operator asking for the phone wins now", async () => {
+      const handler = makeHandlerMock();
+      const coordinator = makeCoordinator(handler);
+      getRedisAuthMetadata.mockResolvedValue(storedMetadata);
+
+      await coordinator.restartWithLease("+5511999");
+
+      expect(clearQuarantine).toHaveBeenCalledWith("+5511999");
+    });
+  });
+
   describe("#importSessionWithLease", () => {
     const creds = { me: { id: "5511999:1@s.whatsapp.net" } } as never;
     const candidates = [
@@ -1053,6 +1128,18 @@ describe("ClusterCoordinator", () => {
       expect(clearRedisAuthState).toHaveBeenCalledWith("+5511999");
       expect(clearQuarantine).toHaveBeenCalledWith("+5511999");
       expect(releaseLease).toHaveBeenCalled();
+    });
+
+    // The send-stall backoff is keyed by phone number and outlives the session
+    // by up to 24h. Left behind, a re-paired number inherits the discarded
+    // session's backoff and has its stall watchdog suppressed.
+    it("clears the send-stall backoff along with the rest of the strike state", async () => {
+      const handler = makeHandlerMock();
+      const coordinator = makeCoordinator(handler);
+
+      await coordinator.logoutWithLease("+5511999");
+
+      expect(clearSendStall).toHaveBeenCalledWith("+5511999");
     });
 
     it("throws when the offline clear is fenced off", async () => {

--- a/src/cluster/coordinator.spec.ts
+++ b/src/cluster/coordinator.spec.ts
@@ -871,7 +871,7 @@ describe("ClusterCoordinator", () => {
 
       const restarted = await coordinator.restartWithLease("+5511999", "stall");
 
-      expect(restarted).toBe(true);
+      expect(restarted).toBe("restarted");
       expect(forceAcquireLease).toHaveBeenCalledWith("+5511999");
       expect(handler.connect).toHaveBeenCalledWith(
         "+5511999",
@@ -929,7 +929,7 @@ describe("ClusterCoordinator", () => {
 
       const restarted = await coordinator.restartWithLease("+5511999");
 
-      expect(restarted).toBe(false);
+      expect(restarted).toBe("not-found");
       expect(releaseLease).toHaveBeenCalledWith("+5511999", 1);
       expect(releaseLease).not.toHaveBeenCalledWith("+5511999", 2);
       expect(
@@ -952,10 +952,28 @@ describe("ClusterCoordinator", () => {
 
       const restarted = await coordinator.restartWithLease("+5511999");
 
-      expect(restarted).toBe(false);
+      expect(restarted).toBe("not-found");
       expect(releaseLease).not.toHaveBeenCalled();
       // And the socket is told which epoch owns it now, or its webhooks are
       // discarded by the client as stale.
+      expect(handler.updateLeaseEpoch).toHaveBeenCalledWith("+5511999", 1);
+    });
+
+    // A Redis blip while inspecting the session must not strand a socket that is
+    // still serving: abandoning the lease stops the renewals under a live
+    // connection, which is the one outcome an inspection failure has no business
+    // causing.
+    it("keeps the lease when the inspection itself fails under a live socket", async () => {
+      const handler = makeHandlerMock();
+      const coordinator = makeCoordinator(handler);
+      handler.connections.add("+5511999");
+      getRedisAuthMetadata.mockRejectedValue(new Error("redis down"));
+
+      await expect(coordinator.restartWithLease("+5511999")).rejects.toThrow(
+        "redis down",
+      );
+
+      expect(releaseLease).not.toHaveBeenCalled();
       expect(handler.updateLeaseEpoch).toHaveBeenCalledWith("+5511999", 1);
     });
 
@@ -969,7 +987,9 @@ describe("ClusterCoordinator", () => {
 
       const restarted = await coordinator.restartWithLease("+5511999");
 
-      expect(restarted).toBe(false);
+      // Not "not-found": the phone usually still has a perfectly good session,
+      // and 404 would send the caller off to re-pair what somebody else rebuilt.
+      expect(restarted).toBe("superseded");
     });
 
     // Taking options from the request would let a restart overwrite good
@@ -1004,7 +1024,7 @@ describe("ClusterCoordinator", () => {
 
       const restarted = await coordinator.restartWithLease("+5511999");
 
-      expect(restarted).toBe(false);
+      expect(restarted).toBe("not-found");
       expect(forceAcquireLease).toHaveBeenCalled();
       expect(releaseLease).toHaveBeenCalledWith("+5511999", 1);
       expect(handler.connect).not.toHaveBeenCalled();
@@ -1022,7 +1042,7 @@ describe("ClusterCoordinator", () => {
 
       const restarted = await coordinator.restartWithLease("+5511999");
 
-      expect(restarted).toBe(false);
+      expect(restarted).toBe("not-found");
       expect(forceAcquireLease).toHaveBeenCalled();
       expect(releaseLease).toHaveBeenCalledWith("+5511999", 1);
       expect(handler.connect).not.toHaveBeenCalled();

--- a/src/cluster/coordinator.spec.ts
+++ b/src/cluster/coordinator.spec.ts
@@ -706,6 +706,45 @@ describe("ClusterCoordinator", () => {
       expect(handler.discardConnection).not.toHaveBeenCalled();
     });
 
+    // heldLeaseEpochs is not the only holder of the epoch. The socket stamps its
+    // connection.update webhooks with the one it was given, and it is what
+    // onSpawnFailed hands to abandonExplicitLease when a background reconnect
+    // gives up. That release is epoch-fenced on both sides, so leaving the socket
+    // on the pre-re-acquire epoch turns the release into a silent no-op and the
+    // lease we just took back sits held with no socket behind it until its TTL.
+    it("hands the re-acquired epoch to the socket, not just to its own map", async () => {
+      const handler = makeHandlerMock();
+      handler.connections.add("+5511999");
+      const coordinator = makeCoordinator(handler);
+      renewLease.mockResolvedValue("missing");
+      acquireLease.mockResolvedValue({ owner: "test-instance", epoch: 7 });
+
+      await coordinator.runRenewCycle();
+
+      expect(handler.updateLeaseEpoch).toHaveBeenCalledWith("+5511999", 7);
+    });
+
+    // A metadata write that fails is not evidence that Redis is down -- the renew
+    // and the re-acquire both just succeeded through it. Letting it reach the
+    // outer catch would pause every claim in the cluster over a write that only
+    // affects one socket's epoch stamp.
+    it("keeps going when the epoch cannot be propagated", async () => {
+      const handler = makeHandlerMock();
+      handler.connections.add("+5511999");
+      const coordinator = makeCoordinator(handler);
+      renewLease.mockResolvedValue("missing");
+      acquireLease.mockResolvedValue({ owner: "test-instance", epoch: 7 });
+      handler.updateLeaseEpoch.mockRejectedValueOnce(new Error("redis down"));
+
+      await coordinator.runRenewCycle();
+
+      expect(handler.discardConnection).not.toHaveBeenCalled();
+      // Not degraded: claims keep running.
+      getRedisSavedAuthStateIds.mockClear();
+      await coordinator.runClaimCycle();
+      expect(getRedisSavedAuthStateIds).toHaveBeenCalled();
+    });
+
     it("fences when the missing lease was already taken by someone else", async () => {
       const handler = makeHandlerMock();
       handler.connections.add("+5511999");

--- a/src/cluster/coordinator.spec.ts
+++ b/src/cluster/coordinator.spec.ts
@@ -912,10 +912,11 @@ describe("ClusterCoordinator", () => {
       expect(shouldProceed()).toBe(false);
     });
 
-    // heldLeaseEpochs is where releaseHeldLease reads the epoch from, and it stops
-    // describing THIS operation the moment a concurrent explicit one force-acquires its
-    // own. Unwinding by the current value hands away that operation's lease and leaves
-    // its live socket unowned, free for any claim loop to take.
+    // heldLeaseEpochs stops describing THIS operation the moment a concurrent explicit
+    // one force-acquires its own. Unwinding by the current value would hand away that
+    // operation's lease and leave its live socket unowned, free for any claim loop to
+    // take; stamping our older epoch into its connection would leave every webhook it
+    // sends discarded by the client as stale.
     it("releases only the epoch it acquired when it unwinds", async () => {
       const handler = makeHandlerMock();
       const coordinator = makeCoordinator(handler);
@@ -930,8 +931,9 @@ describe("ClusterCoordinator", () => {
       const restarted = await coordinator.restartWithLease("+5511999");
 
       expect(restarted).toBe("not-found");
-      expect(releaseLease).toHaveBeenCalledWith("+5511999", 1);
-      expect(releaseLease).not.toHaveBeenCalledWith("+5511999", 2);
+      // Nothing is given back and nothing is corrected: the lease is not ours to
+      // unwind, and its owner's socket already carries its own epoch.
+      expect(releaseLease).not.toHaveBeenCalled();
       expect(
         (
           coordinator as unknown as { heldLeaseEpochs: Map<string, number> }
@@ -975,6 +977,28 @@ describe("ClusterCoordinator", () => {
 
       expect(releaseLease).not.toHaveBeenCalled();
       expect(handler.updateLeaseEpoch).toHaveBeenCalledWith("+5511999", 1);
+    });
+
+    // Same rule, the other outcome: with a live socket under a lease that is no
+    // longer ours, the correction we would apply belongs to the newer operation and
+    // would stamp its webhooks with our older epoch.
+    it("leaves a newer operation's connection untouched when unwinding", async () => {
+      const handler = makeHandlerMock();
+      const coordinator = makeCoordinator(handler);
+      handler.connections.add("+5511999");
+      isRedisAuthStatePaired.mockResolvedValue(false);
+      getRedisAuthMetadata.mockImplementation((async () => {
+        (
+          coordinator as unknown as { heldLeaseEpochs: Map<string, number> }
+        ).heldLeaseEpochs.set("+5511999", 2);
+        return storedMetadata;
+      }) as typeof redisAuthState.getRedisAuthMetadata);
+
+      const restarted = await coordinator.restartWithLease("+5511999");
+
+      expect(restarted).toBe("not-found");
+      expect(handler.updateLeaseEpoch).not.toHaveBeenCalled();
+      expect(releaseLease).not.toHaveBeenCalled();
     });
 
     // A veto after the drain means nothing was rebuilt. Reporting it as success

--- a/src/cluster/coordinator.spec.ts
+++ b/src/cluster/coordinator.spec.ts
@@ -895,7 +895,12 @@ describe("ClusterCoordinator", () => {
       );
     });
 
-    it("reports false when there is no stored session", async () => {
+    // The lease is taken BEFORE the session is inspected, and given back when there
+    // turns out to be nothing to restart. Reading first would let a restart racing a
+    // logout or an options update rebuild from state the previous owner was still
+    // entitled to change; holding the lease afterwards would route 421s here until
+    // the TTL expires, for a phone this instance just declined to serve.
+    it("reports false when there is no stored session, releasing the lease it took", async () => {
       const handler = makeHandlerMock();
       const coordinator = makeCoordinator(handler);
       getRedisAuthMetadata.mockResolvedValue(null);
@@ -903,7 +908,8 @@ describe("ClusterCoordinator", () => {
       const restarted = await coordinator.restartWithLease("+5511999");
 
       expect(restarted).toBe(false);
-      expect(forceAcquireLease).not.toHaveBeenCalled();
+      expect(forceAcquireLease).toHaveBeenCalled();
+      expect(releaseLease).toHaveBeenCalledWith("+5511999", 1);
       expect(handler.connect).not.toHaveBeenCalled();
     });
 
@@ -920,8 +926,27 @@ describe("ClusterCoordinator", () => {
       const restarted = await coordinator.restartWithLease("+5511999");
 
       expect(restarted).toBe(false);
-      expect(forceAcquireLease).not.toHaveBeenCalled();
+      expect(forceAcquireLease).toHaveBeenCalled();
+      expect(releaseLease).toHaveBeenCalledWith("+5511999", 1);
       expect(handler.connect).not.toHaveBeenCalled();
+    });
+
+    // The ordering, not just the outcome: until the lease moves, the previous owner
+    // may still rewrite the metadata (an options update) or delete the auth state (a
+    // logout). Reading first means a restart racing either one rebuilds from
+    // configuration that has since been superseded.
+    it("takes the lease before reading the stored session", async () => {
+      const handler = makeHandlerMock();
+      const coordinator = makeCoordinator(handler);
+      let leaseHeldAtRead = false;
+      getRedisAuthMetadata.mockImplementation((async () => {
+        leaseHeldAtRead = forceAcquireLease.mock.calls.length > 0;
+        return storedMetadata;
+      }) as typeof redisAuthState.getRedisAuthMetadata);
+
+      await coordinator.restartWithLease("+5511999");
+
+      expect(leaseHeldAtRead).toBe(true);
     });
 
     it("clears quarantine — an operator asking for the phone wins now", async () => {

--- a/src/cluster/coordinator.spec.ts
+++ b/src/cluster/coordinator.spec.ts
@@ -77,6 +77,10 @@ function makeHandlerMock() {
     string,
     { inFlightWebhooks: number; lastTrafficAt: number | null }
   >();
+  // What a live connection currently answers for currentOptions -- which a POST
+  // /connections mutates in place, so it is not what the connection was spawned
+  // with and not necessarily what Redis holds.
+  const liveOptions = new Map<string, Record<string, unknown>>();
   const handler = {
     connections,
     activity,
@@ -99,6 +103,9 @@ function makeHandlerMock() {
       return connections.size;
     },
     updateLeaseEpoch: mock(async (_phone: string, _epoch: number) => {}),
+    liveOptions,
+    currentConnectionOptions: (phone: string) =>
+      connections.has(phone) ? (liveOptions.get(phone) ?? null) : null,
     inFlightWebhookCount: () => 0,
     connectionActivity: (phone: string) =>
       connections.has(phone)
@@ -901,6 +908,44 @@ describe("ClusterCoordinator", () => {
         "+5511999",
         {
           ...storedMetadata,
+          isReconnect: true,
+          leaseEpoch: 1,
+          forceRestart: true,
+        },
+        expect.any(Function),
+      );
+    });
+
+    // The lease fences other instances and nothing else. A POST /connections
+    // already running on THIS instance force-acquired an OLDER epoch, so the
+    // guard below does not veto this restart -- and its updateOptions writes the
+    // new webhook config into the live connection first, Redis after. Rebuilding
+    // from the snapshot read before that would hand the replacement the
+    // pre-update copy, and persistMetadata would write it back over the
+    // reconfiguration.
+    it("rebuilds from the live connection's options, not a superseded snapshot", async () => {
+      const handler = makeHandlerMock();
+      const coordinator = makeCoordinator(handler);
+      getRedisAuthMetadata.mockResolvedValue(storedMetadata);
+      // The reconfiguration lands in the window this restart spends on Redis.
+      clearQuarantine.mockImplementation(async () => {
+        handler.connections.add("+5511999");
+        handler.liveOptions.set("+5511999", {
+          webhookUrl: "https://reconfigured.example/hook",
+          webhookVerifyToken: "new-token",
+          clientName: "Stored Client",
+        });
+      });
+
+      const restarted = await coordinator.restartWithLease("+5511999");
+
+      expect(restarted).toBe("restarted");
+      expect(handler.connect).toHaveBeenCalledWith(
+        "+5511999",
+        {
+          webhookUrl: "https://reconfigured.example/hook",
+          webhookVerifyToken: "new-token",
+          clientName: "Stored Client",
           isReconnect: true,
           leaseEpoch: 1,
           forceRestart: true,

--- a/src/cluster/coordinator.spec.ts
+++ b/src/cluster/coordinator.spec.ts
@@ -907,6 +907,23 @@ describe("ClusterCoordinator", () => {
       expect(handler.connect).not.toHaveBeenCalled();
     });
 
+    // Metadata is not a session: useRedisAuthState writes it when the socket
+    // starts, so an unscanned QR flow satisfies the metadata check. Restarting
+    // that would answer 202 and spawn another unpaired QR socket, which is the
+    // opposite of what a route promising "no QR, no re-pairing" should do.
+    it("reports false for a session that never finished pairing", async () => {
+      const handler = makeHandlerMock();
+      const coordinator = makeCoordinator(handler);
+      getRedisAuthMetadata.mockResolvedValue(storedMetadata);
+      isRedisAuthStatePaired.mockResolvedValue(false);
+
+      const restarted = await coordinator.restartWithLease("+5511999");
+
+      expect(restarted).toBe(false);
+      expect(forceAcquireLease).not.toHaveBeenCalled();
+      expect(handler.connect).not.toHaveBeenCalled();
+    });
+
     it("clears quarantine — an operator asking for the phone wins now", async () => {
       const handler = makeHandlerMock();
       const coordinator = makeCoordinator(handler);

--- a/src/cluster/coordinator.spec.ts
+++ b/src/cluster/coordinator.spec.ts
@@ -80,8 +80,12 @@ function makeHandlerMock() {
   const handler = {
     connections,
     activity,
+    // Returns true like the real connect: false means only "shouldProceed vetoed
+    // it", and a double that answered undefined would report every restart as
+    // skipped.
     connect: mock(async (phone: string) => {
       connections.add(phone);
+      return true;
     }),
     logout: mock(async (phone: string) => {
       connections.delete(phone);
@@ -94,6 +98,7 @@ function makeHandlerMock() {
     get size() {
       return connections.size;
     },
+    updateLeaseEpoch: mock(async (_phone: string, _epoch: number) => {}),
     inFlightWebhookCount: () => 0,
     connectionActivity: (phone: string) =>
       connections.has(phone)
@@ -932,6 +937,39 @@ describe("ClusterCoordinator", () => {
           coordinator as unknown as { heldLeaseEpochs: Map<string, number> }
         ).heldLeaseEpochs.get("+5511999"),
       ).toBe(2);
+    });
+
+    // An unpaired QR flow in progress is exactly what gets here, and it has a live
+    // socket. Releasing the lease we just force-acquired would leave that socket
+    // running unowned: the proxy stops routing to it and the next claim cycle
+    // builds a competing socket on the same identity.
+    it("keeps the lease when a live socket is still serving the phone", async () => {
+      const handler = makeHandlerMock();
+      const coordinator = makeCoordinator(handler);
+      handler.connections.add("+5511999");
+      isRedisAuthStatePaired.mockResolvedValue(false);
+      getRedisAuthMetadata.mockResolvedValue(storedMetadata);
+
+      const restarted = await coordinator.restartWithLease("+5511999");
+
+      expect(restarted).toBe(false);
+      expect(releaseLease).not.toHaveBeenCalled();
+      // And the socket is told which epoch owns it now, or its webhooks are
+      // discarded by the client as stale.
+      expect(handler.updateLeaseEpoch).toHaveBeenCalledWith("+5511999", 1);
+    });
+
+    // A veto after the drain means nothing was rebuilt. Reporting it as success
+    // hands the client a 202 for a session that was deleted while it queued.
+    it("reports false when the guarded connect was skipped", async () => {
+      const handler = makeHandlerMock();
+      const coordinator = makeCoordinator(handler);
+      getRedisAuthMetadata.mockResolvedValue(storedMetadata);
+      handler.connect.mockImplementation(async () => false);
+
+      const restarted = await coordinator.restartWithLease("+5511999");
+
+      expect(restarted).toBe(false);
     });
 
     // Taking options from the request would let a restart overwrite good

--- a/src/cluster/coordinator.spec.ts
+++ b/src/cluster/coordinator.spec.ts
@@ -87,7 +87,7 @@ function makeHandlerMock() {
     // Returns true like the real connect: false means only "shouldProceed vetoed
     // it", and a double that answered undefined would report every restart as
     // skipped.
-    connect: mock(async (phone: string) => {
+    connect: mock(async (phone: string, _options?: unknown) => {
       connections.add(phone);
       return true;
     }),
@@ -928,6 +928,16 @@ describe("ClusterCoordinator", () => {
   });
 
   describe("#restartWithLease", () => {
+    // handler.connect now takes a resolver rather than a value: it is invoked
+    // after the drain, which is the point of it. Invoking it here is what the
+    // real connect does.
+    const spawnedWith = (handler: HandlerMock) => {
+      const resolve = handler.connect.mock
+        .calls[0]?.[1] as unknown as () => Record<string, unknown> | null;
+      expect(typeof resolve).toBe("function");
+      return resolve();
+    };
+
     const storedMetadata = {
       webhookUrl: "https://stored.example/hook",
       webhookVerifyToken: "stored-token",
@@ -943,16 +953,12 @@ describe("ClusterCoordinator", () => {
 
       expect(restarted).toBe("restarted");
       expect(forceAcquireLease).toHaveBeenCalledWith("+5511999");
-      expect(handler.connect).toHaveBeenCalledWith(
-        "+5511999",
-        {
-          ...storedMetadata,
-          isReconnect: true,
-          leaseEpoch: 1,
-          forceRestart: true,
-        },
-        expect.any(Function),
-      );
+      expect(spawnedWith(handler)).toEqual({
+        ...storedMetadata,
+        isReconnect: true,
+        leaseEpoch: 1,
+        forceRestart: true,
+      });
     });
 
     // The lease fences other instances and nothing else. A POST /connections
@@ -979,18 +985,46 @@ describe("ClusterCoordinator", () => {
       const restarted = await coordinator.restartWithLease("+5511999");
 
       expect(restarted).toBe("restarted");
-      expect(handler.connect).toHaveBeenCalledWith(
-        "+5511999",
-        {
-          webhookUrl: "https://reconfigured.example/hook",
-          webhookVerifyToken: "new-token",
-          clientName: "Stored Client",
-          isReconnect: true,
-          leaseEpoch: 1,
-          forceRestart: true,
-        },
-        expect.any(Function),
-      );
+      expect(spawnedWith(handler)).toEqual({
+        webhookUrl: "https://reconfigured.example/hook",
+        webhookVerifyToken: "new-token",
+        clientName: "Stored Client",
+        isReconnect: true,
+        leaseEpoch: 1,
+        forceRestart: true,
+      });
+    });
+
+    // The snapshot the restart takes before calling connect is not the last word:
+    // connect drains the per-phone slot first, and an explicit operation holding
+    // it can reconfigure the live connection in that window. Since it acquired an
+    // OLDER epoch, the lease guard does not veto this restart either -- so the
+    // options have to be read again on the other side of the drain.
+    it("re-reads the live options after the drain, not only before it", async () => {
+      const handler = makeHandlerMock();
+      const coordinator = makeCoordinator(handler);
+      getRedisAuthMetadata.mockResolvedValue(storedMetadata);
+      handler.connections.add("+5511999");
+      handler.liveOptions.set("+5511999", {
+        webhookUrl: "https://before-drain.example/hook",
+        webhookVerifyToken: "old-token",
+      });
+
+      await coordinator.restartWithLease("+5511999");
+
+      // The reconfiguration lands while this restart is parked on the slot.
+      handler.liveOptions.set("+5511999", {
+        webhookUrl: "https://after-drain.example/hook",
+        webhookVerifyToken: "new-token",
+      });
+
+      expect(spawnedWith(handler)).toEqual({
+        webhookUrl: "https://after-drain.example/hook",
+        webhookVerifyToken: "new-token",
+        isReconnect: true,
+        leaseEpoch: 1,
+        forceRestart: true,
+      });
     });
 
     // The checks above ran before this restart queued behind the handler's per-phone
@@ -1004,20 +1038,13 @@ describe("ClusterCoordinator", () => {
 
       await coordinator.restartWithLease("+5511999", "stall");
 
-      const shouldProceed = (
-        handler.connect.mock.calls[0] as unknown as [
-          string,
-          Record<string, unknown>,
-          () => boolean,
-        ]
-      )[2];
-      expect(shouldProceed()).toBe(true);
+      expect(spawnedWith(handler)).not.toBeNull();
 
       // Whatever ran while we were parked force-acquired its own lease.
       (
         coordinator as unknown as { heldLeaseEpochs: Map<string, number> }
       ).heldLeaseEpochs.set("+5511999", 2);
-      expect(shouldProceed()).toBe(false);
+      expect(spawnedWith(handler)).toBeNull();
     });
 
     // heldLeaseEpochs stops describing THIS operation the moment a concurrent explicit
@@ -1134,14 +1161,10 @@ describe("ClusterCoordinator", () => {
 
       await coordinator.restartWithLease("+5511999");
 
-      expect(handler.connect).toHaveBeenCalledWith(
-        "+5511999",
-        expect.objectContaining({
-          webhookUrl: storedMetadata.webhookUrl,
-          webhookVerifyToken: storedMetadata.webhookVerifyToken,
-        }),
-        expect.any(Function),
-      );
+      expect(spawnedWith(handler)).toMatchObject({
+        webhookUrl: storedMetadata.webhookUrl,
+        webhookVerifyToken: storedMetadata.webhookVerifyToken,
+      });
     });
 
     // The lease is taken BEFORE the session is inspected, and given back when there

--- a/src/cluster/coordinator.ts
+++ b/src/cluster/coordinator.ts
@@ -113,12 +113,26 @@ export class ClusterCoordinator {
     // would stay dark until the TTL and unclaimed grace elapse while requests
     // route here and 404. Same rule the claim cycle applies to its own failed
     // reconnects.
-    this.handler.onSpawnFailed = async (phoneNumber: string) => {
+    this.handler.onSpawnFailed = async (
+      phoneNumber: string,
+      leaseEpoch: number | null,
+    ) => {
       logger.error(
         "[coordinator] restart failed to rebuild %s, releasing lease",
         phoneNumber,
       );
-      await this.releaseHeldLease(phoneNumber).catch(() => {});
+      // Fenced on the epoch the failed attempt ran under. releaseHeldLease uses
+      // whatever heldLeaseEpochs currently holds, and those stop being the same
+      // the moment a concurrent explicit operation force-acquires its own lease
+      // while this restart was failing -- releasing that one would leave its
+      // live socket unowned and free for any claim loop to take.
+      if (leaseEpoch !== null) {
+        await this.abandonExplicitLease(phoneNumber, leaseEpoch).catch(
+          () => {},
+        );
+      } else {
+        await this.releaseHeldLease(phoneNumber).catch(() => {});
+      }
       void registry.publishOwnershipChanged(phoneNumber);
     };
     this.options = {

--- a/src/cluster/coordinator.ts
+++ b/src/cluster/coordinator.ts
@@ -903,6 +903,14 @@ export class ClusterCoordinator {
   // Keeping ownership means handing the socket the epoch that now holds it, or
   // the client discards its webhooks as stale.
   private async unwindRestartLease(phoneNumber: string, epoch: number) {
+    // Not ours any more: a newer explicit operation force-acquired while we were
+    // reading. Its lease is live and its socket already carries its epoch, so
+    // there is nothing here to give back — and writing our older epoch into that
+    // connection would leave every webhook it sends stamped stale, which is the
+    // one way to make a healthy socket look like a dead one to the client.
+    if (this.heldLeaseEpochs.get(phoneNumber) !== epoch) {
+      return;
+    }
     if (this.handler.hasConnection(phoneNumber)) {
       await this.handler.updateLeaseEpoch(phoneNumber, epoch);
       return;

--- a/src/cluster/coordinator.ts
+++ b/src/cluster/coordinator.ts
@@ -791,6 +791,15 @@ export class ClusterCoordinator {
     if (!metadata?.webhookUrl) {
       return false;
     }
+    // Metadata alone is not a session: useRedisAuthState writes it when the
+    // socket starts, so a QR flow that nobody ever scanned satisfies the check
+    // above. Restarting that would hand back 202 and spawn another unpaired QR
+    // socket, which is the opposite of what this route promises. Same rule the
+    // claim loop applies: a phone that never finished pairing has no session to
+    // resume, and only an explicit POST /connections can move it forward.
+    if (!(await isRedisAuthStatePaired(phoneNumber))) {
+      return false;
+    }
     const acquired = await this.acquireExplicitLease(phoneNumber);
     await this.clearQuarantineForExplicitIntent(phoneNumber);
     logger.warn(

--- a/src/cluster/coordinator.ts
+++ b/src/cluster/coordinator.ts
@@ -692,10 +692,17 @@ export class ClusterCoordinator {
     try {
       return await work();
     } catch (error) {
-      await this.releaseHeldLease(phoneNumber).catch(() => {});
-      void registry.publishOwnershipChanged(phoneNumber);
+      await this.abandonExplicitLease(phoneNumber);
       throw error;
     }
+  }
+
+  // Gives back a lease we acquired but are not going to use. Same reasoning as the
+  // catch above: an explicit lease with no socket behind it routes 421s here until
+  // the TTL expires, so every path that acquires one and then bails has to unwind it.
+  private async abandonExplicitLease(phoneNumber: string) {
+    await this.releaseHeldLease(phoneNumber).catch(() => {});
+    void registry.publishOwnershipChanged(phoneNumber);
   }
 
   // Explicit intent overrides quarantine: the operator asked for this phone
@@ -787,20 +794,33 @@ export class ClusterCoordinator {
   //
   // Returns false when there is no stored session — nothing to restart.
   async restartWithLease(phoneNumber: string, reason?: string) {
-    const metadata = await getRedisAuthMetadata<StoredMetadata>(phoneNumber);
-    if (!metadata?.webhookUrl) {
-      return false;
-    }
-    // Metadata alone is not a session: useRedisAuthState writes it when the
-    // socket starts, so a QR flow that nobody ever scanned satisfies the check
-    // above. Restarting that would hand back 202 and spawn another unpaired QR
-    // socket, which is the opposite of what this route promises. Same rule the
-    // claim loop applies: a phone that never finished pairing has no session to
-    // resume, and only an explicit POST /connections can move it forward.
-    if (!(await isRedisAuthStatePaired(phoneNumber))) {
-      return false;
-    }
+    // Fence BEFORE reading. Both checks below describe the stored session, and until
+    // the lease moves the previous owner is still entitled to rewrite it: an options
+    // update replaces the webhook metadata, a logout deletes the auth state. Reading
+    // first means a restart racing either one rebuilds the socket from configuration
+    // that has since been superseded, or answers 202 and spawns a fresh QR socket for
+    // a session the user just removed.
     const acquired = await this.acquireExplicitLease(phoneNumber);
+    let metadata: StoredMetadata | null;
+    try {
+      metadata = await getRedisAuthMetadata<StoredMetadata>(phoneNumber);
+      // Metadata alone is not a session: useRedisAuthState writes it when the
+      // socket starts, so a QR flow that nobody ever scanned satisfies the first
+      // check. Restarting that would hand back 202 and spawn another unpaired QR
+      // socket, which is the opposite of what this route promises. Same rule the
+      // claim loop applies: a phone that never finished pairing has no session to
+      // resume, and only an explicit POST /connections can move it forward.
+      if (
+        !metadata?.webhookUrl ||
+        !(await isRedisAuthStatePaired(phoneNumber))
+      ) {
+        await this.abandonExplicitLease(phoneNumber);
+        return false;
+      }
+    } catch (error) {
+      await this.abandonExplicitLease(phoneNumber);
+      throw error;
+    }
     await this.clearQuarantineForExplicitIntent(phoneNumber);
     logger.warn(
       "[coordinator] restarting socket for %s (reason=%s)",

--- a/src/cluster/coordinator.ts
+++ b/src/cluster/coordinator.ts
@@ -854,6 +854,12 @@ export class ClusterCoordinator {
     // first means a restart racing either one rebuilds the socket from configuration
     // that has since been superseded, or answers 202 and spawns a fresh QR socket for
     // a session the user just removed.
+    //
+    // The lease fences OTHER instances, and only those. A POST /connections
+    // already in flight on THIS instance keeps writing: the auth writes are
+    // fenced on instanceId, not on the epoch, so its persistMetadata lands
+    // whatever epoch we hold. What that costs is handled at the spawn below,
+    // where the options are re-sourced from the live connection.
     const acquired = await this.acquireExplicitLease(phoneNumber);
     let metadata: StoredMetadata | null;
     try {
@@ -906,6 +912,18 @@ export class ClusterCoordinator {
     // Returned rather than assumed: a veto by that guard means nothing was
     // rebuilt, and reporting it as success hands the client a 202 for a session
     // that was deleted while this restart queued.
+    //
+    // Sourced from the live connection when there is one, and only from the
+    // snapshot above when there is not. A POST /connections for this phone can
+    // have started before this restart and still be running: it force-acquired
+    // an OLDER epoch, so the guard below does not veto us, and its
+    // updateOptions writes the new webhook config into the live connection
+    // first and to Redis after. Spawning from the snapshot would hand the
+    // replacement the pre-update copy and persistMetadata would write it back,
+    // reverting the reconfiguration -- the same hazard, and the same answer, as
+    // the watchdog's requestRestart. Read at the last statement before the call
+    // so no await of ours sits between it and the spawn.
+    const live = this.handler.currentConnectionOptions(phoneNumber);
     const proceeded = await this.runUnderExplicitLease(
       phoneNumber,
       acquired.epoch,
@@ -913,7 +931,7 @@ export class ClusterCoordinator {
         this.handler.connect(
           phoneNumber,
           {
-            ...metadata,
+            ...(live ?? metadata),
             isReconnect: true,
             leaseEpoch: acquired.epoch,
             forceRestart: true,

--- a/src/cluster/coordinator.ts
+++ b/src/cluster/coordinator.ts
@@ -108,6 +108,19 @@ export class ClusterCoordinator {
     options?: Partial<CoordinatorOptions>,
   ) {
     this.handler = handler;
+    // A restart that could not rebuild its socket must not leave us holding the
+    // lease: the claim scan skips any phone that already has one, so the number
+    // would stay dark until the TTL and unclaimed grace elapse while requests
+    // route here and 404. Same rule the claim cycle applies to its own failed
+    // reconnects.
+    this.handler.onSpawnFailed = async (phoneNumber: string) => {
+      logger.error(
+        "[coordinator] restart failed to rebuild %s, releasing lease",
+        phoneNumber,
+      );
+      await this.releaseHeldLease(phoneNumber).catch(() => {});
+      void registry.publishOwnershipChanged(phoneNumber);
+    };
     this.options = {
       claimIntervalMs: config.cluster.claimIntervalMs,
       claimJitterMs: config.cluster.claimJitterMs,

--- a/src/cluster/coordinator.ts
+++ b/src/cluster/coordinator.ts
@@ -20,6 +20,10 @@ import { errorToString } from "@/helpers/errorToString";
 import logger from "@/lib/logger";
 import redis from "@/lib/redis";
 
+// What POST /connections/:phone/restart actually did, because the three answer
+// different HTTP statuses and only one of them is a failure of the phone itself.
+export type RestartOutcome = "restarted" | "not-found" | "superseded";
+
 type StoredMetadata = Omit<
   BaileysConnectionOptions,
   "phoneNumber" | "onConnectionClose"
@@ -805,8 +809,12 @@ export class ClusterCoordinator {
   // explicit field list rather than a spread, so it cannot be persisted and
   // come back on every future reconnect. Keep all three properties intact.
   //
-  // Returns false when there is no stored session — nothing to restart.
-  async restartWithLease(phoneNumber: string, reason?: string) {
+  // Reports which of the three it was, because the caller answers a different
+  // status for each and "false" conflated two of them.
+  async restartWithLease(
+    phoneNumber: string,
+    reason?: string,
+  ): Promise<RestartOutcome> {
     // Fence BEFORE reading. Both checks below describe the stored session, and until
     // the lease moves the previous owner is still entitled to rewrite it: an options
     // update replaces the webhook metadata, a logout deletes the auth state. Reading
@@ -834,15 +842,18 @@ export class ClusterCoordinator {
         // builds a competing socket on the same identity. Keep ownership instead,
         // and hand the socket the epoch that now holds it or its webhooks are
         // discarded by the client as stale.
-        if (this.handler.hasConnection(phoneNumber)) {
-          await this.handler.updateLeaseEpoch(phoneNumber, acquired.epoch);
-          return false;
-        }
-        await this.abandonExplicitLease(phoneNumber, acquired.epoch);
-        return false;
+        await this.unwindRestartLease(phoneNumber, acquired.epoch);
+        return "not-found";
       }
     } catch (error) {
-      await this.abandonExplicitLease(phoneNumber, acquired.epoch);
+      // Same unwind as the branch above, and for the same reason: a Redis blip
+      // while inspecting the session must not strand a socket that is still
+      // serving. Abandoning here would stop the renewals under a live
+      // connection, which is the one outcome an inspection failure has no
+      // business causing.
+      await this.unwindRestartLease(phoneNumber, acquired.epoch).catch(
+        () => {},
+      );
       throw error;
     }
     await this.clearQuarantineForExplicitIntent(phoneNumber);
@@ -862,18 +873,41 @@ export class ClusterCoordinator {
     // Returned rather than assumed: a veto by that guard means nothing was
     // rebuilt, and reporting it as success hands the client a 202 for a session
     // that was deleted while this restart queued.
-    return await this.runUnderExplicitLease(phoneNumber, acquired.epoch, () =>
-      this.handler.connect(
-        phoneNumber,
-        {
-          ...metadata,
-          isReconnect: true,
-          leaseEpoch: acquired.epoch,
-          forceRestart: true,
-        },
-        () => this.heldLeaseEpochs.get(phoneNumber) === acquired.epoch,
-      ),
+    const proceeded = await this.runUnderExplicitLease(
+      phoneNumber,
+      acquired.epoch,
+      () =>
+        this.handler.connect(
+          phoneNumber,
+          {
+            ...metadata,
+            isReconnect: true,
+            leaseEpoch: acquired.epoch,
+            forceRestart: true,
+          },
+          () => this.heldLeaseEpochs.get(phoneNumber) === acquired.epoch,
+        ),
     );
+    // "superseded", not "not-found": the guard only vetoes when a newer explicit
+    // operation took the lease, which usually leaves a perfectly good session
+    // behind. Answering 404 would tell the caller the phone has nothing stored
+    // and send them off to re-pair a connection somebody else just rebuilt.
+    return proceeded ? "restarted" : "superseded";
+  }
+
+  // Gives back a lease this restart took and will not use — unless a live local
+  // socket is serving the phone, which is what an unpaired QR flow in progress
+  // looks like from here. Releasing then leaves that socket running with no
+  // lease: the coordinator stops renewing ownership, the proxy stops routing to
+  // it, and the next claim cycle builds a competing socket on the same identity.
+  // Keeping ownership means handing the socket the epoch that now holds it, or
+  // the client discards its webhooks as stale.
+  private async unwindRestartLease(phoneNumber: string, epoch: number) {
+    if (this.handler.hasConnection(phoneNumber)) {
+      await this.handler.updateLeaseEpoch(phoneNumber, epoch);
+      return;
+    }
+    await this.abandonExplicitLease(phoneNumber, epoch);
   }
 
   get isDraining(): boolean {

--- a/src/cluster/coordinator.ts
+++ b/src/cluster/coordinator.ts
@@ -3,6 +3,7 @@ import { BaileysNotConnectedError } from "@/baileys/connection";
 import type { BaileysConnectionsHandler } from "@/baileys/connectionsHandler";
 import {
   clearRedisAuthState,
+  getRedisAuthMetadata,
   getRedisSavedAuthStateIds,
   isRedisAuthStatePaired,
   seedImportedSession,
@@ -12,6 +13,7 @@ import { instanceId } from "@/cluster/identity";
 import * as registry from "@/cluster/instanceRegistry";
 import * as leaseStore from "@/cluster/leaseStore";
 import * as quarantineStore from "@/cluster/quarantineStore";
+import { clearSendStall } from "@/cluster/sendStallStore";
 import config from "@/config";
 import { asyncSleep } from "@/helpers/asyncSleep";
 import { errorToString } from "@/helpers/errorToString";
@@ -770,6 +772,43 @@ export class ClusterCoordinator {
     });
   }
 
+  // Recreates the socket for a phone whose session we keep. Same explicit-intent
+  // semantics as connectWithLease (force-takes the lease, clears quarantine),
+  // but it takes NO options from the caller: the stored metadata is the same
+  // source runClaimCycle reconnects from, so a restart can never overwrite good
+  // webhook config with whatever an operator happened to type.
+  //
+  // `forceRestart` is a literal here and in importSessionWithLease, and those
+  // are its only two producers — it never arrives from a request body. That
+  // matters because StoredMetadata's type still admits the flag: connect()
+  // strips it (see connectionsHandler.connect) and persistMetadata writes an
+  // explicit field list rather than a spread, so it cannot be persisted and
+  // come back on every future reconnect. Keep all three properties intact.
+  //
+  // Returns false when there is no stored session — nothing to restart.
+  async restartWithLease(phoneNumber: string, reason?: string) {
+    const metadata = await getRedisAuthMetadata<StoredMetadata>(phoneNumber);
+    if (!metadata?.webhookUrl) {
+      return false;
+    }
+    const acquired = await this.acquireExplicitLease(phoneNumber);
+    await this.clearQuarantineForExplicitIntent(phoneNumber);
+    logger.warn(
+      "[coordinator] restarting socket for %s (reason=%s)",
+      phoneNumber,
+      reason ?? "unspecified",
+    );
+    await this.runUnderExplicitLease(phoneNumber, () =>
+      this.handler.connect(phoneNumber, {
+        ...metadata,
+        isReconnect: true,
+        leaseEpoch: acquired.epoch,
+        forceRestart: true,
+      }),
+    );
+    return true;
+  }
+
   get isDraining(): boolean {
     return this.draining;
   }
@@ -797,8 +836,18 @@ export class ClusterCoordinator {
         );
       }
     } finally {
-      // A discarded identity must not leave strike state behind.
+      // A discarded identity must not leave strike state behind. That includes
+      // the send-stall backoff: it is keyed by phone number and outlives the
+      // session by up to 24h, so without this a re-paired number would inherit
+      // the old session's backoff and have its watchdog suppressed.
       await this.clearQuarantineForExplicitIntent(phoneNumber);
+      await clearSendStall(phoneNumber).catch((error) => {
+        logger.warn(
+          "[coordinator] failed to clear send-stall backoff for %s: %s",
+          phoneNumber,
+          errorToString(error),
+        );
+      });
       await this.releaseHeldLease(phoneNumber).catch(() => {});
       void registry.publishOwnershipChanged(phoneNumber);
     }

--- a/src/cluster/coordinator.ts
+++ b/src/cluster/coordinator.ts
@@ -656,6 +656,23 @@ export class ClusterCoordinator {
           const lease = await leaseStore.acquireLease(phone);
           if (lease) {
             this.heldLeaseEpochs.set(phone, lease.epoch);
+            // The socket has to learn the new epoch too, not just this map. It
+            // stamps its connection.update webhooks with the epoch it holds, and
+            // it is what onSpawnFailed hands back to abandonExplicitLease when a
+            // background reconnect gives up -- and that release is epoch-fenced
+            // on both sides, so a stale epoch there is a silent no-op that leaves
+            // the lease we just re-acquired held with no socket behind it until
+            // the TTL runs out. Same call unwindRestartLease makes for the same
+            // reason.
+            await this.handler
+              .updateLeaseEpoch(phone, lease.epoch)
+              .catch((error) => {
+                logger.warn(
+                  "[coordinator] could not propagate re-acquired epoch for %s: %s",
+                  phone,
+                  errorToString(error),
+                );
+              });
             this.redisDegraded = false;
             continue;
           }

--- a/src/cluster/coordinator.ts
+++ b/src/cluster/coordinator.ts
@@ -827,6 +827,17 @@ export class ClusterCoordinator {
         !metadata?.webhookUrl ||
         !(await isRedisAuthStatePaired(phoneNumber))
       ) {
+        // Nothing to restart, so the lease goes back — UNLESS a live local socket
+        // is serving this phone, which is exactly what an unpaired QR flow in
+        // progress looks like from here. Releasing then leaves that socket running
+        // with no lease: the proxy stops routing to it and the next claim cycle
+        // builds a competing socket on the same identity. Keep ownership instead,
+        // and hand the socket the epoch that now holds it or its webhooks are
+        // discarded by the client as stale.
+        if (this.handler.hasConnection(phoneNumber)) {
+          await this.handler.updateLeaseEpoch(phoneNumber, acquired.epoch);
+          return false;
+        }
         await this.abandonExplicitLease(phoneNumber, acquired.epoch);
         return false;
       }
@@ -847,7 +858,11 @@ export class ClusterCoordinator {
     // unpaired credentials and answer 202 — resurrecting as a QR socket the phone
     // the operator just removed. The lease epoch is the signal, and it covers every
     // explicit operation rather than only logout: whoever ran took a newer one.
-    await this.runUnderExplicitLease(phoneNumber, acquired.epoch, () =>
+    //
+    // Returned rather than assumed: a veto by that guard means nothing was
+    // rebuilt, and reporting it as success hands the client a 202 for a session
+    // that was deleted while this restart queued.
+    return await this.runUnderExplicitLease(phoneNumber, acquired.epoch, () =>
       this.handler.connect(
         phoneNumber,
         {
@@ -859,7 +874,6 @@ export class ClusterCoordinator {
         () => this.heldLeaseEpochs.get(phoneNumber) === acquired.epoch,
       ),
     );
-    return true;
   }
 
   get isDraining(): boolean {

--- a/src/cluster/coordinator.ts
+++ b/src/cluster/coordinator.ts
@@ -940,21 +940,22 @@ export class ClusterCoordinator {
     // reverting the reconfiguration -- the same hazard, and the same answer, as
     // the watchdog's requestRestart. Read at the last statement before the call
     // so no await of ours sits between it and the spawn.
-    const live = this.handler.currentConnectionOptions(phoneNumber);
+    const spawnOptions = (): BaileysConnectionOptions | null => {
+      if (this.heldLeaseEpochs.get(phoneNumber) !== acquired.epoch) {
+        return null;
+      }
+      const live = this.handler.currentConnectionOptions(phoneNumber);
+      return {
+        ...(live ?? metadata),
+        isReconnect: true,
+        leaseEpoch: acquired.epoch,
+        forceRestart: true,
+      };
+    };
     const proceeded = await this.runUnderExplicitLease(
       phoneNumber,
       acquired.epoch,
-      () =>
-        this.handler.connect(
-          phoneNumber,
-          {
-            ...(live ?? metadata),
-            isReconnect: true,
-            leaseEpoch: acquired.epoch,
-            forceRestart: true,
-          },
-          () => this.heldLeaseEpochs.get(phoneNumber) === acquired.epoch,
-        ),
+      () => this.handler.connect(phoneNumber, spawnOptions),
     );
     // "superseded", not "not-found": the guard only vetoes when a newer explicit
     // operation took the lease, which usually leaves a perfectly good session

--- a/src/cluster/coordinator.ts
+++ b/src/cluster/coordinator.ts
@@ -419,8 +419,14 @@ export class ClusterCoordinator {
               id,
               errorToString(error),
             );
-            // Don't sit on a lease we can't service — let a peer try.
-            await this.releaseHeldLease(id).catch(() => {});
+            // Don't sit on a lease we can't service — let a peer try. Fenced on
+            // the epoch THIS cycle acquired, not on whatever heldLeaseEpochs now
+            // holds: an explicit connect, import or restart can force-acquire its
+            // own while this spawn is awaiting, and releasing that one would leave
+            // its live socket with a lease nobody renews, free for any claim loop
+            // to take. The guard above catches the same race before the connect,
+            // but nothing stops it landing during one.
+            await this.abandonExplicitLease(id, epoch).catch(() => {});
             void registry.publishOwnershipChanged(id);
           }
         }),

--- a/src/cluster/coordinator.ts
+++ b/src/cluster/coordinator.ts
@@ -687,12 +687,13 @@ export class ClusterCoordinator {
   // until the TTL expires; releasing lets a retry land anywhere.
   private async runUnderExplicitLease<T>(
     phoneNumber: string,
+    epoch: number,
     work: () => Promise<T>,
   ): Promise<T> {
     try {
       return await work();
     } catch (error) {
-      await this.abandonExplicitLease(phoneNumber);
+      await this.abandonExplicitLease(phoneNumber, epoch);
       throw error;
     }
   }
@@ -700,8 +701,20 @@ export class ClusterCoordinator {
   // Gives back a lease we acquired but are not going to use. Same reasoning as the
   // catch above: an explicit lease with no socket behind it routes 421s here until
   // the TTL expires, so every path that acquires one and then bails has to unwind it.
-  private async abandonExplicitLease(phoneNumber: string) {
-    await this.releaseHeldLease(phoneNumber).catch(() => {});
+  //
+  // Fenced on the epoch THIS operation acquired, not on whatever heldLeaseEpochs
+  // currently holds. Those stop being the same the moment a concurrent explicit
+  // operation force-acquires its own lease while we are awaiting: unwinding by the
+  // current value would hand away that operation's lease instead of ours and leave
+  // its live socket unowned, free for any claim loop to take.
+  private async abandonExplicitLease(phoneNumber: string, epoch: number) {
+    if (this.heldLeaseEpochs.get(phoneNumber) === epoch) {
+      this.heldLeaseEpochs.delete(phoneNumber);
+      this.claimedAt.delete(phoneNumber);
+    }
+    // Epoch-fenced server-side too, so a stale epoch here is a no-op rather than a
+    // release of someone else's lease.
+    await leaseStore.releaseLease(phoneNumber, epoch).catch(() => {});
     void registry.publishOwnershipChanged(phoneNumber);
   }
 
@@ -730,7 +743,7 @@ export class ClusterCoordinator {
   ) {
     const acquired = await this.acquireExplicitLease(phoneNumber);
     await this.clearQuarantineForExplicitIntent(phoneNumber);
-    await this.runUnderExplicitLease(phoneNumber, () =>
+    await this.runUnderExplicitLease(phoneNumber, acquired.epoch, () =>
       this.handler.connect(phoneNumber, {
         ...options,
         leaseEpoch: acquired.epoch,
@@ -753,7 +766,7 @@ export class ClusterCoordinator {
   ) {
     const acquired = await this.acquireExplicitLease(phoneNumber);
     await this.clearQuarantineForExplicitIntent(phoneNumber);
-    await this.runUnderExplicitLease(phoneNumber, async () => {
+    await this.runUnderExplicitLease(phoneNumber, acquired.epoch, async () => {
       // Creds and the candidate cursor are written together (single fenced
       // write), so an import never lands with one persisted but not the other.
       // A fenced-off write means another instance grabbed the lease between
@@ -814,11 +827,11 @@ export class ClusterCoordinator {
         !metadata?.webhookUrl ||
         !(await isRedisAuthStatePaired(phoneNumber))
       ) {
-        await this.abandonExplicitLease(phoneNumber);
+        await this.abandonExplicitLease(phoneNumber, acquired.epoch);
         return false;
       }
     } catch (error) {
-      await this.abandonExplicitLease(phoneNumber);
+      await this.abandonExplicitLease(phoneNumber, acquired.epoch);
       throw error;
     }
     await this.clearQuarantineForExplicitIntent(phoneNumber);
@@ -827,13 +840,24 @@ export class ClusterCoordinator {
       phoneNumber,
       reason ?? "unspecified",
     );
-    await this.runUnderExplicitLease(phoneNumber, () =>
-      this.handler.connect(phoneNumber, {
-        ...metadata,
-        isReconnect: true,
-        leaseEpoch: acquired.epoch,
-        forceRestart: true,
-      }),
+    // Re-checked after every drain inside connect(), because the checks above were
+    // made before we queued behind the handler's per-phone lock. A DELETE holding
+    // that lock clears the auth state and takes its own lease on the way in, so a
+    // restart that proceeded on the metadata it read earlier would create fresh
+    // unpaired credentials and answer 202 — resurrecting as a QR socket the phone
+    // the operator just removed. The lease epoch is the signal, and it covers every
+    // explicit operation rather than only logout: whoever ran took a newer one.
+    await this.runUnderExplicitLease(phoneNumber, acquired.epoch, () =>
+      this.handler.connect(
+        phoneNumber,
+        {
+          ...metadata,
+          isReconnect: true,
+          leaseEpoch: acquired.epoch,
+          forceRestart: true,
+        },
+        () => this.heldLeaseEpochs.get(phoneNumber) === acquired.epoch,
+      ),
     );
     return true;
   }

--- a/src/cluster/keys.ts
+++ b/src/cluster/keys.ts
@@ -13,6 +13,12 @@ export const clusterKeys = {
   // Backoff state for phones whose reconnect cycles keep failing — see
   // cluster/quarantineStore.ts.
   quarantine: (phoneNumber: string) => `${prefix}:quarantine:${phoneNumber}`,
+  // Backoff state for phones whose sends keep stalling — see
+  // cluster/sendStallStore.ts. Deliberately a sibling of `quarantine` rather
+  // than the same key: quarantine means "do not CLAIM this phone", this means
+  // "do not RESTART it again yet", and a healthy open clears quarantine (which
+  // a stall restart produces seconds later, so the backoff would never grow).
+  sendStall: (phoneNumber: string) => `${prefix}:send-stall:${phoneNumber}`,
   eventsChannel: `${prefix}:events`,
 };
 

--- a/src/cluster/sendStallStore.spec.ts
+++ b/src/cluster/sendStallStore.spec.ts
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import redis from "@/lib/redis";
+import {
+  backoffMs,
+  canRestart,
+  clearSendStall,
+  nextRestartAllowedAt,
+  recordRestart,
+} from "./sendStallStore";
+
+const stringData = (redis as any).__stringData as Map<string, string>;
+const PHONE = "+5511999999999";
+const KEY = `@baileys-api:cluster:send-stall:${PHONE}`;
+
+describe("sendStallStore", () => {
+  afterEach(() => {
+    stringData.clear();
+  });
+
+  // Recovering fast the first time is the whole point; the backoff only exists
+  // to stop a phone that restarting clearly is not curing.
+  it("allows the first restart immediately", async () => {
+    expect(await canRestart(PHONE)).toBe(true);
+  });
+
+  it("holds off a second restart inside the backoff window", async () => {
+    await recordRestart(PHONE);
+    expect(await canRestart(PHONE)).toBe(false);
+  });
+
+  it("escalates the backoff on repeated restarts", async () => {
+    expect(backoffMs(1)).toBe(5 * 60 * 1000);
+    expect(backoffMs(2)).toBe(10 * 60 * 1000);
+    expect(backoffMs(3)).toBe(20 * 60 * 1000);
+  });
+
+  it("caps the backoff at an hour", () => {
+    expect(backoffMs(50)).toBe(60 * 60 * 1000);
+  });
+
+  it("counts restarts across calls", async () => {
+    await recordRestart(PHONE);
+    const second = await recordRestart(PHONE);
+    expect(second.restarts).toBe(2);
+  });
+
+  it("reports when the next restart becomes allowed", async () => {
+    const state = await recordRestart(PHONE);
+    expect(await nextRestartAllowedAt(PHONE)).toBe(state.nextRestartAllowedAt);
+  });
+
+  it("returns null when no stall has been recorded", async () => {
+    expect(await nextRestartAllowedAt(PHONE)).toBeNull();
+  });
+
+  it("allows a restart again once the window has passed", async () => {
+    stringData.set(
+      KEY,
+      JSON.stringify({ restarts: 1, nextRestartAllowedAt: Date.now() - 1 }),
+    );
+    expect(await canRestart(PHONE)).toBe(true);
+  });
+
+  // A corrupted entry must not wedge recovery shut.
+  it("treats an unparseable entry as no backoff", async () => {
+    stringData.set(KEY, "not json");
+    expect(await canRestart(PHONE)).toBe(true);
+  });
+
+  it("clears the state", async () => {
+    await recordRestart(PHONE);
+    await clearSendStall(PHONE);
+    expect(await canRestart(PHONE)).toBe(true);
+  });
+});

--- a/src/cluster/sendStallStore.spec.ts
+++ b/src/cluster/sendStallStore.spec.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it, type mock } from "bun:test";
 import redis from "@/lib/redis";
 import {
   backoffMs,
@@ -65,7 +65,12 @@ describe("sendStallStore", () => {
     const second = await recordRestart(PHONE);
     expect(second.state.restarts).toBe(2);
 
-    await restoreState(PHONE, second.previous);
+    await restoreState(
+      PHONE,
+      second.previous,
+      second.previousTtlMs,
+      second.wrote,
+    );
 
     expect(await nextRestartAllowedAt(PHONE)).toBe(
       first.state.nextRestartAllowedAt,
@@ -89,7 +94,12 @@ describe("sendStallStore", () => {
       value: 24 * 60 * 60 * 1000,
     });
 
-    await restoreState(PHONE, second.previous, second.previousTtlMs);
+    await restoreState(
+      PHONE,
+      second.previous,
+      second.previousTtlMs,
+      second.wrote,
+    );
 
     expect(expirations.get(KEY)).toEqual({ type: "PX", value: 60_000 });
   });
@@ -106,7 +116,12 @@ describe("sendStallStore", () => {
     const second = await recordRestart(PHONE);
     expect(second.previousTtlMs).toBeNull();
 
-    await restoreState(PHONE, second.previous, second.previousTtlMs);
+    await restoreState(
+      PHONE,
+      second.previous,
+      second.previousTtlMs,
+      second.wrote,
+    );
 
     expect(expirations.get(KEY)).toEqual({
       type: "PX",
@@ -114,11 +129,70 @@ describe("sendStallStore", () => {
     });
   });
 
+  // The undo applies only while the key is still exactly what this attempt
+  // wrote. During a lease handoff two owners overlap briefly, and a newer
+  // owner's strike landing in between is a real event this rollback knows
+  // nothing about: putting `previous` back over it erases the whole history on
+  // the one phone that is flapping between instances.
+  it("leaves a newer owner's strike alone when it rolls back", async () => {
+    stringData.set(
+      KEY,
+      JSON.stringify({ restarts: 1, nextRestartAllowedAt: Date.now() - 1 }),
+    );
+    const mine = await recordRestart(PHONE);
+    expect(mine.previous?.restarts).toBe(1);
+
+    // The socket moved, and the new owner recorded its own strike.
+    stringData.set(
+      KEY,
+      JSON.stringify({ restarts: 9, nextRestartAllowedAt: Date.now() + 1000 }),
+    );
+
+    await restoreState(PHONE, mine.previous, mine.previousTtlMs, mine.wrote);
+
+    expect(JSON.parse(stringData.get(KEY) ?? "{}").restarts).toBe(9);
+  });
+
+  // Same rule on the delete half: a first-strike rollback must not remove a
+  // successor's key either.
+  it("leaves a newer owner's strike alone when it rolls back the first one", async () => {
+    const mine = await recordRestart(PHONE);
+    expect(mine.previous).toBeNull();
+
+    stringData.set(
+      KEY,
+      JSON.stringify({ restarts: 9, nextRestartAllowedAt: Date.now() + 1000 }),
+    );
+
+    await restoreState(PHONE, mine.previous, mine.previousTtlMs, mine.wrote);
+
+    expect(JSON.parse(stringData.get(KEY) ?? "{}").restarts).toBe(9);
+  });
+
+  // Two owners incrementing at once must not collapse into one strike: the CAS
+  // loses, re-reads, and increments on top of what it finds.
+  it("re-reads and stacks when another owner writes first", async () => {
+    const evalMock = redis.eval as unknown as ReturnType<typeof mock>;
+    // The first compare-and-set loses, as if another owner had just written.
+    evalMock.mockImplementationOnce(async () => {
+      stringData.set(
+        KEY,
+        JSON.stringify({ restarts: 4, nextRestartAllowedAt: Date.now() - 1 }),
+      );
+      return 0;
+    });
+
+    const result = await recordRestart(PHONE);
+
+    expect(result.state.restarts).toBe(5);
+    expect(JSON.parse(stringData.get(KEY) ?? "{}").restarts).toBe(5);
+  });
+
   it("clears the key when the cancelled restart was the first", async () => {
     const first = await recordRestart(PHONE);
     expect(first.previous).toBeNull();
 
-    await restoreState(PHONE, first.previous);
+    await restoreState(PHONE, first.previous, first.previousTtlMs, first.wrote);
 
     expect(await nextRestartAllowedAt(PHONE)).toBeNull();
   });

--- a/src/cluster/sendStallStore.spec.ts
+++ b/src/cluster/sendStallStore.spec.ts
@@ -6,6 +6,7 @@ import {
   clearSendStall,
   nextRestartAllowedAt,
   recordRestart,
+  restoreState,
 } from "./sendStallStore";
 
 const stringData = (redis as any).__stringData as Map<string, string>;
@@ -41,12 +42,38 @@ describe("sendStallStore", () => {
   it("counts restarts across calls", async () => {
     await recordRestart(PHONE);
     const second = await recordRestart(PHONE);
-    expect(second.restarts).toBe(2);
+    expect(second.state.restarts).toBe(2);
+    // The caller gets what it is undoing, not just what it wrote.
+    expect(second.previous?.restarts).toBe(1);
   });
 
   it("reports when the next restart becomes allowed", async () => {
-    const state = await recordRestart(PHONE);
+    const { state } = await recordRestart(PHONE);
     expect(await nextRestartAllowedAt(PHONE)).toBe(state.nextRestartAllowedAt);
+  });
+
+  // A restart cancelled after the strike was written has to undo exactly its own
+  // increment. Deleting the key would also wipe an earlier genuine strike and
+  // hand the phone a clean slate it did not earn.
+  it("restores the state a cancelled restart replaced", async () => {
+    const first = await recordRestart(PHONE);
+    const second = await recordRestart(PHONE);
+    expect(second.state.restarts).toBe(2);
+
+    await restoreState(PHONE, second.previous);
+
+    expect(await nextRestartAllowedAt(PHONE)).toBe(
+      first.state.nextRestartAllowedAt,
+    );
+  });
+
+  it("clears the key when the cancelled restart was the first", async () => {
+    const first = await recordRestart(PHONE);
+    expect(first.previous).toBeNull();
+
+    await restoreState(PHONE, first.previous);
+
+    expect(await nextRestartAllowedAt(PHONE)).toBeNull();
   });
 
   it("returns null when no stall has been recorded", async () => {

--- a/src/cluster/sendStallStore.spec.ts
+++ b/src/cluster/sendStallStore.spec.ts
@@ -10,12 +10,17 @@ import {
 } from "./sendStallStore";
 
 const stringData = (redis as any).__stringData as Map<string, string>;
+const expirations = (redis as any).__expirations as Map<
+  string,
+  { type: string; value: number }
+>;
 const PHONE = "+5511999999999";
 const KEY = `@baileys-api:cluster:send-stall:${PHONE}`;
 
 describe("sendStallStore", () => {
   afterEach(() => {
     stringData.clear();
+    expirations.clear();
   });
 
   // Recovering fast the first time is the whole point; the backoff only exists
@@ -65,6 +70,48 @@ describe("sendStallStore", () => {
     expect(await nextRestartAllowedAt(PHONE)).toBe(
       first.state.nextRestartAllowedAt,
     );
+  });
+
+  // The 24h window is per phone and slides with each GENUINE restart. A restart
+  // that was called off must not slide it: restoring with a fresh lifetime gives
+  // an old history another full day to escalate the backoff from, on the
+  // strength of a restart that never happened.
+  it("puts back the expiry the cancelled restart found, not a fresh one", async () => {
+    await recordRestart(PHONE);
+    // The key is near the end of its day by the time the second episode starts.
+    expirations.set(KEY, { type: "PX", value: 60_000 });
+
+    const second = await recordRestart(PHONE);
+    expect(second.previousTtlMs).toBe(60_000);
+    // The genuine strike did slide it.
+    expect(expirations.get(KEY)).toEqual({
+      type: "PX",
+      value: 24 * 60 * 60 * 1000,
+    });
+
+    await restoreState(PHONE, second.previous, second.previousTtlMs);
+
+    expect(expirations.get(KEY)).toEqual({ type: "PX", value: 60_000 });
+  });
+
+  // No expiry (-1) and no key (-2) are not durations. Falling back to the full
+  // lifetime is the safe direction: the alternative is writing a key that never
+  // expires.
+  it("falls back to a full lifetime when the previous expiry is unreadable", async () => {
+    stringData.set(
+      KEY,
+      JSON.stringify({ restarts: 1, nextRestartAllowedAt: Date.now() - 1 }),
+    );
+    // Written without any expiration -- what a pre-upgrade instance left behind.
+    const second = await recordRestart(PHONE);
+    expect(second.previousTtlMs).toBeNull();
+
+    await restoreState(PHONE, second.previous, second.previousTtlMs);
+
+    expect(expirations.get(KEY)).toEqual({
+      type: "PX",
+      value: 24 * 60 * 60 * 1000,
+    });
   });
 
   it("clears the key when the cancelled restart was the first", async () => {

--- a/src/cluster/sendStallStore.ts
+++ b/src/cluster/sendStallStore.ts
@@ -62,11 +62,18 @@ export async function canRestart(phoneNumber: string): Promise<boolean> {
 
 // Plain read-modify-write, no CAS, mirroring quarantineStore: the only writer
 // is the instance that owns the stalled socket.
-export async function recordRestart(
-  phoneNumber: string,
-): Promise<{ state: SendStallState; previous: SendStallState | null }> {
+export async function recordRestart(phoneNumber: string): Promise<{
+  state: SendStallState;
+  previous: SendStallState | null;
+  previousTtlMs: number | null;
+}> {
   const key = clusterKeys.sendStall(phoneNumber);
   const previous = await readState(key);
+  // Read BEFORE the write below resets it. A cancelled restart has to put back
+  // the expiry it found as well as the value: restoring with a fresh 24h would
+  // give an old restart history another full day to escalate from, on the
+  // strength of a restart that never happened.
+  const previousTtlMs = previous === null ? null : await readTtlMs(key);
   const restarts = (previous?.restarts ?? 0) + 1;
   const state: SendStallState = {
     restarts,
@@ -79,7 +86,19 @@ export async function recordRestart(
   // fact can undo exactly its own increment. Deleting instead would hand the
   // phone a clean slate it did not earn: the history in here is per phone and
   // lives 24h, so an earlier genuine strike would go with it.
-  return { state, previous };
+  return { state, previous, previousTtlMs };
+}
+
+// -1 means the key has no expiry and -2 that it is gone; neither is a duration
+// worth restoring, and both fall back to a full TTL rather than writing a key
+// that never expires.
+async function readTtlMs(key: string): Promise<number | null> {
+  try {
+    const ttl = await redis.pTTL(key);
+    return typeof ttl === "number" && ttl > 0 ? ttl : null;
+  } catch {
+    return null;
+  }
 }
 
 // Undoes one recordRestart. Same read-modify-write assumption as everything else
@@ -87,6 +106,7 @@ export async function recordRestart(
 export async function restoreState(
   phoneNumber: string,
   previous: SendStallState | null,
+  ttlMs: number | null = null,
 ): Promise<void> {
   const key = clusterKeys.sendStall(phoneNumber);
   if (previous === null) {
@@ -94,7 +114,11 @@ export async function restoreState(
     return;
   }
   await redis.set(key, JSON.stringify(previous), {
-    expiration: { type: "PX", value: SEND_STALL_TTL_MS },
+    // The expiry the key had when recordRestart found it, not a fresh one. The
+    // window is per phone and slides with each GENUINE restart; a restart that
+    // was called off must not slide it, or an old history keeps escalating the
+    // backoff for up to a day longer than it earned.
+    expiration: { type: "PX", value: ttlMs ?? SEND_STALL_TTL_MS },
   });
 }
 

--- a/src/cluster/sendStallStore.ts
+++ b/src/cluster/sendStallStore.ts
@@ -64,7 +64,7 @@ export async function canRestart(phoneNumber: string): Promise<boolean> {
 // is the instance that owns the stalled socket.
 export async function recordRestart(
   phoneNumber: string,
-): Promise<SendStallState> {
+): Promise<{ state: SendStallState; previous: SendStallState | null }> {
   const key = clusterKeys.sendStall(phoneNumber);
   const previous = await readState(key);
   const restarts = (previous?.restarts ?? 0) + 1;
@@ -75,7 +75,27 @@ export async function recordRestart(
   await redis.set(key, JSON.stringify(state), {
     expiration: { type: "PX", value: SEND_STALL_TTL_MS },
   });
-  return state;
+  // `previous` travels back so a caller whose restart is cancelled after the
+  // fact can undo exactly its own increment. Deleting instead would hand the
+  // phone a clean slate it did not earn: the history in here is per phone and
+  // lives 24h, so an earlier genuine strike would go with it.
+  return { state, previous };
+}
+
+// Undoes one recordRestart. Same read-modify-write assumption as everything else
+// in this file: the only writer is the instance that owns the stalled socket.
+export async function restoreState(
+  phoneNumber: string,
+  previous: SendStallState | null,
+): Promise<void> {
+  const key = clusterKeys.sendStall(phoneNumber);
+  if (previous === null) {
+    await redis.del(key);
+    return;
+  }
+  await redis.set(key, JSON.stringify(previous), {
+    expiration: { type: "PX", value: SEND_STALL_TTL_MS },
+  });
 }
 
 export async function nextRestartAllowedAt(

--- a/src/cluster/sendStallStore.ts
+++ b/src/cluster/sendStallStore.ts
@@ -1,0 +1,90 @@
+import { clusterKeys } from "@/cluster/keys";
+import redis from "@/lib/redis";
+
+// Rate-limits the send-stall watchdog's socket restarts per phone. A phone that
+// stalls again minutes after a restart is not being cured by restarting, so the
+// backoff escalates towards "give up and let the operator see it" instead of
+// looping.
+//
+// This is a sibling of quarantineStore, not a reuse of it, for two reasons.
+// Semantics are opposite: quarantine means "do not CLAIM this phone" and is
+// read only by background claims, so feeding stall strikes into it would make a
+// stalled-but-healthy phone unclaimable right after a failover — when moving to
+// another instance is precisely the cure. And the mechanism would not even
+// work: clearQuarantine runs on every healthy `open`, which a stall restart
+// produces seconds later, so the strike would be wiped before it ever mattered.
+//
+// The key is per-phone and cluster-wide, which here is deliberate: a phone that
+// stalls on instance A should not be hammered with restarts after it migrates
+// to instance B.
+export interface SendStallState {
+  restarts: number;
+  nextRestartAllowedAt: number;
+}
+
+// Kept as module constants rather than env vars, matching
+// CONNECTION_REPLACED_LOOP_* in connection.ts: these are the shape of a
+// heuristic, not something an operator tunes per deployment.
+const SEND_STALL_BACKOFF_BASE_MS = 5 * 60 * 1000;
+const SEND_STALL_BACKOFF_MAX_MS = 60 * 60 * 1000;
+// Shorter than quarantine's 7 days: 13 occurrences since May is sparse history,
+// so this only needs to catch flapping within a day and then self-clean.
+const SEND_STALL_TTL_MS = 24 * 60 * 60 * 1000;
+const MAX_BACKOFF_EXPONENT = 25;
+
+export function backoffMs(restarts: number): number {
+  const exponent = Math.min(Math.max(restarts - 1, 0), MAX_BACKOFF_EXPONENT);
+  return Math.min(
+    SEND_STALL_BACKOFF_BASE_MS * 2 ** exponent,
+    SEND_STALL_BACKOFF_MAX_MS,
+  );
+}
+
+async function readState(key: string): Promise<SendStallState | null> {
+  const raw = await redis.get(key);
+  if (!raw) {
+    return null;
+  }
+  try {
+    return JSON.parse(raw) as SendStallState;
+  } catch {
+    return null;
+  }
+}
+
+// Whether a restart may run now. The FIRST restart for a phone is always
+// allowed — the backoff only gates repeats inside the window, because the whole
+// point is to recover fast the first time.
+export async function canRestart(phoneNumber: string): Promise<boolean> {
+  const state = await readState(clusterKeys.sendStall(phoneNumber));
+  return !state || state.nextRestartAllowedAt <= Date.now();
+}
+
+// Plain read-modify-write, no CAS, mirroring quarantineStore: the only writer
+// is the instance that owns the stalled socket.
+export async function recordRestart(
+  phoneNumber: string,
+): Promise<SendStallState> {
+  const key = clusterKeys.sendStall(phoneNumber);
+  const previous = await readState(key);
+  const restarts = (previous?.restarts ?? 0) + 1;
+  const state: SendStallState = {
+    restarts,
+    nextRestartAllowedAt: Date.now() + backoffMs(restarts),
+  };
+  await redis.set(key, JSON.stringify(state), {
+    expiration: { type: "PX", value: SEND_STALL_TTL_MS },
+  });
+  return state;
+}
+
+export async function nextRestartAllowedAt(
+  phoneNumber: string,
+): Promise<number | null> {
+  const state = await readState(clusterKeys.sendStall(phoneNumber));
+  return state?.nextRestartAllowedAt ?? null;
+}
+
+export async function clearSendStall(phoneNumber: string): Promise<void> {
+  await redis.del(clusterKeys.sendStall(phoneNumber));
+}

--- a/src/cluster/sendStallStore.ts
+++ b/src/cluster/sendStallStore.ts
@@ -40,8 +40,7 @@ export function backoffMs(restarts: number): number {
   );
 }
 
-async function readState(key: string): Promise<SendStallState | null> {
-  const raw = await redis.get(key);
+function parseState(raw: string | null): SendStallState | null {
   if (!raw) {
     return null;
   }
@@ -52,6 +51,10 @@ async function readState(key: string): Promise<SendStallState | null> {
   }
 }
 
+async function readState(key: string): Promise<SendStallState | null> {
+  return parseState(await redis.get(key));
+}
+
 // Whether a restart may run now. The FIRST restart for a phone is always
 // allowed — the backoff only gates repeats inside the window, because the whole
 // point is to recover fast the first time.
@@ -60,33 +63,81 @@ export async function canRestart(phoneNumber: string): Promise<boolean> {
   return !state || state.nextRestartAllowedAt <= Date.now();
 }
 
-// Plain read-modify-write, no CAS, mirroring quarantineStore: the only writer
-// is the instance that owns the stalled socket.
+// Compare-and-set, not the plain read-modify-write quarantineStore uses. That
+// pattern rests on "the only writer is the instance that owns the stalled
+// socket", and this key has a window where two of them exist: during a lease
+// handoff the old owner can still be inside an episode -- it discovers the
+// handoff in the same round trip that writes this strike -- while the new owner
+// starts one of its own. A lost increment costs one step of escalation; an old
+// owner's rollback landing on the new owner's strike costs the whole history,
+// on precisely the phone that is flapping between instances.
+//
+// KEYS[1]=key, ARGV=[expected ("" for absent), value, ttlMs]. Every value ever
+// stored here is JSON, so "" is unambiguous as "the key must not exist".
+const CAS_SCRIPT = `-- send-stall-cas
+local raw = redis.call("GET", KEYS[1])
+if (raw == false and ARGV[1] == "") or raw == ARGV[1] then
+  redis.call("SET", KEYS[1], ARGV[2], "PX", ARGV[3])
+  return 1
+end
+return 0`;
+
+// The delete half of the same rule: drop the key only if it still holds what we
+// wrote. KEYS[1]=key, ARGV[1]=expected.
+const CAD_SCRIPT = `-- send-stall-cad
+if redis.call("GET", KEYS[1]) == ARGV[1] then
+  redis.call("DEL", KEYS[1])
+  return 1
+end
+return 0`;
+
+// Bounded, because a retry only makes sense while the contention is real. Losing
+// three in a row means another owner is writing steadily, and its strikes are
+// doing the job this one would have.
+const CAS_ATTEMPTS = 3;
+
 export async function recordRestart(phoneNumber: string): Promise<{
   state: SendStallState;
   previous: SendStallState | null;
   previousTtlMs: number | null;
+  // Exactly what was written, so a rollback can prove the key is still its own
+  // before touching it.
+  wrote: string;
 }> {
   const key = clusterKeys.sendStall(phoneNumber);
-  const previous = await readState(key);
-  // Read BEFORE the write below resets it. A cancelled restart has to put back
-  // the expiry it found as well as the value: restoring with a fresh 24h would
-  // give an old restart history another full day to escalate from, on the
-  // strength of a restart that never happened.
-  const previousTtlMs = previous === null ? null : await readTtlMs(key);
-  const restarts = (previous?.restarts ?? 0) + 1;
-  const state: SendStallState = {
-    restarts,
-    nextRestartAllowedAt: Date.now() + backoffMs(restarts),
-  };
-  await redis.set(key, JSON.stringify(state), {
-    expiration: { type: "PX", value: SEND_STALL_TTL_MS },
-  });
-  // `previous` travels back so a caller whose restart is cancelled after the
-  // fact can undo exactly its own increment. Deleting instead would hand the
-  // phone a clean slate it did not earn: the history in here is per phone and
-  // lives 24h, so an earlier genuine strike would go with it.
-  return { state, previous, previousTtlMs };
+  for (let attempt = 0; attempt < CAS_ATTEMPTS; attempt += 1) {
+    const raw = await redis.get(key);
+    const previous = parseState(raw);
+    // Read BEFORE the write below resets it. A cancelled restart has to put back
+    // the expiry it found as well as the value: restoring with a fresh 24h would
+    // give an old restart history another full day to escalate from, on the
+    // strength of a restart that never happened.
+    const previousTtlMs = previous === null ? null : await readTtlMs(key);
+    const restarts = (previous?.restarts ?? 0) + 1;
+    const state: SendStallState = {
+      restarts,
+      nextRestartAllowedAt: Date.now() + backoffMs(restarts),
+    };
+    const wrote = JSON.stringify(state);
+    const applied = await redis.eval(CAS_SCRIPT, {
+      keys: [key],
+      arguments: [raw ?? "", wrote, String(SEND_STALL_TTL_MS)],
+    });
+    if (applied === 1) {
+      // `previous` travels back so a caller whose restart is cancelled after the
+      // fact can undo exactly its own increment. Deleting instead would hand the
+      // phone a clean slate it did not earn: the history in here is per phone and
+      // lives 24h, so an earlier genuine strike would go with it.
+      return { state, previous, previousTtlMs, wrote };
+    }
+  }
+  // Throwing rather than forcing the write, and the caller treats it as it does
+  // any other failure to record: suppress, do not restart blind. That is the
+  // right answer here too -- losing every attempt means another owner recorded
+  // its own strike, so this phone is already accounted for.
+  throw new Error(
+    `send-stall strike for ${phoneNumber} lost every compare-and-set attempt`,
+  );
 }
 
 // -1 means the key has no expiry and -2 that it is gone; neither is a duration
@@ -106,19 +157,29 @@ async function readTtlMs(key: string): Promise<number | null> {
 export async function restoreState(
   phoneNumber: string,
   previous: SendStallState | null,
-  ttlMs: number | null = null,
+  ttlMs: number | null,
+  // What recordRestart wrote. The undo only applies while the key is still that
+  // exact value: a newer owner's strike landing in between is a real event this
+  // rollback knows nothing about, and putting our `previous` back over it would
+  // erase the whole history on the one phone that is flapping between instances.
+  expected: string,
 ): Promise<void> {
   const key = clusterKeys.sendStall(phoneNumber);
   if (previous === null) {
-    await redis.del(key);
+    await redis.eval(CAD_SCRIPT, { keys: [key], arguments: [expected] });
     return;
   }
-  await redis.set(key, JSON.stringify(previous), {
-    // The expiry the key had when recordRestart found it, not a fresh one. The
-    // window is per phone and slides with each GENUINE restart; a restart that
-    // was called off must not slide it, or an old history keeps escalating the
-    // backoff for up to a day longer than it earned.
-    expiration: { type: "PX", value: ttlMs ?? SEND_STALL_TTL_MS },
+  await redis.eval(CAS_SCRIPT, {
+    keys: [key],
+    arguments: [
+      expected,
+      JSON.stringify(previous),
+      // The expiry the key had when recordRestart found it, not a fresh one. The
+      // window is per phone and slides with each GENUINE restart; a restart that
+      // was called off must not slide it, or an old history keeps escalating the
+      // backoff for up to a day longer than it earned.
+      String(ttlMs ?? SEND_STALL_TTL_MS),
+    ],
   });
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,6 +6,11 @@ const {
   PORT,
   LOG_LEVEL,
   BAILEYS_LOG_LEVEL,
+  BAILEYS_HTTP_TIMEOUT_MS,
+  BAILEYS_TX_ACQUIRE_TIMEOUT_MS,
+  BAILEYS_TX_HOLD_WARN_MS,
+  BAILEYS_SEND_TIMEOUT_MS,
+  BAILEYS_SEND_STALL_RESTART_ENABLED,
   BAILEYS_CLIENT_VERSION,
   BAILEYS_OVERRIDE_CLIENT_VERSION,
   REDIS_URL,
@@ -93,6 +98,56 @@ const config = {
   logLevel: (LOG_LEVEL || "info") as LevelWithSilentOrString,
   baileys: {
     logLevel: (BAILEYS_LOG_LEVEL || "warn") as LevelWithSilentOrString,
+    // Deadline for the lib's own HTTP downloads (patched into getHttpStream).
+    // A parked TLS stream there hangs inside the keystore transaction keyed by
+    // our own JID and wedges every send on the connection -- the silent send
+    // stall. App-state blobs are small, so 120s is pure headroom for the case
+    // that matters.
+    httpTimeoutMs: intFromEnv(
+      "BAILEYS_HTTP_TIMEOUT_MS",
+      BAILEYS_HTTP_TIMEOUT_MS,
+      120_000,
+    ),
+    // Reject after waiting this long for the keystore transaction mutex. Six
+    // operations share the key `meId`, so one that never returns blocks all of
+    // them. Floor is 90s: below `defaultQueryTimeoutMs` (60s) a legitimately
+    // slow IQ inside the holder would fail everyone waiting. Defaults to the
+    // conservative rollout value -- high enough to be diagnosis-only, since
+    // `resyncAppState` is the longest legitimate holder -- so a deploy that
+    // sets nothing cannot start failing real transactions. Lower to 90_000
+    // once the stall reports name the culprit. 0 disables.
+    txAcquireTimeoutMs: intFromEnv(
+      "BAILEYS_TX_ACQUIRE_TIMEOUT_MS",
+      BAILEYS_TX_ACQUIRE_TIMEOUT_MS,
+      300_000,
+      { min: 0 },
+    ),
+    // Report a transaction still holding the mutex after this long. Kept below
+    // txAcquireTimeoutMs so the holder's stall report precedes the waiters'
+    // timeouts and the logs read in causal order. 0 disables.
+    txHoldWarnMs: intFromEnv(
+      "BAILEYS_TX_HOLD_WARN_MS",
+      BAILEYS_TX_HOLD_WARN_MS,
+      30_000,
+      { min: 0 },
+    ),
+    // Deadline on the socket's own sendMessage. Must stay below
+    // PROXY_REQUEST_TIMEOUT_MS, otherwise the proxy cuts first and the worker
+    // never gets to release the idempotency lock or count the stall.
+    sendTimeoutMs: intFromEnv(
+      "BAILEYS_SEND_TIMEOUT_MS",
+      BAILEYS_SEND_TIMEOUT_MS,
+      45_000,
+    ),
+    // Whether a connection whose sends keep timing out may recreate its own
+    // socket. Off by default: this kills a live socket on a heuristic, so it
+    // is opted into after a period of watching the detector fire only on the
+    // real pattern. Detection, logging and the webhook run either way.
+    sendStallRestartEnabled: boolFromEnv(
+      "BAILEYS_SEND_STALL_RESTART_ENABLED",
+      BAILEYS_SEND_STALL_RESTART_ENABLED,
+      false,
+    ),
     clientVersion: BAILEYS_CLIENT_VERSION || "default",
     overrideClientVersion: BAILEYS_OVERRIDE_CLIENT_VERSION === "true",
     // FIXME: We ignore any non-user messages for now. As we implement more features,
@@ -294,6 +349,24 @@ if (config.cluster.heartbeatIntervalMs > config.cluster.instanceTtlMs / 2) {
 if (config.cluster.quarantineBaseMs > config.cluster.quarantineMaxMs) {
   throw new Error(
     "CLUSTER_QUARANTINE_BASE_MS must be at most CLUSTER_QUARANTINE_MAX_MS",
+  );
+}
+// The holder's stall report has to land before the waiters start timing out,
+// otherwise the logs show the symptom with no trace of its cause.
+if (
+  config.baileys.txAcquireTimeoutMs > 0 &&
+  config.baileys.txHoldWarnMs >= config.baileys.txAcquireTimeoutMs
+) {
+  throw new Error(
+    "BAILEYS_TX_HOLD_WARN_MS must be lower than BAILEYS_TX_ACQUIRE_TIMEOUT_MS",
+  );
+}
+// A send that outlives the proxy's deadline is answered by the proxy's generic
+// 504, so the worker's own 504/503 -- and the lock release that goes with it --
+// never reach the caller.
+if (config.baileys.sendTimeoutMs >= config.proxy.requestTimeoutMs) {
+  throw new Error(
+    "BAILEYS_SEND_TIMEOUT_MS must be lower than PROXY_REQUEST_TIMEOUT_MS",
   );
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -351,6 +351,18 @@ if (config.cluster.quarantineBaseMs > config.cluster.quarantineMaxMs) {
     "CLUSTER_QUARANTINE_BASE_MS must be at most CLUSTER_QUARANTINE_MAX_MS",
   );
 }
+// The floor exists because defaultQueryTimeoutMs is 60s: below that, an IQ the
+// holder is legitimately waiting on would fail every waiter behind it. A small
+// nonzero value is therefore never a gentler setting, it is a way to break all
+// sends, so it is rejected rather than clamped.
+if (
+  config.baileys.txAcquireTimeoutMs > 0 &&
+  config.baileys.txAcquireTimeoutMs < 90_000
+) {
+  throw new Error(
+    "BAILEYS_TX_ACQUIRE_TIMEOUT_MS must be 0 (disabled) or at least 90000",
+  );
+}
 // The holder's stall report has to land before the waiters start timing out,
 // otherwise the logs show the symptom with no trace of its cause.
 if (

--- a/src/config.ts
+++ b/src/config.ts
@@ -86,6 +86,14 @@ function boolFromEnv(
   return raw === "true";
 }
 
+// How long the two ffmpeg jobs behind an audio/PTT send may take before we give
+// up converting and send the original buffer instead -- the same degradation
+// the code already applies when ffmpeg is missing. Not configurable: its only
+// job is to make the worker's total wall time bounded and checkable against
+// PROXY_REQUEST_TIMEOUT_MS, and an env var would let that check be defeated by
+// the same operator it protects.
+const AUDIO_PREPROCESS_TIMEOUT_MS = 20_000;
+
 const config = {
   packageInfo: {
     name: packageInfo.name,
@@ -134,6 +142,14 @@ const config = {
       30_000,
       { min: 0 },
     ),
+    // Deadline on the local ffmpeg work that runs BEFORE the send deadline is
+    // armed. Deliberately outside it: ffmpeg is local and slow for honest
+    // reasons, so counting it as a send timeout would open the breaker and
+    // recreate healthy sockets. But it still spends the request's budget, and
+    // the worker's wall time is this plus sendTimeoutMs -- which is what the
+    // invariant at the bottom of this file checks against the proxy deadline.
+    // Fixed rather than env-driven precisely so that sum stays checkable.
+    audioPreprocessTimeoutMs: AUDIO_PREPROCESS_TIMEOUT_MS,
     // Deadline on the socket's own sendMessage. Must stay below
     // PROXY_REQUEST_TIMEOUT_MS, otherwise the proxy cuts first and the worker
     // never gets to release the idempotency lock or count the stall.
@@ -378,10 +394,16 @@ if (
 }
 // A send that outlives the proxy's deadline is answered by the proxy's generic
 // 504, so the worker's own 504/503 -- and the lock release that goes with it --
-// never reach the caller.
-if (config.baileys.sendTimeoutMs >= config.proxy.requestTimeoutMs) {
+// never reach the caller. The audio budget is part of the sum because it is
+// spent BEFORE the send deadline is armed: for a PTT the worker's wall time is
+// both, and comparing the send deadline alone would state a guarantee the
+// worker cannot keep.
+if (
+  config.baileys.sendTimeoutMs + config.baileys.audioPreprocessTimeoutMs >=
+  config.proxy.requestTimeoutMs
+) {
   throw new Error(
-    "BAILEYS_SEND_TIMEOUT_MS must be lower than PROXY_REQUEST_TIMEOUT_MS",
+    `BAILEYS_SEND_TIMEOUT_MS plus the ${AUDIO_PREPROCESS_TIMEOUT_MS}ms audio-preprocessing budget must be lower than PROXY_REQUEST_TIMEOUT_MS`,
   );
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -115,7 +115,10 @@ const config = {
     // conservative rollout value -- high enough to be diagnosis-only, since
     // `resyncAppState` is the longest legitimate holder -- so a deploy that
     // sets nothing cannot start failing real transactions. Lower to 90_000
-    // once the stall reports name the culprit. 0 disables.
+    // once the stall reports name the culprit. 0 disables — and disabling gives up
+    // the only bound on how long an abandoned send stays queued on the mutex,
+    // which the 24h indeterminate marker in withIdempotency assumes is shorter
+    // than a day. Off is a kill switch, not a steady state.
     txAcquireTimeoutMs: intFromEnv(
       "BAILEYS_TX_ACQUIRE_TIMEOUT_MS",
       BAILEYS_TX_ACQUIRE_TIMEOUT_MS,

--- a/src/controllers/cluster.ts
+++ b/src/controllers/cluster.ts
@@ -8,6 +8,11 @@ export interface ClusterHealthResponse {
   role: string;
   connectionCount: number;
   draining: boolean;
+  // Connections that are registered and receiving but whose sends are wedged.
+  // NOTE: For alerting only. This must never make the container health check
+  // fail — a failing check restarts the process and takes every healthy
+  // connection down with it, which is strictly worse than the stall.
+  stalledConnectionCount: number;
 }
 
 // Unauthenticated by design: consumed by container healthchecks and the
@@ -24,6 +29,7 @@ const clusterController = new Elysia({
     role,
     connectionCount: baileys.size,
     draining: coordinator.isDraining,
+    stalledConnectionCount: baileys.stalledConnectionCount(),
   }),
   {
     detail: {

--- a/src/controllers/connections/index.spec.ts
+++ b/src/controllers/connections/index.spec.ts
@@ -220,6 +220,33 @@ describe("connectionsController send-message", () => {
     }
   });
 
+  // The wedge reported one layer down, by the patched keystore transaction. Left
+  // unmapped it leaves as a generic 500, which tells the caller nothing and gets
+  // the channel marked down on the Chatwoot side. It is retry-safe unconditionally,
+  // unlike the 504: a waiter that gave up on the mutex never entered the
+  // transaction, so no node reached the wire and the message was not sent.
+  it("answers 503 when a keystore transaction gives up on its mutex", async () => {
+    const spy = spyOn(baileys, "sendMessage").mockImplementation(async () => {
+      throw Object.assign(new Error("keystore transaction timed out"), {
+        data: { key: "me@s.whatsapp.net", code: "E_TX_MUTEX_TIMEOUT" },
+      });
+    });
+
+    try {
+      const app = new Elysia().use(connectionsController);
+      // No reserved id, which is what makes the 504 branch above answer
+      // "unprotected". This branch must not care: nothing was sent.
+      const res = await app.handle(sendMessageRequest("+551234567890"));
+
+      expect(res.status).toBe(503);
+      expect(res.headers.get("x-baileys-send-state")).toBe("stalled");
+      expect(res.headers.get("retry-after")).toBe("60");
+      expect(await res.text()).toContain("was not sent");
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
   // With neither a chatwootMessageId nor a messageId there is no key, so
   // withIdempotency takes its no-key path and never records anything: nothing
   // stands between a retry and a second WhatsApp message. The response must not

--- a/src/controllers/connections/index.spec.ts
+++ b/src/controllers/connections/index.spec.ts
@@ -211,8 +211,58 @@ describe("connectionsController send-message", () => {
 
       expect(res.status).toBe(503);
       expect(res.headers.get("retry-after")).toBe("60");
+      // An ordinary outage, a draining proxy and a wedged socket all answer 503,
+      // and only this one means "the connection is up, do not mark it down". A
+      // caller that reads the status alone skips a reconnect it needed.
+      expect(res.headers.get("x-baileys-send-state")).toBe("stalled");
     } finally {
       spy.mockRestore();
+    }
+  });
+
+  // With neither a chatwootMessageId nor a messageId there is no key, so
+  // withIdempotency takes its no-key path and never records anything: nothing
+  // stands between a retry and a second WhatsApp message. The response must not
+  // ask for that retry.
+  it("does not invite a retry when a timed-out send reserved no id at all", async () => {
+    const spy = spyOn(baileys, "sendMessage").mockImplementation(async () => {
+      throw new OperationTimeoutError("sendMessage", 45_000);
+    });
+
+    try {
+      const app = new Elysia().use(connectionsController);
+      const res = await app.handle(sendMessageRequest("+551234567890"));
+
+      expect(res.status).toBe(504);
+      expect(res.headers.get("retry-after")).toBeNull();
+      expect(res.headers.get("x-baileys-idempotency-state")).toBe(
+        "unprotected",
+      );
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  // The idempotency key alone is protection enough: the retry meets the
+  // indeterminate marker and gets a 409 instead of sending again.
+  it("still invites a retry when only an idempotency key was supplied", async () => {
+    const stringData = (redis as any).__stringData as Map<string, string>;
+    stringData.clear();
+    const spy = spyOn(baileys, "sendMessage").mockImplementation(async () => {
+      throw new OperationTimeoutError("sendMessage", 45_000);
+    });
+
+    try {
+      const app = new Elysia().use(connectionsController);
+      const res = await app.handle(
+        sendMessageRequest("+551234567890", { chatwootMessageId: "42" }),
+      );
+
+      expect(res.status).toBe(504);
+      expect(res.headers.get("retry-after")).toBe("60");
+    } finally {
+      spy.mockRestore();
+      stringData.clear();
     }
   });
 

--- a/src/controllers/connections/index.spec.ts
+++ b/src/controllers/connections/index.spec.ts
@@ -329,12 +329,12 @@ describe("connectionsController send-message", () => {
     }
   });
 
-  // The way out the 409 body advertises, and it has to actually work: a resend
-  // carrying a reserved messageId lands on the same WhatsApp key, so it cannot
-  // produce a second message. Without this the marker is a dead end for a full
-  // day — including for the caller that reserved an id precisely so its send
-  // could be safely repeated.
-  it("lets a resend with a reserved messageId past an indeterminate marker", async () => {
+  // A marker is only ever written for a send that had NO reserved id, so the
+  // WhatsApp key that attempt used is unknown to us. A retry supplying a freshly
+  // reserved id lands on a DIFFERENT key, which is a second message rather than a
+  // deduplicated one — so the id that makes a FIRST send safe does not make this
+  // retry safe, and the marker holds.
+  it("refuses a resend with a reserved messageId past an indeterminate marker", async () => {
     const stringData = (redis as any).__stringData as Map<string, string>;
     stringData.clear();
     const spy = spyOn(baileys, "sendMessage").mockImplementation(async () => {
@@ -360,7 +360,10 @@ describe("connectionsController send-message", () => {
         }),
       );
 
-      expect(res.status).toBe(200);
+      expect(res.status).toBe(409);
+      expect(res.headers.get("x-baileys-idempotency-state")).toBe(
+        "indeterminate",
+      );
     } finally {
       spy.mockRestore();
       stringData.clear();
@@ -596,7 +599,9 @@ describe("connectionsController restart", () => {
     });
 
   it("answers 202 once the restart is accepted", async () => {
-    const spy = spyOn(coordinator, "restartWithLease").mockResolvedValue(true);
+    const spy = spyOn(coordinator, "restartWithLease").mockResolvedValue(
+      "restarted",
+    );
 
     try {
       const app = new Elysia().use(connectionsController);
@@ -610,7 +615,9 @@ describe("connectionsController restart", () => {
   });
 
   it("passes the caller's reason through to the coordinator", async () => {
-    const spy = spyOn(coordinator, "restartWithLease").mockResolvedValue(true);
+    const spy = spyOn(coordinator, "restartWithLease").mockResolvedValue(
+      "restarted",
+    );
 
     try {
       const app = new Elysia().use(connectionsController);
@@ -629,8 +636,28 @@ describe("connectionsController restart", () => {
     }
   });
 
+  // A newer explicit operation ran first, which usually leaves a perfectly good
+  // session behind. 404 would send the caller off to re-pair what somebody else
+  // just rebuilt.
+  it("answers 409 when another operation superseded the restart", async () => {
+    const spy = spyOn(coordinator, "restartWithLease").mockResolvedValue(
+      "superseded",
+    );
+
+    try {
+      const app = new Elysia().use(connectionsController);
+      const res = await app.handle(restartRequest("+551234567890"));
+
+      expect(res.status).toBe(409);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
   it("answers 404 when there is no stored session to restart", async () => {
-    const spy = spyOn(coordinator, "restartWithLease").mockResolvedValue(false);
+    const spy = spyOn(coordinator, "restartWithLease").mockResolvedValue(
+      "not-found",
+    );
 
     try {
       const app = new Elysia().use(connectionsController);

--- a/src/controllers/connections/index.spec.ts
+++ b/src/controllers/connections/index.spec.ts
@@ -318,6 +318,49 @@ describe("connectionsController send-message", () => {
       expect(res.headers.get("x-baileys-idempotency-state")).toBe(
         "indeterminate",
       );
+      // No retry-after: nothing clears this marker on a timer. It outlives the
+      // caller's retries by design, so a 60-second wait would promise a state
+      // change that never comes and turn a message needing reconciliation into
+      // a job that retries for a day.
+      expect(res.headers.get("retry-after")).toBeNull();
+    } finally {
+      spy.mockRestore();
+      stringData.clear();
+    }
+  });
+
+  // The way out the 409 body advertises, and it has to actually work: a resend
+  // carrying a reserved messageId lands on the same WhatsApp key, so it cannot
+  // produce a second message. Without this the marker is a dead end for a full
+  // day — including for the caller that reserved an id precisely so its send
+  // could be safely repeated.
+  it("lets a resend with a reserved messageId past an indeterminate marker", async () => {
+    const stringData = (redis as any).__stringData as Map<string, string>;
+    stringData.clear();
+    const spy = spyOn(baileys, "sendMessage").mockImplementation(async () => {
+      throw new OperationTimeoutError("sendMessage", 45_000);
+    });
+
+    try {
+      const app = new Elysia().use(connectionsController);
+      await app.handle(
+        sendMessageRequest("+551234567890", { chatwootMessageId: "42" }),
+      );
+      const key = "@baileys-api:idempotency:send-message:+551234567890:42";
+      expect(stringData.get(key)).toStartWith("indeterminate:");
+
+      spy.mockImplementation(async () => ({
+        key: { id: "3EB0RESERVED" },
+        messageTimestamp: 1,
+      }));
+      const res = await app.handle(
+        sendMessageRequest("+551234567890", {
+          chatwootMessageId: "42",
+          messageId: "3EB0RESERVED",
+        }),
+      );
+
+      expect(res.status).toBe(200);
     } finally {
       spy.mockRestore();
       stringData.clear();

--- a/src/controllers/connections/index.spec.ts
+++ b/src/controllers/connections/index.spec.ts
@@ -1,4 +1,12 @@
-import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  type mock,
+  spyOn,
+} from "bun:test";
 import Elysia from "elysia";
 import baileys from "@/baileys";
 import { BaileysSendStalledError } from "@/baileys/connection";
@@ -287,6 +295,103 @@ describe("connectionsController send-message", () => {
 
       expect(res.status).toBe(504);
       expect(res.headers.get("retry-after")).toBe("60");
+    } finally {
+      spy.mockRestore();
+      stringData.clear();
+    }
+  });
+
+  // Holding a key is not the same as being protected by one. withIdempotency
+  // fails open on purpose -- acquireLock returns success when it cannot write and
+  // markIndeterminate only warns -- so a Redis outage runs the send unlocked and
+  // leaves nothing behind. `retry-after` is an instruction, and issuing one here
+  // tells the caller to do the one thing that duplicates.
+  it("does not invite a retry when the marker could not be written", async () => {
+    const stringData = (redis as any).__stringData as Map<string, string>;
+    stringData.clear();
+    const spy = spyOn(baileys, "sendMessage").mockImplementation(async () => {
+      throw new OperationTimeoutError("sendMessage", 45_000);
+    });
+    // mockImplementationOnce on the existing mock, never spyOn: redis.set is
+    // already a mock here, and spying over one leaks past mockRestore into every
+    // later spec file. Twice, because the outage has to reach both writes -- the
+    // lock acquire, which fails open, and the marker.
+    const setMock = redis.set as unknown as ReturnType<typeof mock>;
+    setMock.mockClear();
+    const down = async () => {
+      throw new Error("redis down");
+    };
+    setMock.mockImplementationOnce(down).mockImplementationOnce(down);
+
+    try {
+      const app = new Elysia().use(connectionsController);
+      const res = await app.handle(
+        sendMessageRequest("+551234567890", { chatwootMessageId: "42" }),
+      );
+
+      expect(res.status).toBe(504);
+      expect(res.headers.get("retry-after")).toBeNull();
+      expect(res.headers.get("x-baileys-idempotency-state")).toBe(
+        "unprotected",
+      );
+      // Nothing was recorded, which is exactly why the retry is not safe.
+      expect(
+        stringData.has(
+          "@baileys-api:idempotency:send-message:+551234567890:42",
+        ),
+      ).toBe(false);
+      // Both writes were actually attempted, or the stub above proved nothing.
+      expect(setMock.mock.calls.length).toBe(2);
+    } finally {
+      spy.mockRestore();
+      stringData.clear();
+    }
+  });
+
+  // The marker says "outcome unknown". A mutex-acquire timeout arriving minutes
+  // later makes it known: that waiter never entered the transaction, so it read
+  // nothing, wrote nothing and relayed nothing. Leaving the marker up then 409s
+  // the operator's resend of this same message for 24h, when a resend is now
+  // exactly the right thing.
+  it("retracts the indeterminate marker once the send is proved not to have happened", async () => {
+    const stringData = (redis as any).__stringData as Map<string, string>;
+    stringData.clear();
+    let lateFailure: (() => void) | undefined;
+    const spy = spyOn(baileys, "sendMessage").mockImplementation(
+      async (
+        _phone: string,
+        args: { onLateDefinitiveFailure?: () => void },
+      ) => {
+        lateFailure = args.onLateDefinitiveFailure;
+        throw new OperationTimeoutError("sendMessage", 45_000);
+      },
+    );
+
+    try {
+      const app = new Elysia().use(connectionsController);
+      await app.handle(
+        sendMessageRequest("+551234567890", { chatwootMessageId: "42" }),
+      );
+
+      const key = "@baileys-api:idempotency:send-message:+551234567890:42";
+      expect(stringData.get(key)).toStartWith("indeterminate:");
+
+      // The parked send finally rejects, with the one error that proves it never
+      // reached WhatsApp.
+      expect(lateFailure).toBeDefined();
+      lateFailure?.();
+      await new Promise((r) => setTimeout(r, 5));
+      expect(stringData.has(key)).toBe(false);
+
+      // And the resend now goes through instead of meeting a 409.
+      spy.mockImplementation(async () => ({
+        key: { id: "3EB0AGAIN" },
+        messageTimestamp: 1,
+      }));
+      const res = await app.handle(
+        sendMessageRequest("+551234567890", { chatwootMessageId: "42" }),
+      );
+      expect(res.status).toBe(200);
     } finally {
       spy.mockRestore();
       stringData.clear();

--- a/src/controllers/connections/index.spec.ts
+++ b/src/controllers/connections/index.spec.ts
@@ -312,16 +312,19 @@ describe("connectionsController send-message", () => {
     const spy = spyOn(baileys, "sendMessage").mockImplementation(async () => {
       throw new OperationTimeoutError("sendMessage", 45_000);
     });
-    // mockImplementationOnce on the existing mock, never spyOn: redis.set is
-    // already a mock here, and spying over one leaks past mockRestore into every
-    // later spec file. Twice, because the outage has to reach both writes -- the
-    // lock acquire, which fails open, and the marker.
+    // mockImplementationOnce on the existing mocks, never spyOn: these are
+    // already mocks here, and spying over one leaks past mockRestore into every
+    // later spec file. Both writes have to be reached -- the lock acquire (SET,
+    // which fails open) and the marker (a compare-and-set EVAL).
     const setMock = redis.set as unknown as ReturnType<typeof mock>;
+    const evalMock = redis.eval as unknown as ReturnType<typeof mock>;
     setMock.mockClear();
+    evalMock.mockClear();
     const down = async () => {
       throw new Error("redis down");
     };
-    setMock.mockImplementationOnce(down).mockImplementationOnce(down);
+    setMock.mockImplementationOnce(down);
+    evalMock.mockImplementationOnce(down);
 
     try {
       const app = new Elysia().use(connectionsController);
@@ -340,8 +343,9 @@ describe("connectionsController send-message", () => {
           "@baileys-api:idempotency:send-message:+551234567890:42",
         ),
       ).toBe(false);
-      // Both writes were actually attempted, or the stub above proved nothing.
-      expect(setMock.mock.calls.length).toBe(2);
+      // Both writes were actually attempted, or the stubs above proved nothing.
+      expect(setMock.mock.calls.length).toBe(1);
+      expect(evalMock.mock.calls.length).toBe(1);
     } finally {
       spy.mockRestore();
       stringData.clear();

--- a/src/controllers/connections/index.spec.ts
+++ b/src/controllers/connections/index.spec.ts
@@ -350,6 +350,15 @@ describe("connectionsController send-message", () => {
       // change that never comes and turn a message needing reconciliation into
       // a job that retries for a day.
       expect(res.headers.get("retry-after")).toBeNull();
+      // The body reaches a person: Chatwoot stores it as the message's
+      // external_error, and it is what an agent acts on. It must not name the
+      // one procedure that duplicates: a resend under a new chatwootMessageId
+      // asks a different question and sidesteps this marker entirely, while the
+      // timed-out attempt reserved no WhatsApp id for anything to deduplicate
+      // against.
+      const body = await res.text();
+      expect(body).toContain("Reconcile against the conversation");
+      expect(body).not.toContain("chatwootMessageId");
     } finally {
       spy.mockRestore();
       stringData.clear();

--- a/src/controllers/connections/index.spec.ts
+++ b/src/controllers/connections/index.spec.ts
@@ -1,9 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
 import Elysia from "elysia";
 import baileys from "@/baileys";
+import { BaileysSendStalledError } from "@/baileys/connection";
 import coordinator from "@/cluster";
 import { BaileysConnectionOwnedElsewhereError } from "@/cluster/coordinator";
 import config from "@/config";
+import { OperationTimeoutError } from "@/helpers/withTimeout";
+import redis from "@/lib/redis";
 import connectionsController from "./index";
 
 // Elysia merges the controller-level `detail` into each route by mutating a shallow copy, so a
@@ -25,7 +28,10 @@ describe("connectionsController route documentation", () => {
       "/connections/:phoneNumber/messages",
     );
 
-    expect(sendMessage[409]?.description).toBe(
+    // Substring, not equality: the guard is against the cluster-ownership 409
+    // description leaking onto this route, which this still catches — without
+    // breaking every time the idempotency wording is refined.
+    expect(sendMessage[409]?.description).toContain(
       "Message is already being processed",
     );
     expect(sendMessage[500]?.description).toBe("Message not sent");
@@ -132,6 +138,101 @@ describe("connectionsController send-message", () => {
       expect(res.status).toBe(500);
     } finally {
       spy.mockRestore();
+    }
+  });
+
+  // 504 and 503 say different things on purpose: 504 is "this attempt expired,
+  // outcome unknown, a careful retry is fine"; 503 is "this connection is known
+  // not to be sending, stop burning workers on it".
+  it("answers 504 when the send times out", async () => {
+    const spy = spyOn(baileys, "sendMessage").mockImplementation(async () => {
+      throw new OperationTimeoutError("sendMessage", 45_000);
+    });
+
+    try {
+      const app = new Elysia().use(connectionsController);
+      const res = await app.handle(
+        sendMessageRequest("+551234567890", { messageId: "3EB0RESERVED" }),
+      );
+
+      expect(res.status).toBe(504);
+      expect(res.headers.get("retry-after")).toBe("60");
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("answers 503 when the connection is already known to be stalled", async () => {
+    const spy = spyOn(baileys, "sendMessage").mockImplementation(async () => {
+      throw new BaileysSendStalledError();
+    });
+
+    try {
+      const app = new Elysia().use(connectionsController);
+      const res = await app.handle(sendMessageRequest("+551234567890"));
+
+      expect(res.status).toBe(503);
+      expect(res.headers.get("retry-after")).toBe("60");
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  // With a reserved messageId the resend lands on the same WhatsApp key.id, so
+  // WhatsApp dedupes it and releasing the lock is strictly safe.
+  it("releases the idempotency lock on timeout when a messageId was reserved", async () => {
+    const stringData = (redis as any).__stringData as Map<string, string>;
+    stringData.clear();
+    const spy = spyOn(baileys, "sendMessage").mockImplementation(async () => {
+      throw new OperationTimeoutError("sendMessage", 45_000);
+    });
+
+    try {
+      const app = new Elysia().use(connectionsController);
+      await app.handle(
+        sendMessageRequest("+551234567890", {
+          chatwootMessageId: "42",
+          messageId: "3EB0RESERVED",
+        }),
+      );
+
+      const key = "@baileys-api:idempotency:send-message:+551234567890:42";
+      expect(stringData.has(key)).toBe(false);
+    } finally {
+      spy.mockRestore();
+      stringData.clear();
+    }
+  });
+
+  // Without one, a retry would create a SECOND WhatsApp message, so the outcome
+  // is recorded as unknown and the caller is told to reconcile.
+  it("marks the outcome indeterminate on timeout when no messageId was reserved", async () => {
+    const stringData = (redis as any).__stringData as Map<string, string>;
+    stringData.clear();
+    const spy = spyOn(baileys, "sendMessage").mockImplementation(async () => {
+      throw new OperationTimeoutError("sendMessage", 45_000);
+    });
+
+    try {
+      const app = new Elysia().use(connectionsController);
+      await app.handle(
+        sendMessageRequest("+551234567890", { chatwootMessageId: "42" }),
+      );
+
+      const key = "@baileys-api:idempotency:send-message:+551234567890:42";
+      expect(stringData.get(key)).toStartWith("indeterminate:");
+
+      // The follow-up retry gets a 409 that says which kind of conflict it is.
+      const res = await app.handle(
+        sendMessageRequest("+551234567890", { chatwootMessageId: "42" }),
+      );
+      expect(res.status).toBe(409);
+      expect(res.headers.get("x-baileys-idempotency-state")).toBe(
+        "indeterminate",
+      );
+    } finally {
+      spy.mockRestore();
+      stringData.clear();
     }
   });
 });
@@ -336,5 +437,207 @@ describe("connectionsController import-session", () => {
     );
 
     expect(res.status).toBe(422);
+  });
+});
+
+describe("connectionsController restart", () => {
+  let prevEnv: typeof config.env;
+  let prevRole: typeof config.cluster.role;
+  const stringData = (redis as any).__stringData as Map<string, string>;
+
+  beforeEach(() => {
+    prevEnv = config.env;
+    prevRole = config.cluster.role;
+    config.env = "development";
+    config.cluster.role = "standalone";
+    stringData.clear();
+  });
+
+  afterEach(() => {
+    config.env = prevEnv;
+    config.cluster.role = prevRole;
+    stringData.clear();
+  });
+
+  const restartRequest = (phone: string) =>
+    new Request(`http://localhost/connections/${phone}/restart`, {
+      method: "POST",
+    });
+
+  it("answers 202 once the restart is accepted", async () => {
+    const spy = spyOn(coordinator, "restartWithLease").mockResolvedValue(true);
+
+    try {
+      const app = new Elysia().use(connectionsController);
+      const res = await app.handle(restartRequest("+551234567890"));
+
+      expect(res.status).toBe(202);
+      expect(spy).toHaveBeenCalledWith("+551234567890", undefined);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("passes the caller's reason through to the coordinator", async () => {
+    const spy = spyOn(coordinator, "restartWithLease").mockResolvedValue(true);
+
+    try {
+      const app = new Elysia().use(connectionsController);
+      const res = await app.handle(
+        new Request("http://localhost/connections/+551234567890/restart", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ reason: "send stall" }),
+        }),
+      );
+
+      expect(res.status).toBe(202);
+      expect(spy).toHaveBeenCalledWith("+551234567890", "send stall");
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("answers 404 when there is no stored session to restart", async () => {
+    const spy = spyOn(coordinator, "restartWithLease").mockResolvedValue(false);
+
+    try {
+      const app = new Elysia().use(connectionsController);
+      const res = await app.handle(restartRequest("+551234567890"));
+
+      expect(res.status).toBe(404);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("answers 409 with the owner when a live peer owns the phone", async () => {
+    const spy = spyOn(coordinator, "restartWithLease").mockImplementation(
+      async () => {
+        throw new BaileysConnectionOwnedElsewhereError("other-instance");
+      },
+    );
+
+    try {
+      const app = new Elysia().use(connectionsController);
+      const res = await app.handle(restartRequest("+551234567890"));
+
+      expect(res.status).toBe(409);
+      expect(res.headers.get("x-baileys-owner")).toBe("other-instance");
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  // The highest-value test here. Without /restart in the takeover allowlist,
+  // onBeforeHandle answers 421 and sends the caller back to the very instance
+  // whose socket is wedged — the one answer guaranteed not to help. Ownership
+  // must be resolved by the coordinator (409), not by the misdirect check.
+  it("is not answered with 421, even when another live instance holds the lease", async () => {
+    config.cluster.role = "worker";
+    stringData.set(
+      "@baileys-api:cluster:lease:+551234567890",
+      JSON.stringify({ owner: "other-instance", epoch: 7 }),
+    );
+    stringData.set("@baileys-api:cluster:instance:other-instance", "{}");
+
+    const spy = spyOn(coordinator, "restartWithLease").mockImplementation(
+      async () => {
+        throw new BaileysConnectionOwnedElsewhereError("other-instance");
+      },
+    );
+
+    try {
+      const app = new Elysia().use(connectionsController);
+      const res = await app.handle(restartRequest("+551234567890"));
+
+      expect(res.status).not.toBe(421);
+      expect(res.status).toBe(409);
+      expect(spy).toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  // The control: a non-takeover route in the same situation DOES get the 421,
+  // which is what proves the exemption above is scoped and not a blanket hole.
+  it("still answers 421 for a non-takeover route in the same situation", async () => {
+    config.cluster.role = "worker";
+    stringData.set(
+      "@baileys-api:cluster:lease:+551234567890",
+      JSON.stringify({ owner: "other-instance", epoch: 7 }),
+    );
+    stringData.set("@baileys-api:cluster:instance:other-instance", "{}");
+
+    const app = new Elysia().use(connectionsController);
+    const res = await app.handle(
+      new Request("http://localhost/connections/+551234567890/health", {
+        method: "GET",
+      }),
+    );
+
+    expect(res.status).toBe(421);
+  });
+});
+
+describe("connectionsController connection health", () => {
+  let prevEnv: typeof config.env;
+  let prevRole: typeof config.cluster.role;
+
+  beforeEach(() => {
+    prevEnv = config.env;
+    prevRole = config.cluster.role;
+    config.env = "development";
+    config.cluster.role = "standalone";
+  });
+
+  afterEach(() => {
+    config.env = prevEnv;
+    config.cluster.role = prevRole;
+  });
+
+  it("answers 404 for a phone with no live connection", async () => {
+    const app = new Elysia().use(connectionsController);
+    const res = await app.handle(
+      new Request("http://localhost/connections/+551234567890/health", {
+        method: "GET",
+      }),
+    );
+
+    expect(res.status).toBe(404);
+  });
+
+  it("reports the send-side snapshot", async () => {
+    const spy = spyOn(baileys, "sendHealth").mockReturnValue({
+      connected: true,
+      sendState: "stalled",
+      consecutiveSendTimeouts: 3,
+      lastTrafficAgoMs: 1200,
+      lastSendCompletedAgoMs: 214_000,
+      lastOutgoingAckAgoMs: 219_000,
+    });
+
+    try {
+      const app = new Elysia().use(connectionsController);
+      const res = await app.handle(
+        new Request("http://localhost/connections/+551234567890/health", {
+          method: "GET",
+        }),
+      );
+
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({
+        data: {
+          connected: true,
+          sendState: "stalled",
+          consecutiveSendTimeouts: 3,
+          lastTrafficAgoMs: 1200,
+          lastSendCompletedAgoMs: 214_000,
+          lastOutgoingAckAgoMs: 219_000,
+        },
+      });
+    } finally {
+      spy.mockRestore();
+    }
   });
 });

--- a/src/controllers/connections/index.spec.ts
+++ b/src/controllers/connections/index.spec.ts
@@ -162,6 +162,44 @@ describe("connectionsController send-message", () => {
     }
   });
 
+  // delete and edit relay through the same socket.sendMessage, so they take the
+  // same keystore mutex and can fail the same two ways. Answering 500 would
+  // present documented, expected behaviour as an internal error.
+  it.each([
+    ["deleteMessage", "DELETE"],
+    ["editMessage", "PATCH"],
+  ])("maps %s timeouts to 504 like send-message", async (method, verb) => {
+    const spy = spyOn(
+      baileys,
+      method as "deleteMessage" | "editMessage",
+    ).mockImplementation(async () => {
+      throw new OperationTimeoutError(method, 45_000);
+    });
+
+    try {
+      const app = new Elysia().use(connectionsController);
+      const res = await app.handle(
+        new Request("http://localhost/connections/%2B551234567890/messages", {
+          method: verb,
+          headers: {
+            "content-type": "application/json",
+            "x-api-key": "test-api-key",
+          },
+          body: JSON.stringify({
+            jid: "551101234567@s.whatsapp.net",
+            key: { id: "msg-id" },
+            ...(verb === "PATCH" ? { messageContent: { text: "hi" } } : {}),
+          }),
+        }),
+      );
+
+      expect(res.status).toBe(504);
+      expect(res.headers.get("retry-after")).toBe("60");
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
   it("answers 503 when the connection is already known to be stalled", async () => {
     const spy = spyOn(baileys, "sendMessage").mockImplementation(async () => {
       throw new BaileysSendStalledError();

--- a/src/controllers/connections/index.spec.ts
+++ b/src/controllers/connections/index.spec.ts
@@ -402,6 +402,56 @@ describe("connectionsController send-message", () => {
     }
   });
 
+  // The two events race. markIndeterminate is a Redis round trip, and the parked
+  // send can reject inside it -- so the "never sent" verdict can arrive while
+  // there is still no marker to retract. Acting on it inline would leave the
+  // marker that lands a moment later standing for 24h over an outcome that is no
+  // longer unknown, 409ing the operator's resend of a message that never went.
+  it("retracts a marker installed after the never-sent verdict arrived", async () => {
+    const stringData = (redis as any).__stringData as Map<string, string>;
+    stringData.clear();
+    const spy = spyOn(baileys, "sendMessage").mockImplementation(
+      async (
+        _phone: string,
+        args: { onLateDefinitiveFailure?: () => void },
+      ) => {
+        // The verdict beats the marker: it fires while withIdempotency is still
+        // on its way to writing one.
+        args.onLateDefinitiveFailure?.();
+        throw new OperationTimeoutError("sendMessage", 45_000);
+      },
+    );
+
+    try {
+      const app = new Elysia().use(connectionsController);
+      const res = await app.handle(
+        sendMessageRequest("+551234567890", { chatwootMessageId: "42" }),
+      );
+
+      await new Promise((r) => setTimeout(r, 5));
+      const key = "@baileys-api:idempotency:send-message:+551234567890:42";
+      expect(stringData.has(key)).toBe(false);
+
+      // And the answer says a retry is safe, because the send provably did not
+      // happen.
+      expect(res.status).toBe(504);
+      expect(res.headers.get("retry-after")).toBe("60");
+
+      // The resend goes through instead of meeting a 409.
+      spy.mockImplementation(async () => ({
+        key: { id: "3EB0AGAIN" },
+        messageTimestamp: 1,
+      }));
+      const resend = await app.handle(
+        sendMessageRequest("+551234567890", { chatwootMessageId: "42" }),
+      );
+      expect(resend.status).toBe(200);
+    } finally {
+      spy.mockRestore();
+      stringData.clear();
+    }
+  });
+
   // With a reserved messageId the resend lands on the same WhatsApp key.id, so
   // WhatsApp dedupes it and releasing the lock is strictly safe.
   it("releases the idempotency lock on timeout when a messageId was reserved", async () => {

--- a/src/controllers/connections/index.ts
+++ b/src/controllers/connections/index.ts
@@ -4,6 +4,7 @@ import baileys from "@/baileys";
 import {
   BaileysConnectionForbiddenError,
   BaileysNotConnectedError,
+  BaileysSendStalledError,
 } from "@/baileys/connection";
 import {
   InvalidNoiseCandidateError,
@@ -17,6 +18,8 @@ import {
   buildMessageContent,
 } from "@/controllers/connections/helpers";
 import { withIdempotency } from "@/helpers/withIdempotency";
+import { OperationTimeoutError } from "@/helpers/withTimeout";
+import logger from "@/lib/logger";
 import { authMiddleware } from "@/middlewares/auth";
 import {
   anyJid,
@@ -32,6 +35,10 @@ import {
   userJid,
 } from "./types";
 
+// Routes exempt from the 421 misdirect: each resolves ownership itself in the
+// coordinator, which answers 409 when a live peer owns the phone.
+const TAKEOVER_SUFFIXES = ["", "/import-session", "/restart"] as const;
+
 // Responses every route under this controller can return, on top of its own.
 const SHARED_RESPONSES = {
   403: {
@@ -40,7 +47,7 @@ const SHARED_RESPONSES = {
   },
   421: {
     description:
-      "Misdirected Request — in cluster mode, this instance does not own the connection. The owning instance id is in the x-baileys-owner header; a proxy re-routes the request there. Not returned for POST /connections/{phoneNumber} (explicit takeover).",
+      "Misdirected Request — in cluster mode, this instance does not own the connection. The owning instance id is in the x-baileys-owner header; a proxy re-routes the request there. Not returned for the explicit-takeover routes: POST /connections/{phoneNumber}, /import-session and /restart.",
     headers: {
       "x-baileys-owner": {
         description: "Instance id of the connection owner",
@@ -78,14 +85,18 @@ const connectionsController = new Elysia({
     // lease transition the local metadata (apiKeyHash) can lag the new
     // owner's writes, and answering 403 off that stale copy would mask the
     // misdirect the proxy knows how to recover from.
-    // POST /connections/:phone and .../import-session are exempt — both are
-    // explicit takeovers and resolve ownership in the coordinator (409 when the
-    // owner is alive).
+    // POST /connections/:phone, .../import-session and .../restart are exempt —
+    // all three are explicit takeovers and resolve ownership in the coordinator
+    // (409 when the owner is alive). Restart especially must bypass the 421: it
+    // exists for connections whose owner is registered but misbehaving, and
+    // bouncing the caller back to that owner is the one answer guaranteed not
+    // to help.
     const decodedPath = decodeURIComponent(path);
     const isConnectTakeover =
       request.method === "POST" &&
-      (decodedPath === `/connections/${phoneNumber}` ||
-        decodedPath === `/connections/${phoneNumber}/import-session`);
+      TAKEOVER_SUFFIXES.some(
+        (suffix) => decodedPath === `/connections/${phoneNumber}${suffix}`,
+      );
     if (!isConnectTakeover) {
       const owner = await resolveMisdirectedRequest(phoneNumber);
       if (owner) {
@@ -229,6 +240,137 @@ const connectionsController = new Elysia({
       },
     },
   )
+  .post(
+    "/:phoneNumber/restart",
+    async ({ params, body, set }) => {
+      const { phoneNumber } = params;
+      try {
+        const restarted = await coordinator.restartWithLease(
+          phoneNumber,
+          body?.reason,
+        );
+        if (!restarted) {
+          set.status = 404;
+          return {
+            error: "Not Found",
+            message: "No stored session for this phone number",
+          };
+        }
+      } catch (e) {
+        if (e instanceof BaileysConnectionOwnedElsewhereError) {
+          set.status = 409;
+          set.headers["x-baileys-owner"] = e.ownerInstanceId;
+          return {
+            error: "Conflict",
+            message: "Connection is owned by another instance",
+          };
+        }
+        throw e;
+      }
+      set.status = 202;
+    },
+    {
+      params: phoneNumberParams,
+      // Takes no connection options on purpose: the socket is rebuilt from the
+      // stored metadata, so a restart cannot clobber good webhook config.
+      body: t.Optional(
+        t.Object({
+          reason: t.Optional(
+            t.String({
+              maxLength: 200,
+              description: "Free-text note recorded in the restart log line",
+              example: "send stall",
+            }),
+          ),
+        }),
+      ),
+      detail: {
+        summary: "Recreate the socket, keeping the session",
+        description:
+          "Tears down the live socket and spawns a replacement using the stored session, without clearing auth state — no QR, no re-pairing. Recovers a connection that is receiving and passing health checks but whose sends are wedged.",
+        responses: {
+          202: { description: "Restart accepted; reconnecting" },
+          404: { description: "No stored session for this phone number" },
+          409: {
+            description:
+              "Conflict — in cluster mode, the connection is owned by another live instance (id in the x-baileys-owner header).",
+            headers: {
+              "x-baileys-owner": {
+                description: "Instance id of the connection owner",
+                schema: { type: "string" },
+              },
+            },
+          },
+        },
+      },
+    },
+  )
+  .get(
+    "/:phoneNumber/health",
+    ({ params, set }) => {
+      const health = baileys.sendHealth(params.phoneNumber);
+      if (!health) {
+        set.status = 404;
+        return { error: "Not Found", message: "Phone number not connected" };
+      }
+      return { data: health };
+    },
+    {
+      params: phoneNumberParams,
+      detail: {
+        summary: "Send-side health for this connection",
+        description:
+          "Whether this connection is actually able to send, which POST /connections cannot tell you: that path only does a presence update, which does not touch the keystore and therefore passes while sends are wedged. `sendState` is `unknown` when no send has been observed yet — a connection nobody writes to can be stalled and still look perfect, so this never claims health it has not seen.",
+        responses: {
+          200: {
+            description: "Send-side health snapshot",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    data: {
+                      type: "object",
+                      properties: {
+                        connected: { type: "boolean" },
+                        sendState: {
+                          type: "string",
+                          enum: ["unknown", "ok", "degraded", "stalled"],
+                          description:
+                            "'unknown' means no send has been observed on this connection yet",
+                          example: "ok",
+                        },
+                        consecutiveSendTimeouts: { type: "integer" },
+                        lastTrafficAgoMs: {
+                          type: "integer",
+                          nullable: true,
+                          description:
+                            "Age of the last message-level traffic, inbound or outbound. Stays fresh on inbound traffic alone, so it does NOT prove sending works.",
+                        },
+                        lastSendCompletedAgoMs: {
+                          type: "integer",
+                          nullable: true,
+                          description:
+                            "Age of the last send that completed, i.e. the keystore mutex was free",
+                        },
+                        lastOutgoingAckAgoMs: {
+                          type: "integer",
+                          nullable: true,
+                          description:
+                            "Age of the last WhatsApp acknowledgement of one of our messages — the only end-to-end proof that sending works",
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+          404: { description: "Phone number not connected" },
+        },
+      },
+    },
+  )
   .patch(
     "/:phoneNumber/presence",
     async ({ params, body }) => {
@@ -311,24 +453,39 @@ const connectionsController = new Elysia({
 
       let result: Awaited<ReturnType<typeof withIdempotency>>;
       try {
-        result = await withIdempotency(idempotencyKey, async () => {
-          const { messageContent: builtContent, quoted } =
-            buildMessageContent(messageContent);
+        result = await withIdempotency(
+          idempotencyKey,
+          async () => {
+            const { messageContent: builtContent, quoted } =
+              buildMessageContent(messageContent);
 
-          const response = await baileys.sendMessage(phoneNumber, {
-            jid,
-            messageContent: builtContent,
-            quoted,
-            messageId,
-          });
+            const response = await baileys.sendMessage(phoneNumber, {
+              jid,
+              messageContent: builtContent,
+              quoted,
+              messageId,
+            });
 
-          if (!response) return null;
+            if (!response) return null;
 
-          return {
-            key: response.key,
-            messageTimestamp: response.messageTimestamp,
-          };
-        });
+            return {
+              key: response.key,
+              messageTimestamp: response.messageTimestamp,
+            };
+          },
+          {
+            // A timed-out send is not cancelled — it stays parked in the
+            // socket's keystore mutex and may still reach WhatsApp. With a
+            // caller-reserved messageId the resend lands on the same WhatsApp
+            // key.id, so WhatsApp itself dedupes it and releasing the lock is
+            // strictly better: the retry is free and cannot duplicate. Without
+            // one, a retry would create a SECOND WhatsApp message, so the
+            // outcome is recorded as unknown and the caller is told to
+            // reconcile rather than resend blindly.
+            isIndeterminate: (e) =>
+              e instanceof OperationTimeoutError && !messageId,
+          },
+        );
       } catch (e) {
         // The phone has no live socket on this instance (never connected, or
         // dropped mid-request). Surface it as 404 instead of a generic 500 so
@@ -338,13 +495,54 @@ const connectionsController = new Elysia({
         if (e instanceof BaileysNotConnectedError) {
           return new Response("Phone number not connected", { status: 404 });
         }
+        // The send did not complete in time. Distinct from 503 below: this
+        // attempt's outcome is unknown, so a caller may retry it (safely, if it
+        // reserved a messageId), whereas 503 means the connection is known not
+        // to be sending at all and retrying only burns workers.
+        if (e instanceof OperationTimeoutError) {
+          if (!messageId) {
+            // Surfaces which integrations still let Baileys generate the id;
+            // production runs at LOG_LEVEL=warn, so this is the list.
+            logger.warn(
+              "[%s] [send-message] timed out without a reserved messageId — resend is not duplicate-safe",
+              phoneNumber,
+            );
+          }
+          return new Response("Send timed out; outcome unknown", {
+            status: 504,
+            headers: { "retry-after": "60" },
+          });
+        }
+        if (e instanceof BaileysSendStalledError) {
+          return new Response("Connection is not accepting sends", {
+            status: 503,
+            headers: { "retry-after": "60" },
+          });
+        }
         throw e;
       }
 
+      // Both idempotency conflicts answer 409 to preserve the contract callers
+      // already handle; the header is what tells them apart, since a plain-text
+      // body is no basis for that decision.
       if (result.status === "processing") {
         return new Response("Message is already being processed", {
           status: 409,
+          headers: { "x-baileys-idempotency-state": "processing" },
         });
+      }
+
+      if (result.status === "indeterminate") {
+        return new Response(
+          "Previous send timed out; outcome unknown. Reconcile before resending, or resend with a reserved messageId.",
+          {
+            status: 409,
+            headers: {
+              "x-baileys-idempotency-state": "indeterminate",
+              "retry-after": "60",
+            },
+          },
+        );
       }
 
       if (result.status === "failed") {
@@ -387,10 +585,18 @@ const connectionsController = new Elysia({
             description: "Phone number not connected",
           },
           409: {
-            description: "Message is already being processed",
+            description:
+              "Message is already being processed, or a previous send timed out with an unknown outcome. `x-baileys-idempotency-state` tells them apart: `processing` vs `indeterminate`.",
           },
           500: {
             description: "Message not sent",
+          },
+          503: {
+            description:
+              "Connection is not accepting sends (send stall detected)",
+          },
+          504: {
+            description: "Send timed out; outcome unknown",
           },
         },
       },

--- a/src/controllers/connections/index.ts
+++ b/src/controllers/connections/index.ts
@@ -307,15 +307,28 @@ const connectionsController = new Elysia({
     async ({ params, body, set }) => {
       const { phoneNumber } = params;
       try {
-        const restarted = await coordinator.restartWithLease(
+        const outcome = await coordinator.restartWithLease(
           phoneNumber,
           body?.reason,
         );
-        if (!restarted) {
+        if (outcome === "not-found") {
           set.status = 404;
           return {
             error: "Not Found",
             message: "No stored session for this phone number",
+          };
+        }
+        // A newer explicit operation (connect, import, another restart, a
+        // logout) took the lease while this one queued behind the handler's
+        // per-phone lock, so nothing was rebuilt. 409 rather than 404: the
+        // phone usually still has a perfectly good session, and 404 would send
+        // the caller off to re-pair a connection somebody else just rebuilt.
+        if (outcome === "superseded") {
+          set.status = 409;
+          return {
+            error: "Conflict",
+            message:
+              "Another connection operation for this phone number ran first",
           };
         }
       } catch (e) {
@@ -546,12 +559,6 @@ const connectionsController = new Elysia({
             // reconcile rather than resend blindly.
             isIndeterminate: (e) =>
               e instanceof OperationTimeoutError && !messageId,
-            // The other half of the same rule. A reserved id makes the resend
-            // land on the same WhatsApp key, so it cannot duplicate — and it is
-            // exactly the caller that must be able to get past a marker an
-            // earlier id-less attempt left behind, which otherwise stands for a
-            // full day and refuses every attempt to resolve it.
-            overrideIndeterminate: Boolean(messageId),
           },
         );
       } catch (e) {
@@ -605,7 +612,7 @@ const connectionsController = new Elysia({
         // named in the body instead, and it works: a resend carrying a reserved
         // messageId is admitted, because it cannot produce a second message.
         return new Response(
-          "Previous send timed out; outcome unknown. Reconcile before resending, or resend with a reserved messageId.",
+          "Previous send timed out; outcome unknown. Check the conversation on WhatsApp and, if the message is not there, resend it under a new chatwootMessageId.",
           {
             status: 409,
             headers: { "x-baileys-idempotency-state": "indeterminate" },

--- a/src/controllers/connections/index.ts
+++ b/src/controllers/connections/index.ts
@@ -46,8 +46,27 @@ const TAKEOVER_SUFFIXES = ["", "/import-session", "/restart"] as const;
 // and the two mean different things to a caller — 504 is "this attempt's outcome
 // is unknown, you may retry it", 503 is "this connection is known not to be
 // sending, retrying only burns workers".
-function sendPathErrorResponse(error: unknown): Response | null {
+// `retrySafe` is whether a retry of THIS request can be prevented from creating a
+// second WhatsApp message — either because the caller reserved a messageId (WhatsApp
+// dedupes on the key) or because an idempotency key exists, in which case the
+// indeterminate marker answers 409 instead of sending again. With neither, nothing
+// stands between a retry and a duplicate, so the response must not invite one:
+// `retry-after` is an instruction, and a 504 carrying it tells the caller to do the
+// one thing that cannot be undone.
+function sendPathErrorResponse(
+  error: unknown,
+  { retrySafe = true }: { retrySafe?: boolean } = {},
+): Response | null {
   if (error instanceof OperationTimeoutError) {
+    if (!retrySafe) {
+      return new Response(
+        "Send timed out; outcome unknown and this request reserved no id, so a retry may duplicate the message. Reconcile, or resend with a reserved messageId.",
+        {
+          status: 504,
+          headers: { "x-baileys-idempotency-state": "unprotected" },
+        },
+      );
+    }
     return new Response("Send timed out; outcome unknown", {
       status: 504,
       headers: { "retry-after": "60" },
@@ -56,7 +75,14 @@ function sendPathErrorResponse(error: unknown): Response | null {
   if (error instanceof BaileysSendStalledError) {
     return new Response("Connection is not accepting sends", {
       status: 503,
-      headers: { "retry-after": "60" },
+      headers: {
+        "retry-after": "60",
+        // The discriminator, and it has to be a header: an ordinary outage, a
+        // draining proxy and a wedged socket all answer 503, and only this one
+        // means "the connection is up, do not mark it down". A caller that
+        // treats every 503 as a stall skips the reconnect it needed.
+        "x-baileys-send-state": "stalled",
+      },
     });
   }
   return null;
@@ -66,9 +92,13 @@ function sendPathErrorResponse(error: unknown): Response | null {
 // document different things for the same two failures.
 const SEND_PATH_RESPONSES = {
   503: {
-    description: "Connection is not accepting sends (send stall detected)",
+    description:
+      "Connection is not accepting sends (send stall detected). Carries `x-baileys-send-state: stalled`, which is what tells this apart from an ordinary 503 (outage, draining proxy): the connection is up and must NOT be marked down.",
   },
-  504: { description: "Send timed out; outcome unknown" },
+  504: {
+    description:
+      "Send timed out; outcome unknown. Carries `retry-after` only when a retry cannot duplicate the message — i.e. a `messageId` or a `chatwootMessageId` was supplied. Otherwise it carries `x-baileys-idempotency-state: unprotected` and no `retry-after`: nothing would stop a retry from sending a second message.",
+  },
 } as const;
 
 // Responses every route under this controller can return, on top of its own.
@@ -539,7 +569,12 @@ const connectionsController = new Elysia({
             phoneNumber,
           );
         }
-        const sendPathResponse = sendPathErrorResponse(e);
+        // With no key at all, withIdempotency took its no-key path and never
+        // consulted isIndeterminate, so nothing was recorded and nothing will
+        // stop the next attempt from sending a second message.
+        const sendPathResponse = sendPathErrorResponse(e, {
+          retrySafe: Boolean(messageId) || idempotencyKey !== null,
+        });
         if (sendPathResponse) {
           return sendPathResponse;
         }

--- a/src/controllers/connections/index.ts
+++ b/src/controllers/connections/index.ts
@@ -553,6 +553,21 @@ const connectionsController = new Elysia({
       // The value, not a flag, because retracting it later has to prove the
       // marker is still the one this attempt wrote.
       let indeterminateMarker: string | null = null;
+      // Whether the parked send has been proved never to have reached WhatsApp.
+      // Kept as state rather than acted on inline because the two events race:
+      // markIndeterminate is a Redis round trip, and the parked send can reject
+      // inside it. A verdict that arrives first would otherwise find no marker,
+      // return, and leave the marker that lands a moment later standing for 24h
+      // over an outcome that is no longer unknown.
+      let knownNotSent = false;
+      const retractIndeterminate = () => {
+        if (!idempotencyKey || !knownNotSent || indeterminateMarker === null) {
+          return;
+        }
+        const marker = indeterminateMarker;
+        indeterminateMarker = null;
+        void clearIndeterminate(idempotencyKey, marker);
+      };
       let result: Awaited<ReturnType<typeof withIdempotency>>;
       try {
         result = await withIdempotency(
@@ -573,17 +588,14 @@ const connectionsController = new Elysia({
               // and it is what makes an operator's resend of this same message
               // answer 409 for 24h. Retract it: with the send known not to have
               // happened, that resend is exactly the right thing.
+              // Both sides call the same retraction, and it fires on whichever
+              // arrives second. Nothing is retracted while no marker of ours has
+              // landed -- deleting on that evidence would strip another attempt's
+              // marker off an outcome that is still unknown.
               onLateDefinitiveFailure: idempotencyKey
                 ? () => {
-                    // Nothing to retract if no marker of ours ever landed -- and
-                    // deleting on that evidence would strip a retry's own marker
-                    // off an outcome that is still unknown.
-                    if (indeterminateMarker) {
-                      void clearIndeterminate(
-                        idempotencyKey,
-                        indeterminateMarker,
-                      );
-                    }
+                    knownNotSent = true;
+                    retractIndeterminate();
                   }
                 : undefined,
             });
@@ -608,6 +620,7 @@ const connectionsController = new Elysia({
               e instanceof OperationTimeoutError && !messageId,
             onIndeterminate: (marker) => {
               indeterminateMarker = marker;
+              retractIndeterminate();
             },
           },
         );
@@ -639,7 +652,12 @@ const connectionsController = new Elysia({
         // stop the next attempt from sending a second message, and `retry-after`
         // is an instruction to make one.
         const sendPathResponse = sendPathErrorResponse(e, {
-          retrySafe: Boolean(messageId) || indeterminateMarker !== null,
+          // knownNotSent counts as protection in its own right, and is the
+          // strongest of the three: the send provably did not happen, so a retry
+          // cannot duplicate anything. It also covers the case where the verdict
+          // beat the marker and the retraction above already ran.
+          retrySafe:
+            Boolean(messageId) || knownNotSent || indeterminateMarker !== null,
         });
         if (sendPathResponse) {
           return sendPathResponse;

--- a/src/controllers/connections/index.ts
+++ b/src/controllers/connections/index.ts
@@ -546,6 +546,12 @@ const connectionsController = new Elysia({
             // reconcile rather than resend blindly.
             isIndeterminate: (e) =>
               e instanceof OperationTimeoutError && !messageId,
+            // The other half of the same rule. A reserved id makes the resend
+            // land on the same WhatsApp key, so it cannot duplicate — and it is
+            // exactly the caller that must be able to get past a marker an
+            // earlier id-less attempt left behind, which otherwise stands for a
+            // full day and refuses every attempt to resolve it.
+            overrideIndeterminate: Boolean(messageId),
           },
         );
       } catch (e) {
@@ -592,14 +598,17 @@ const connectionsController = new Elysia({
       }
 
       if (result.status === "indeterminate") {
+        // No retry-after: nothing clears this marker on a timer. It outlives the
+        // caller's retries on purpose, so advertising a 60-second wait would
+        // promise a state change that never comes and turn a message needing
+        // reconciliation into a job that retries for a day. The way forward is
+        // named in the body instead, and it works: a resend carrying a reserved
+        // messageId is admitted, because it cannot produce a second message.
         return new Response(
           "Previous send timed out; outcome unknown. Reconcile before resending, or resend with a reserved messageId.",
           {
             status: 409,
-            headers: {
-              "x-baileys-idempotency-state": "indeterminate",
-              "retry-after": "60",
-            },
+            headers: { "x-baileys-idempotency-state": "indeterminate" },
           },
         );
       }

--- a/src/controllers/connections/index.ts
+++ b/src/controllers/connections/index.ts
@@ -629,11 +629,20 @@ const connectionsController = new Elysia({
         // No retry-after: nothing clears this marker on a timer. It outlives the
         // caller's retries on purpose, so advertising a 60-second wait would
         // promise a state change that never comes and turn a message needing
-        // reconciliation into a job that retries for a day. The way forward is
-        // named in the body instead, and it works: a resend carrying a reserved
-        // messageId is admitted, because it cannot produce a second message.
+        // reconciliation into a job that retries for a day.
+        //
+        // And no way forward is named, because there is not one. A marker is only
+        // ever written for a send that reserved NO WhatsApp message id, so the key
+        // that attempt used is unknown here and nothing can deduplicate a resend
+        // against it: not a freshly reserved id, which lands on a different key
+        // and is therefore a second message (which is why the marker refuses one
+        // (see withIdempotency), and not a new chatwootMessageId, which only
+        // sidesteps the marker by asking a different question. The parked send can
+        // still reach WhatsApp, and "it is not in the conversation yet" is no
+        // evidence that it will not. Reconciliation is the answer; reserving an id
+        // on the FIRST send is how a caller avoids ever landing here.
         return new Response(
-          "Previous send timed out; outcome unknown. Check the conversation on WhatsApp and, if the message is not there, resend it under a new chatwootMessageId.",
+          "Previous send timed out and may still be delivered; the outcome is unknown. It reserved no WhatsApp message id, so no resend can be deduplicated against it. Reconcile against the conversation on WhatsApp instead of resending.",
           {
             status: 409,
             headers: { "x-baileys-idempotency-state": "indeterminate" },
@@ -682,7 +691,7 @@ const connectionsController = new Elysia({
           },
           409: {
             description:
-              "Message is already being processed, or a previous send timed out with an unknown outcome. `x-baileys-idempotency-state` tells them apart: `processing` vs `indeterminate`.",
+              "Message is already being processed, or a previous send timed out with an unknown outcome. `x-baileys-idempotency-state` tells them apart: `processing` vs `indeterminate`. `indeterminate` is not resolved by retrying, under any id or under a new `chatwootMessageId`, because the timed-out attempt reserved no WhatsApp message id and may still be delivered.",
           },
           500: {
             description: "Message not sent",

--- a/src/controllers/connections/index.ts
+++ b/src/controllers/connections/index.ts
@@ -547,10 +547,12 @@ const connectionsController = new Elysia({
           ? `@baileys-api:idempotency:send-message:${phoneNumber}:${String(chatwootMessageId)}`
           : null;
 
-      // Whether the indeterminate marker actually reached Redis. Holding an
+      // The indeterminate marker that actually reached Redis, if any. Holding an
       // idempotency key is not the same thing: withIdempotency fails open, so a
       // Redis outage lets the send run with no lock and leaves no marker behind.
-      let indeterminateRecorded = false;
+      // The value, not a flag, because retracting it later has to prove the
+      // marker is still the one this attempt wrote.
+      let indeterminateMarker: string | null = null;
       let result: Awaited<ReturnType<typeof withIdempotency>>;
       try {
         result = await withIdempotency(
@@ -573,7 +575,15 @@ const connectionsController = new Elysia({
               // happened, that resend is exactly the right thing.
               onLateDefinitiveFailure: idempotencyKey
                 ? () => {
-                    void clearIndeterminate(idempotencyKey);
+                    // Nothing to retract if no marker of ours ever landed -- and
+                    // deleting on that evidence would strip a retry's own marker
+                    // off an outcome that is still unknown.
+                    if (indeterminateMarker) {
+                      void clearIndeterminate(
+                        idempotencyKey,
+                        indeterminateMarker,
+                      );
+                    }
                   }
                 : undefined,
             });
@@ -596,8 +606,8 @@ const connectionsController = new Elysia({
             // reconcile rather than resend blindly.
             isIndeterminate: (e) =>
               e instanceof OperationTimeoutError && !messageId,
-            onIndeterminate: (persisted) => {
-              indeterminateRecorded = persisted;
+            onIndeterminate: (marker) => {
+              indeterminateMarker = marker;
             },
           },
         );
@@ -629,7 +639,7 @@ const connectionsController = new Elysia({
         // stop the next attempt from sending a second message, and `retry-after`
         // is an instruction to make one.
         const sendPathResponse = sendPathErrorResponse(e, {
-          retrySafe: Boolean(messageId) || indeterminateRecorded,
+          retrySafe: Boolean(messageId) || indeterminateMarker !== null,
         });
         if (sendPathResponse) {
           return sendPathResponse;

--- a/src/controllers/connections/index.ts
+++ b/src/controllers/connections/index.ts
@@ -39,6 +39,38 @@ import {
 // coordinator, which answers 409 when a live peer owns the phone.
 const TAKEOVER_SUFFIXES = ["", "/import-session", "/restart"] as const;
 
+// Every route that reaches the connection's send path shares these two failures,
+// because all of them take the same keystore transaction: send-message, and the
+// delete and edit endpoints that relay through socket.sendMessage. Answering 500
+// for either would present documented, expected behaviour as an internal error,
+// and the two mean different things to a caller — 504 is "this attempt's outcome
+// is unknown, you may retry it", 503 is "this connection is known not to be
+// sending, retrying only burns workers".
+function sendPathErrorResponse(error: unknown): Response | null {
+  if (error instanceof OperationTimeoutError) {
+    return new Response("Send timed out; outcome unknown", {
+      status: 504,
+      headers: { "retry-after": "60" },
+    });
+  }
+  if (error instanceof BaileysSendStalledError) {
+    return new Response("Connection is not accepting sends", {
+      status: 503,
+      headers: { "retry-after": "60" },
+    });
+  }
+  return null;
+}
+
+// The 503/504 half of a send-path route's OpenAPI responses, so the three cannot
+// document different things for the same two failures.
+const SEND_PATH_RESPONSES = {
+  503: {
+    description: "Connection is not accepting sends (send stall detected)",
+  },
+  504: { description: "Send timed out; outcome unknown" },
+} as const;
+
 // Responses every route under this controller can return, on top of its own.
 const SHARED_RESPONSES = {
   403: {
@@ -499,25 +531,17 @@ const connectionsController = new Elysia({
         // attempt's outcome is unknown, so a caller may retry it (safely, if it
         // reserved a messageId), whereas 503 means the connection is known not
         // to be sending at all and retrying only burns workers.
-        if (e instanceof OperationTimeoutError) {
-          if (!messageId) {
-            // Surfaces which integrations still let Baileys generate the id;
-            // production runs at LOG_LEVEL=warn, so this is the list.
-            logger.warn(
-              "[%s] [send-message] timed out without a reserved messageId — resend is not duplicate-safe",
-              phoneNumber,
-            );
-          }
-          return new Response("Send timed out; outcome unknown", {
-            status: 504,
-            headers: { "retry-after": "60" },
-          });
+        if (e instanceof OperationTimeoutError && !messageId) {
+          // Surfaces which integrations still let Baileys generate the id;
+          // production runs at LOG_LEVEL=warn, so this is the list.
+          logger.warn(
+            "[%s] [send-message] timed out without a reserved messageId — resend is not duplicate-safe",
+            phoneNumber,
+          );
         }
-        if (e instanceof BaileysSendStalledError) {
-          return new Response("Connection is not accepting sends", {
-            status: 503,
-            headers: { "retry-after": "60" },
-          });
+        const sendPathResponse = sendPathErrorResponse(e);
+        if (sendPathResponse) {
+          return sendPathResponse;
         }
         throw e;
       }
@@ -591,13 +615,7 @@ const connectionsController = new Elysia({
           500: {
             description: "Message not sent",
           },
-          503: {
-            description:
-              "Connection is not accepting sends (send stall detected)",
-          },
-          504: {
-            description: "Send timed out; outcome unknown",
-          },
+          ...SEND_PATH_RESPONSES,
         },
       },
     },
@@ -701,7 +719,15 @@ const connectionsController = new Elysia({
     async ({ params, body }) => {
       const { phoneNumber } = params;
 
-      await baileys.deleteMessage(phoneNumber, body);
+      try {
+        await baileys.deleteMessage(phoneNumber, body);
+      } catch (e) {
+        const sendPathResponse = sendPathErrorResponse(e);
+        if (sendPathResponse) {
+          return sendPathResponse;
+        }
+        throw e;
+      }
     },
     {
       params: phoneNumberParams,
@@ -716,6 +742,7 @@ const connectionsController = new Elysia({
           200: {
             description: "Message deleted successfully",
           },
+          ...SEND_PATH_RESPONSES,
         },
       },
     },
@@ -726,11 +753,20 @@ const connectionsController = new Elysia({
       const { phoneNumber } = params;
       const { jid, key, messageContent } = body;
 
-      const response = await baileys.editMessage(phoneNumber, {
-        jid,
-        key,
-        messageContent: buildEditableMessageContent(messageContent),
-      });
+      let response: Awaited<ReturnType<typeof baileys.editMessage>>;
+      try {
+        response = await baileys.editMessage(phoneNumber, {
+          jid,
+          key,
+          messageContent: buildEditableMessageContent(messageContent),
+        });
+      } catch (e) {
+        const sendPathResponse = sendPathErrorResponse(e);
+        if (sendPathResponse) {
+          return sendPathResponse;
+        }
+        throw e;
+      }
 
       if (!response) {
         return new Response("Message not edited", { status: 500 });
@@ -770,6 +806,7 @@ const connectionsController = new Elysia({
           500: {
             description: "Message not edited",
           },
+          ...SEND_PATH_RESPONSES,
         },
       },
     },

--- a/src/controllers/connections/index.ts
+++ b/src/controllers/connections/index.ts
@@ -18,7 +18,7 @@ import {
   buildEditableMessageContent,
   buildMessageContent,
 } from "@/controllers/connections/helpers";
-import { withIdempotency } from "@/helpers/withIdempotency";
+import { clearIndeterminate, withIdempotency } from "@/helpers/withIdempotency";
 import { OperationTimeoutError } from "@/helpers/withTimeout";
 import logger from "@/lib/logger";
 import { authMiddleware } from "@/middlewares/auth";
@@ -547,6 +547,10 @@ const connectionsController = new Elysia({
           ? `@baileys-api:idempotency:send-message:${phoneNumber}:${String(chatwootMessageId)}`
           : null;
 
+      // Whether the indeterminate marker actually reached Redis. Holding an
+      // idempotency key is not the same thing: withIdempotency fails open, so a
+      // Redis outage lets the send run with no lock and leaves no marker behind.
+      let indeterminateRecorded = false;
       let result: Awaited<ReturnType<typeof withIdempotency>>;
       try {
         result = await withIdempotency(
@@ -560,6 +564,18 @@ const connectionsController = new Elysia({
               messageContent: builtContent,
               quoted,
               messageId,
+              // Minutes after this request answered, the parked send can reject
+              // with a mutex-acquire timeout, which proves it never entered the
+              // transaction and so never reached WhatsApp. The 409 we left behind
+              // then says "outcome unknown" about an outcome that is now known,
+              // and it is what makes an operator's resend of this same message
+              // answer 409 for 24h. Retract it: with the send known not to have
+              // happened, that resend is exactly the right thing.
+              onLateDefinitiveFailure: idempotencyKey
+                ? () => {
+                    void clearIndeterminate(idempotencyKey);
+                  }
+                : undefined,
             });
 
             if (!response) return null;
@@ -580,6 +596,9 @@ const connectionsController = new Elysia({
             // reconcile rather than resend blindly.
             isIndeterminate: (e) =>
               e instanceof OperationTimeoutError && !messageId,
+            onIndeterminate: (persisted) => {
+              indeterminateRecorded = persisted;
+            },
           },
         );
       } catch (e) {
@@ -603,11 +622,14 @@ const connectionsController = new Elysia({
             phoneNumber,
           );
         }
-        // With no key at all, withIdempotency took its no-key path and never
-        // consulted isIndeterminate, so nothing was recorded and nothing will
-        // stop the next attempt from sending a second message.
+        // The marker that actually landed, never the key that was supplied. With
+        // no key at all, withIdempotency took its no-key path and never consulted
+        // isIndeterminate; with a key but no Redis it failed open, ran the send
+        // unlocked and could not write the marker either. Both leave nothing to
+        // stop the next attempt from sending a second message, and `retry-after`
+        // is an instruction to make one.
         const sendPathResponse = sendPathErrorResponse(e, {
-          retrySafe: Boolean(messageId) || idempotencyKey !== null,
+          retrySafe: Boolean(messageId) || indeterminateRecorded,
         });
         if (sendPathResponse) {
           return sendPathResponse;

--- a/src/controllers/connections/index.ts
+++ b/src/controllers/connections/index.ts
@@ -6,6 +6,7 @@ import {
   BaileysNotConnectedError,
   BaileysSendStalledError,
 } from "@/baileys/connection";
+import { isTxMutexTimeout } from "@/baileys/helpers/isTxMutexTimeout";
 import {
   InvalidNoiseCandidateError,
   mapSessionToCreds,
@@ -85,6 +86,26 @@ function sendPathErrorResponse(
       },
     });
   }
+  // The same verdict, reached one layer down and with a stronger guarantee. A
+  // waiter that gives up on the keystore mutex never entered the transaction: no
+  // context, no read, no write, no commit, and no node on the wire. So unlike the
+  // 504 above, this outcome is not unknown — the message was NOT sent — and the
+  // retry is safe whether or not an id was reserved, which is why `retrySafe`
+  // does not gate it. Without this branch the wedge the watchdog exists to catch
+  // leaves as a generic 500, which tells a caller nothing and marks the channel
+  // down on the Chatwoot side.
+  if (isTxMutexTimeout(error)) {
+    return new Response(
+      "Connection is not accepting sends (keystore transaction timed out); the message was not sent",
+      {
+        status: 503,
+        headers: {
+          "retry-after": "60",
+          "x-baileys-send-state": "stalled",
+        },
+      },
+    );
+  }
   return null;
 }
 
@@ -93,7 +114,7 @@ function sendPathErrorResponse(
 const SEND_PATH_RESPONSES = {
   503: {
     description:
-      "Connection is not accepting sends (send stall detected). Carries `x-baileys-send-state: stalled`, which is what tells this apart from an ordinary 503 (outage, draining proxy): the connection is up and must NOT be marked down.",
+      "Connection is not accepting sends. Returned when the circuit breaker is open (send stall detected) and when a keystore transaction gives up waiting for its mutex; in the second case the message was definitively not sent. Carries `x-baileys-send-state: stalled`, which is what tells this apart from an ordinary 503 (outage, draining proxy): the connection is up and must NOT be marked down.",
   },
   504: {
     description:

--- a/src/helpers/withIdempotency.spec.ts
+++ b/src/helpers/withIdempotency.spec.ts
@@ -288,4 +288,80 @@ describe("withIdempotency", () => {
       }
     });
   });
+
+  describe("indeterminate outcomes", () => {
+    const KEY = "@baileys-api:idempotency:send-message:+55:1";
+
+    // A timed-out send is not cancelled — it stays parked in the socket's
+    // keystore mutex and may still reach WhatsApp. Deleting the key would let a
+    // retry duplicate the message; keeping "processing" would 409 blindly for
+    // the full TTL. Neither is right, so the state is recorded distinctly.
+    it("marks the key indeterminate instead of releasing it", async () => {
+      const error = new Error("timed out");
+
+      await expect(
+        withIdempotency(
+          KEY,
+          async () => {
+            throw error;
+          },
+          { isIndeterminate: () => true },
+        ),
+      ).rejects.toBe(error);
+
+      expect(stringData.get(KEY)).toStartWith("indeterminate:");
+    });
+
+    it("still releases the key when the failure is conclusive", async () => {
+      const error = new Error("bad request");
+
+      await expect(
+        withIdempotency(
+          KEY,
+          async () => {
+            throw error;
+          },
+          { isIndeterminate: () => false },
+        ),
+      ).rejects.toBe(error);
+
+      expect(stringData.has(KEY)).toBe(false);
+    });
+
+    it("reports indeterminate to a later caller instead of re-running the work", async () => {
+      await withIdempotency(
+        KEY,
+        async () => {
+          throw new Error("timed out");
+        },
+        { isIndeterminate: () => true },
+      ).catch(() => {});
+
+      const fn = mock(async () => ({ id: "msg_1" }));
+      const result = await withIdempotency(KEY, fn);
+
+      expect(result).toEqual({ status: "indeterminate" });
+      expect(fn).not.toHaveBeenCalled();
+    });
+
+    // Deliberately no steal path: a dead holder tells us nothing about whether
+    // its send reached WhatsApp, so the outcome stays unknown.
+    it("never steals an indeterminate marker, even from a dead instance", async () => {
+      stringData.set(KEY, "indeterminate:some-dead-instance#abc");
+
+      const fn = mock(async () => ({ id: "msg_1" }));
+      const result = await withIdempotency(KEY, fn);
+
+      expect(result).toEqual({ status: "indeterminate" });
+      expect(fn).not.toHaveBeenCalled();
+    });
+
+    it("defaults to releasing the lock when no predicate is given", async () => {
+      await withIdempotency(KEY, async () => {
+        throw new Error("boom");
+      }).catch(() => {});
+
+      expect(stringData.has(KEY)).toBe(false);
+    });
+  });
 });

--- a/src/helpers/withIdempotency.spec.ts
+++ b/src/helpers/withIdempotency.spec.ts
@@ -5,6 +5,10 @@ import redis from "@/lib/redis";
 import { withIdempotency } from "./withIdempotency";
 
 const stringData = (redis as any).__stringData as Map<string, string>;
+const expirations = (redis as any).__expirations as Map<
+  string,
+  { type: string; value: number }
+>;
 
 // instanceId resolves to "test-instance" via the mocked config in preload.ts.
 const SELF = "test-instance";
@@ -310,6 +314,28 @@ describe("withIdempotency", () => {
       ).rejects.toBe(error);
 
       expect(stringData.get(KEY)).toStartWith("indeterminate:");
+    });
+
+    // The marker has to outlive both the abandoned operation (nothing cancels it; it
+    // sits in the keystore mutex until that socket dies) and the person reconciling
+    // it. On the cached-result TTL, a send that landed 11 minutes late would find its
+    // marker gone and let a retry duplicate the message — the exact outcome the
+    // marker exists to prevent.
+    it("keeps the indeterminate marker far longer than a cached result", async () => {
+      await expect(
+        withIdempotency(
+          KEY,
+          async () => {
+            throw new Error("timed out");
+          },
+          { isIndeterminate: () => true },
+        ),
+      ).rejects.toThrow();
+
+      expect(expirations.get(KEY)).toEqual({ type: "EX", value: 86_400 });
+
+      await withIdempotency("other-key", async () => ({ ok: true }));
+      expect(expirations.get("other-key")).toEqual({ type: "EX", value: 600 });
     });
 
     it("still releases the key when the failure is conclusive", async () => {

--- a/src/helpers/withIdempotency.spec.ts
+++ b/src/helpers/withIdempotency.spec.ts
@@ -235,24 +235,20 @@ describe("withIdempotency", () => {
 
   describe("with idempotency key, cache write fails after successful send", () => {
     it("releases lock and still returns executed", async () => {
-      const originalSet = redis.set;
-      let callCount = 0;
-      (redis as any).set = mock(async () => {
-        callCount++;
-        if (callCount === 1) return "OK";
+      // The cache write is a compare-and-set EVAL now, and the release that
+      // follows it is another one that has to go through -- so this fails the
+      // first EVAL only, rather than swapping the whole client out.
+      const evalMock = redis.eval as unknown as ReturnType<typeof mock>;
+      evalMock.mockImplementationOnce(async () => {
         throw new Error("Cache write failed");
       });
 
-      try {
-        const fn = mock(async () => ({ id: "msg_1" }));
-        const result = await withIdempotency("test-key", fn);
+      const fn = mock(async () => ({ id: "msg_1" }));
+      const result = await withIdempotency("test-key", fn);
 
-        expect(result).toEqual({ status: "executed", value: { id: "msg_1" } });
-        expect(fn).toHaveBeenCalledTimes(1);
-        expect(stringData.has("test-key")).toBe(false);
-      } finally {
-        (redis as any).set = originalSet;
-      }
+      expect(result).toEqual({ status: "executed", value: { id: "msg_1" } });
+      expect(fn).toHaveBeenCalledTimes(1);
+      expect(stringData.has("test-key")).toBe(false);
     });
   });
 
@@ -352,6 +348,63 @@ describe("withIdempotency", () => {
       // And the caller is told the marker did not land, so it must not answer
       // with a `retry-after` that claims the retry is protected.
       expect(persisted).toBe(false);
+    });
+
+    // The processing marker identifies a PROCESS, not an acquisition: two
+    // requests on the same worker write a byte-identical one. So a request that
+    // failed open holds nothing, yet its marker matches the lock a concurrent
+    // retry legitimately owns -- and comparing against it would let the one that
+    // holds nothing overwrite the one that does. When that retry then releases,
+    // the first request is left with no guard at all and the next caller sends
+    // again.
+    it("cannot overwrite a concurrent lock it never held", async () => {
+      const setMock = redis.set as unknown as ReturnType<typeof mock>;
+      setMock.mockImplementationOnce(async () => {
+        throw new Error("redis down");
+      });
+      let persisted: boolean | undefined;
+
+      await expect(
+        withIdempotency(
+          KEY,
+          async () => {
+            // Redis is back and a retry takes the lock -- with the same marker
+            // this process would write.
+            stringData.set(KEY, `processing:test-instance#${incarnationId}`);
+            throw new Error("timed out");
+          },
+          {
+            isIndeterminate: () => true,
+            onIndeterminate: (ok) => {
+              persisted = ok;
+            },
+          },
+        ),
+      ).rejects.toThrow();
+
+      // The retry's lock is untouched.
+      expect(stringData.get(KEY)).toBe(
+        `processing:test-instance#${incarnationId}`,
+      );
+      expect(persisted).toBe(false);
+    });
+
+    // Same rule on the way out: you may only delete what you hold. A DEL from a
+    // request that failed open drops a successor's live lock, or its result.
+    it("does not release a lock it never held", async () => {
+      const setMock = redis.set as unknown as ReturnType<typeof mock>;
+      setMock.mockImplementationOnce(async () => {
+        throw new Error("redis down");
+      });
+
+      const result = await withIdempotency(KEY, async () => {
+        stringData.set(KEY, JSON.stringify({ ok: true }));
+        // A null return is the "failed, release the lock" path.
+        return null;
+      });
+
+      expect(result).toEqual({ status: "failed" });
+      expect(JSON.parse(stringData.get(KEY) ?? "{}")).toEqual({ ok: true });
     });
 
     // The marker has to outlive both the abandoned operation (nothing cancels it; it

--- a/src/helpers/withIdempotency.spec.ts
+++ b/src/helpers/withIdempotency.spec.ts
@@ -316,6 +316,44 @@ describe("withIdempotency", () => {
       expect(stringData.get(KEY)).toStartWith("indeterminate:");
     });
 
+    // acquireLock fails OPEN, so a request can be running with no lock at all.
+    // By the time it gives up, a retry (or another instance) may have taken the
+    // key and cached a successful result under it. Burying that under an "outcome
+    // unknown" 409s every later caller for 24h about a message that demonstrably
+    // went out -- and, since a late mutex timeout now retracts the marker, opens
+    // the door to a resend that duplicates it.
+    it("does not bury a successor's result when it never held the lock", async () => {
+      const setMock = redis.set as unknown as ReturnType<typeof mock>;
+      // The acquire cannot reach Redis: withIdempotency proceeds unlocked.
+      setMock.mockImplementationOnce(async () => {
+        throw new Error("redis down");
+      });
+      let persisted: boolean | undefined;
+
+      await expect(
+        withIdempotency(
+          KEY,
+          async () => {
+            // Redis comes back and a retry runs the send, succeeds, and caches.
+            stringData.set(KEY, JSON.stringify({ ok: true }));
+            throw new Error("timed out");
+          },
+          {
+            isIndeterminate: () => true,
+            onIndeterminate: (ok) => {
+              persisted = ok;
+            },
+          },
+        ),
+      ).rejects.toThrow();
+
+      // The successor's result stands.
+      expect(JSON.parse(stringData.get(KEY) ?? "{}")).toEqual({ ok: true });
+      // And the caller is told the marker did not land, so it must not answer
+      // with a `retry-after` that claims the retry is protected.
+      expect(persisted).toBe(false);
+    });
+
     // The marker has to outlive both the abandoned operation (nothing cancels it; it
     // sits in the keystore mutex until that socket dies) and the person reconciling
     // it. On the cached-result TTL, a send that landed 11 minutes late would find its

--- a/src/helpers/withIdempotency.spec.ts
+++ b/src/helpers/withIdempotency.spec.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it, mock } from "bun:test";
 import { incarnationId } from "@/cluster/identity";
 import { clusterKeys } from "@/cluster/keys";
 import redis from "@/lib/redis";
-import { withIdempotency } from "./withIdempotency";
+import { clearIndeterminate, withIdempotency } from "./withIdempotency";
 
 const stringData = (redis as any).__stringData as Map<string, string>;
 const expirations = (redis as any).__expirations as Map<
@@ -324,7 +324,7 @@ describe("withIdempotency", () => {
       setMock.mockImplementationOnce(async () => {
         throw new Error("redis down");
       });
-      let persisted: boolean | undefined;
+      let marker: string | null | undefined;
 
       await expect(
         withIdempotency(
@@ -336,8 +336,8 @@ describe("withIdempotency", () => {
           },
           {
             isIndeterminate: () => true,
-            onIndeterminate: (ok) => {
-              persisted = ok;
+            onIndeterminate: (written) => {
+              marker = written;
             },
           },
         ),
@@ -347,7 +347,7 @@ describe("withIdempotency", () => {
       expect(JSON.parse(stringData.get(KEY) ?? "{}")).toEqual({ ok: true });
       // And the caller is told the marker did not land, so it must not answer
       // with a `retry-after` that claims the retry is protected.
-      expect(persisted).toBe(false);
+      expect(marker).toBeNull();
     });
 
     // The processing marker identifies a PROCESS, not an acquisition: two
@@ -362,7 +362,7 @@ describe("withIdempotency", () => {
       setMock.mockImplementationOnce(async () => {
         throw new Error("redis down");
       });
-      let persisted: boolean | undefined;
+      let marker: string | null | undefined;
 
       await expect(
         withIdempotency(
@@ -375,8 +375,8 @@ describe("withIdempotency", () => {
           },
           {
             isIndeterminate: () => true,
-            onIndeterminate: (ok) => {
-              persisted = ok;
+            onIndeterminate: (written) => {
+              marker = written;
             },
           },
         ),
@@ -386,7 +386,7 @@ describe("withIdempotency", () => {
       expect(stringData.get(KEY)).toBe(
         `processing:test-instance#${incarnationId}`,
       );
-      expect(persisted).toBe(false);
+      expect(marker).toBeNull();
     });
 
     // Same rule on the way out: you may only delete what you hold. A DEL from a
@@ -405,6 +405,71 @@ describe("withIdempotency", () => {
 
       expect(result).toEqual({ status: "failed" });
       expect(JSON.parse(stringData.get(KEY) ?? "{}")).toEqual({ ok: true });
+    });
+
+    // The retraction proves the marker is still its own before deleting it. A
+    // prefix check cannot: an attempt that failed open and could not write a
+    // marker at all is still handed a late "never sent" verdict, and on the
+    // prefix it would delete whatever indeterminate marker it found -- including
+    // a later attempt's, whose outcome is still unknown. The next caller then
+    // sends on top of it.
+    it("retracts only the marker its own attempt wrote", async () => {
+      let mine: string | null | undefined;
+      await expect(
+        withIdempotency(
+          KEY,
+          async () => {
+            throw new Error("timed out");
+          },
+          {
+            isIndeterminate: () => true,
+            onIndeterminate: (written) => {
+              mine = written;
+            },
+          },
+        ),
+      ).rejects.toThrow();
+      expect(mine).toStartWith("indeterminate:");
+
+      // A different attempt's marker is under the key by the time the late
+      // verdict for `mine` arrives.
+      const theirs = `${mine}-other`;
+      stringData.set(KEY, theirs);
+
+      expect(await clearIndeterminate(KEY, mine as string)).toBe(false);
+      expect(stringData.get(KEY)).toBe(theirs);
+
+      // And the attempt that does own it still retracts its own.
+      expect(await clearIndeterminate(KEY, theirs)).toBe(true);
+      expect(stringData.has(KEY)).toBe(false);
+    });
+
+    // Two attempts in one process must not write the same marker, or the
+    // comparison above compares nothing.
+    it("gives each attempt a distinguishable marker", async () => {
+      const written: (string | null)[] = [];
+      const record = async () => {
+        await expect(
+          withIdempotency(
+            KEY,
+            async () => {
+              throw new Error("timed out");
+            },
+            {
+              isIndeterminate: () => true,
+              onIndeterminate: (marker) => {
+                written.push(marker);
+              },
+            },
+          ),
+        ).rejects.toThrow();
+        stringData.clear();
+      };
+
+      await record();
+      await record();
+
+      expect(written[0]).not.toBe(written[1]);
     });
 
     // The marker has to outlive both the abandoned operation (nothing cancels it; it

--- a/src/helpers/withIdempotency.ts
+++ b/src/helpers/withIdempotency.ts
@@ -53,6 +53,18 @@ const INDETERMINATE_PREFIX = "indeterminate:";
 const processingValue = () =>
   `${PROCESSING_PREFIX}${instanceId}#${incarnationId}`;
 
+// The indeterminate marker carries a per-ATTEMPT suffix on top of the
+// per-process identity, because two attempts in one process would otherwise
+// write a byte-identical value -- and the late retraction compares against that
+// value to prove the marker is still its own. Unlike the processing marker,
+// nothing parses this one (acquireOrSteal only checks its prefix), so the extra
+// segment costs nothing.
+let attemptCounter = 0;
+const indeterminateValue = () => {
+  attemptCounter += 1;
+  return `${INDETERMINATE_PREFIX}${instanceId}#${incarnationId}#${attemptCounter.toString(36)}`;
+};
+
 // Atomic compare-and-set: only overwrite the orphaned marker if it is still the
 // exact value we observed, so two instances racing to reclaim the same dead
 // lock cannot both win. KEYS[1]=key, ARGV[1]=expected, ARGV[2]=new, ARGV[3]=ttl.
@@ -63,13 +75,15 @@ if redis.call("GET", KEYS[1]) == ARGV[1] then
 end
 return 0`;
 
-// Compare-and-delete, so a late verdict can only drop the marker it is a verdict
-// about. By the time this runs the request is long gone and anything may have
-// written to the key -- a retry that got past a cleared marker and cached its
-// result, most of all. KEYS[1]=key.
+// Compare-and-delete against the EXACT marker this attempt wrote, not merely
+// against the prefix. By the time a late verdict runs the request is long gone
+// and anything may sit under the key: a retry that got past a cleared marker and
+// cached its result, or -- the case a prefix check cannot see -- a retry's OWN
+// indeterminate marker, whose outcome is still unknown. Dropping that one strips
+// the protection off a live attempt and lets a third send go out.
+// KEYS[1]=key, ARGV[1]=the marker written by the attempt now retracting it.
 const CLEAR_INDETERMINATE_SCRIPT = `-- clear-indeterminate
-local raw = redis.call("GET", KEYS[1])
-if raw and string.sub(raw, 1, ${INDETERMINATE_PREFIX.length}) == "${INDETERMINATE_PREFIX}" then
+if redis.call("GET", KEYS[1]) == ARGV[1] then
   redis.call("DEL", KEYS[1])
   return 1
 end
@@ -109,10 +123,14 @@ return 0`;
 // makes an operator's resend of the SAME message answer 409 for 24h. Once the
 // send is known not to have happened, that retry is exactly the right thing and
 // nothing should be blocking it.
-export async function clearIndeterminate(key: string): Promise<boolean> {
+export async function clearIndeterminate(
+  key: string,
+  marker: string,
+): Promise<boolean> {
   try {
     const result = await redis.eval(CLEAR_INDETERMINATE_SCRIPT, {
       keys: [key],
+      arguments: [marker],
     });
     return result === 1;
   } catch (error) {
@@ -136,12 +154,13 @@ export interface IdempotencyOptions {
   // Predicate for "the work threw, but it may still take effect". Returning
   // true records the indeterminate marker instead of releasing the lock.
   isIndeterminate?: (error: unknown) => boolean;
-  // Whether that marker actually reached Redis. Everything in this module fails
-  // open -- acquireLock returns true when it cannot write, and markIndeterminate
-  // only warns -- so holding a key is NOT evidence that a retry is protected. A
-  // caller that answers differently for a protected retry has to know which of
-  // the two it got.
-  onIndeterminate?: (persisted: boolean) => void;
+  // The marker that actually reached Redis, or null if none did. Everything in
+  // this module fails open -- acquireLock returns success when it cannot write,
+  // and markIndeterminate only warns -- so holding a key is NOT evidence that a
+  // retry is protected. The value itself is handed back rather than a boolean
+  // because a later retraction has to prove the marker is still the one this
+  // attempt wrote before deleting it.
+  onIndeterminate?: (marker: string | null) => void;
 }
 
 export async function withIdempotency<T>(
@@ -186,8 +205,8 @@ export async function withIdempotency<T>(
       // reads the same but is not: optional chaining short-circuits the whole
       // call expression when the callback is absent, arguments included, so the
       // marker would never be written for any caller that did not pass one.
-      const persisted = await markIndeterminate(key, held);
-      options.onIndeterminate?.(persisted);
+      const marker = await markIndeterminate(key, held);
+      options.onIndeterminate?.(marker);
     } else {
       await releaseLock(key, held);
     }
@@ -368,13 +387,17 @@ async function stealLock(key: string, expected: string): Promise<boolean> {
   }
 }
 
-async function markIndeterminate(key: string, held: boolean): Promise<boolean> {
+async function markIndeterminate(
+  key: string,
+  held: boolean,
+): Promise<string | null> {
+  const marker = indeterminateValue();
   try {
     const result = await redis.eval(WRITE_IF_OURS_SCRIPT, {
       keys: [key],
       arguments: [
         processingValue(),
-        `${INDETERMINATE_PREFIX}${instanceId}#${incarnationId}`,
+        marker,
         String(INDETERMINATE_TTL),
         held ? "1" : "0",
       ],
@@ -389,9 +412,9 @@ async function markIndeterminate(key: string, held: boolean): Promise<boolean> {
         "[withIdempotency] %s moved on before it could be marked indeterminate",
         key,
       );
-      return false;
+      return null;
     }
-    return true;
+    return marker;
   } catch (error) {
     // Leave the `processing:` marker in place rather than releasing: it 409s
     // the retry for the rest of the TTL, which is the safe direction here —
@@ -403,7 +426,7 @@ async function markIndeterminate(key: string, held: boolean): Promise<boolean> {
       key,
       errorToString(error),
     );
-    return false;
+    return null;
   }
 }
 

--- a/src/helpers/withIdempotency.ts
+++ b/src/helpers/withIdempotency.ts
@@ -5,6 +5,14 @@ import logger from "@/lib/logger";
 import redis from "@/lib/redis";
 
 const IDEMPOTENCY_TTL = 600;
+// An unknown outcome outlives a cached result by design, and by a lot. The 600s above
+// bounds a convenience: how long a repeated request gets the same answer for free. This
+// one bounds a safety record, and it has to outlive both the abandoned operation (which
+// nothing cancels — it sits in the socket's keystore mutex until that socket dies) and
+// the human who has to reconcile it. At 600s a send that finally landed 11 minutes late
+// would find its marker gone and let a retry duplicate the message, which is the one
+// outcome the marker exists to prevent.
+const INDETERMINATE_TTL = 86_400;
 const PROCESSING_PREFIX = "processing:";
 // Marks work that threw in a way that leaves the outcome unknowable — a send
 // that timed out is still parked inside the socket's keystore mutex and may
@@ -261,7 +269,7 @@ async function markIndeterminate(key: string): Promise<void> {
     await redis.set(
       key,
       `${INDETERMINATE_PREFIX}${instanceId}#${incarnationId}`,
-      { EX: IDEMPOTENCY_TTL },
+      { EX: INDETERMINATE_TTL },
     );
   } catch (error) {
     // Leave the `processing:` marker in place rather than releasing: it 409s

--- a/src/helpers/withIdempotency.ts
+++ b/src/helpers/withIdempotency.ts
@@ -63,6 +63,43 @@ if redis.call("GET", KEYS[1]) == ARGV[1] then
 end
 return 0`;
 
+// Compare-and-delete, so a late verdict can only drop the marker it is a verdict
+// about. By the time this runs the request is long gone and anything may have
+// written to the key -- a retry that got past a cleared marker and cached its
+// result, most of all. KEYS[1]=key.
+const CLEAR_INDETERMINATE_SCRIPT = `-- clear-indeterminate
+local raw = redis.call("GET", KEYS[1])
+if raw and string.sub(raw, 1, ${INDETERMINATE_PREFIX.length}) == "${INDETERMINATE_PREFIX}" then
+  redis.call("DEL", KEYS[1])
+  return 1
+end
+return 0`;
+
+// Retracts an "outcome unknown" once the outcome becomes known to be "did not
+// happen". Only one thing proves that: a mutex-acquire timeout, whose waiter
+// never entered the transaction and so cannot have reached WhatsApp. Everything
+// else that arrives late is still ambiguous and must leave the marker standing.
+//
+// Worth doing rather than letting the marker expire, because the marker is what
+// makes an operator's resend of the SAME message answer 409 for 24h. Once the
+// send is known not to have happened, that retry is exactly the right thing and
+// nothing should be blocking it.
+export async function clearIndeterminate(key: string): Promise<boolean> {
+  try {
+    const result = await redis.eval(CLEAR_INDETERMINATE_SCRIPT, {
+      keys: [key],
+    });
+    return result === 1;
+  } catch (error) {
+    logger.warn(
+      "[withIdempotency] failed to clear indeterminate marker %s: %s",
+      key,
+      errorToString(error),
+    );
+    return false;
+  }
+}
+
 export type IdempotencyResult<T> =
   | { status: "executed"; value: T }
   | { status: "cached"; value: T }
@@ -74,6 +111,12 @@ export interface IdempotencyOptions {
   // Predicate for "the work threw, but it may still take effect". Returning
   // true records the indeterminate marker instead of releasing the lock.
   isIndeterminate?: (error: unknown) => boolean;
+  // Whether that marker actually reached Redis. Everything in this module fails
+  // open -- acquireLock returns true when it cannot write, and markIndeterminate
+  // only warns -- so holding a key is NOT evidence that a retry is protected. A
+  // caller that answers differently for a protected retry has to know which of
+  // the two it got.
+  onIndeterminate?: (persisted: boolean) => void;
 }
 
 export async function withIdempotency<T>(
@@ -111,7 +154,12 @@ export async function withIdempotency<T>(
     return { status: "executed", value };
   } catch (error) {
     if (options?.isIndeterminate?.(error)) {
-      await markIndeterminate(key);
+      // Two statements, deliberately. `options.onIndeterminate?.(await mark(...))`
+      // reads the same but is not: optional chaining short-circuits the whole
+      // call expression when the callback is absent, arguments included, so the
+      // marker would never be written for any caller that did not pass one.
+      const persisted = await markIndeterminate(key);
+      options.onIndeterminate?.(persisted);
     } else {
       await releaseLock(key);
     }
@@ -279,13 +327,14 @@ async function stealLock(key: string, expected: string): Promise<boolean> {
   }
 }
 
-async function markIndeterminate(key: string): Promise<void> {
+async function markIndeterminate(key: string): Promise<boolean> {
   try {
     await redis.set(
       key,
       `${INDETERMINATE_PREFIX}${instanceId}#${incarnationId}`,
       { EX: INDETERMINATE_TTL },
     );
+    return true;
   } catch (error) {
     // Leave the `processing:` marker in place rather than releasing: it 409s
     // the retry for the rest of the TTL, which is the safe direction here —
@@ -297,6 +346,7 @@ async function markIndeterminate(key: string): Promise<void> {
       key,
       errorToString(error),
     );
+    return false;
   }
 }
 

--- a/src/helpers/withIdempotency.ts
+++ b/src/helpers/withIdempotency.ts
@@ -82,10 +82,20 @@ return 0`;
 // an "outcome unknown" that then 409s every later caller for 24h -- for a message
 // that demonstrably went out. Write only over our own processing marker, or over
 // nothing. KEYS[1]=key, ARGV=[ourProcessingValue, marker, ttl].
-const MARK_INDETERMINATE_SCRIPT = `-- mark-indeterminate
+const WRITE_IF_OURS_SCRIPT = `-- mark-indeterminate write-if-ours
 local raw = redis.call("GET", KEYS[1])
-if raw == false or raw == ARGV[1] then
+if raw == false or (ARGV[4] == "1" and raw == ARGV[1]) then
   redis.call("SET", KEYS[1], ARGV[2], "EX", ARGV[3])
+  return 1
+end
+return 0`;
+
+// Same rule for the release: you may only delete what you hold. On the fail-open
+// path there is nothing of ours under the key, so a DEL there would drop a
+// successor's live lock -- or its cached result. KEYS[1]=key, ARGV[1]=our marker.
+const RELEASE_IF_OURS_SCRIPT = `-- release-if-ours
+if redis.call("GET", KEYS[1]) == ARGV[1] then
+  redis.call("DEL", KEYS[1])
   return 1
 end
 return 0`;
@@ -154,17 +164,20 @@ export async function withIdempotency<T>(
     return { status: outcome.status };
   }
 
-  // outcome.status === "owned": we hold the lock, run the work.
+  // outcome.status === "owned": run the work. `held` says whether the key is
+  // actually ours; on the fail-open path it is not, and every write below is
+  // conditioned on that.
+  const held = outcome.held;
   try {
     const value = await fn();
 
     if (value === null) {
-      await releaseLock(key);
+      await releaseLock(key, held);
       return { status: "failed" };
     }
 
-    const cached = await cacheResult(key, value);
-    if (!cached) await releaseLock(key);
+    const cached = await cacheResult(key, value, held);
+    if (!cached) await releaseLock(key, held);
 
     return { status: "executed", value };
   } catch (error) {
@@ -173,24 +186,27 @@ export async function withIdempotency<T>(
       // reads the same but is not: optional chaining short-circuits the whole
       // call expression when the callback is absent, arguments included, so the
       // marker would never be written for any caller that did not pass one.
-      const persisted = await markIndeterminate(key);
+      const persisted = await markIndeterminate(key, held);
       options.onIndeterminate?.(persisted);
     } else {
-      await releaseLock(key);
+      await releaseLock(key, held);
     }
     throw error;
   }
 }
 
 type AcquireOutcome<T> =
-  | { status: "owned" }
+  // `held` is false only on the fail-open path: we are running the work, but the
+  // key is not ours and may belong to someone else by the time we finish.
+  | { status: "owned"; held: boolean }
   | { status: "cached"; value: T }
   | { status: "processing" }
   | { status: "indeterminate" };
 
 async function acquireOrSteal<T>(key: string): Promise<AcquireOutcome<T>> {
-  if (await acquireLock(key)) {
-    return { status: "owned" };
+  const first = await acquireLock(key);
+  if (first !== "taken") {
+    return { status: "owned", held: first === "acquired" };
   }
 
   // Someone else holds the key. Inspect it: it is either a finished result we
@@ -208,9 +224,10 @@ async function acquireOrSteal<T>(key: string): Promise<AcquireOutcome<T>> {
 
   if (current === null) {
     // Released in the gap between the failed NX and this read; try once more.
-    return (await acquireLock(key))
-      ? { status: "owned" }
-      : { status: "processing" };
+    const second = await acquireLock(key);
+    return second === "taken"
+      ? { status: "processing" }
+      : { status: "owned", held: second === "acquired" };
   }
 
   // Our own genuine in-flight request (exact match incl. our incarnation).
@@ -268,6 +285,7 @@ async function acquireOrSteal<T>(key: string): Promise<AcquireOutcome<T>> {
 
   // Holder is gone: reclaim the orphaned lock atomically.
   if (await stealLock(key, current)) {
+    // A steal leaves OUR processingValue under the key, so this is held.
     logger.info(
       "[withIdempotency] reclaimed orphaned lock %s from dead holder %s",
       key,
@@ -275,7 +293,7 @@ async function acquireOrSteal<T>(key: string): Promise<AcquireOutcome<T>> {
         ? `${holder.instanceId}#${holder.incarnationId}`
         : holder.instanceId,
     );
-    return { status: "owned" };
+    return { status: "owned", held: true };
   }
   return { status: "processing" };
 }
@@ -310,19 +328,27 @@ function parseHolder(value: string): Holder | null {
   };
 }
 
-async function acquireLock(key: string): Promise<boolean> {
+// Three outcomes, and the third is the one every writer below has to respect.
+// "failed-open" means the work runs with NO lock behind it: the key may be free,
+// or a retry may take it while we run. Every later write has to know which of
+// these it got, because "only ever write over your own marker, or over nothing"
+// is the rule that keeps a request that holds nothing from clobbering the one
+// that does.
+type LockOutcome = "acquired" | "taken" | "failed-open";
+
+async function acquireLock(key: string): Promise<LockOutcome> {
   try {
     const result = await redis.set(key, processingValue(), {
       NX: true,
       EX: IDEMPOTENCY_TTL,
     });
-    return result === "OK";
+    return result === "OK" ? "acquired" : "taken";
   } catch (error) {
     logger.warn(
       "[withIdempotency] lock acquire failed, proceeding without cache: %s",
       errorToString(error),
     );
-    return true;
+    return "failed-open";
   }
 }
 
@@ -342,14 +368,15 @@ async function stealLock(key: string, expected: string): Promise<boolean> {
   }
 }
 
-async function markIndeterminate(key: string): Promise<boolean> {
+async function markIndeterminate(key: string, held: boolean): Promise<boolean> {
   try {
-    const result = await redis.eval(MARK_INDETERMINATE_SCRIPT, {
+    const result = await redis.eval(WRITE_IF_OURS_SCRIPT, {
       keys: [key],
       arguments: [
         processingValue(),
         `${INDETERMINATE_PREFIX}${instanceId}#${incarnationId}`,
         String(INDETERMINATE_TTL),
+        held ? "1" : "0",
       ],
     });
     if (result !== 1) {
@@ -380,18 +407,45 @@ async function markIndeterminate(key: string): Promise<boolean> {
   }
 }
 
-async function releaseLock(key: string): Promise<void> {
+async function releaseLock(key: string, held: boolean): Promise<void> {
+  // Nothing of ours is under the key on the fail-open path, and the marker there
+  // identifies a PROCESS, not an acquisition: a concurrent retry on this same
+  // worker writes a byte-identical one. Deleting on that evidence drops the
+  // retry's live lock, and the request that gave up then has nothing guarding
+  // it.
+  if (!held) {
+    return;
+  }
   try {
-    await redis.del(key);
+    await redis.eval(RELEASE_IF_OURS_SCRIPT, {
+      keys: [key],
+      arguments: [processingValue()],
+    });
   } catch {
     /* fail-open */
   }
 }
 
-async function cacheResult<T>(key: string, value: T): Promise<boolean> {
+async function cacheResult<T>(
+  key: string,
+  value: T,
+  held: boolean,
+): Promise<boolean> {
   try {
-    await redis.set(key, JSON.stringify(value), { EX: IDEMPOTENCY_TTL });
-    return true;
+    const result = await redis.eval(WRITE_IF_OURS_SCRIPT, {
+      keys: [key],
+      arguments: [
+        processingValue(),
+        JSON.stringify(value),
+        String(IDEMPOTENCY_TTL),
+        held ? "1" : "0",
+      ],
+    });
+    // Not an error: a successor holds the key, so its answer stands. Reported as
+    // "not cached" so the caller does not then try to release a lock it never
+    // had -- releaseLock refuses that on its own, and this keeps the two honest
+    // together.
+    return result === 1;
   } catch (error) {
     logger.warn(
       "[withIdempotency] cache write failed: %s",

--- a/src/helpers/withIdempotency.ts
+++ b/src/helpers/withIdempotency.ts
@@ -75,6 +75,21 @@ if raw and string.sub(raw, 1, ${INDETERMINATE_PREFIX.length}) == "${INDETERMINAT
 end
 return 0`;
 
+// Compare-and-set, for the fail-open case. acquireLock returns success when it
+// cannot reach Redis, so this request may hold no lock at all: by the time it
+// gives up, a retry (or another instance) can have taken the key and even cached
+// a successful result under it. An unconditional SET would bury that result under
+// an "outcome unknown" that then 409s every later caller for 24h -- for a message
+// that demonstrably went out. Write only over our own processing marker, or over
+// nothing. KEYS[1]=key, ARGV=[ourProcessingValue, marker, ttl].
+const MARK_INDETERMINATE_SCRIPT = `-- mark-indeterminate
+local raw = redis.call("GET", KEYS[1])
+if raw == false or raw == ARGV[1] then
+  redis.call("SET", KEYS[1], ARGV[2], "EX", ARGV[3])
+  return 1
+end
+return 0`;
+
 // Retracts an "outcome unknown" once the outcome becomes known to be "did not
 // happen". Only one thing proves that: a mutex-acquire timeout, whose waiter
 // never entered the transaction and so cannot have reached WhatsApp. Everything
@@ -329,11 +344,26 @@ async function stealLock(key: string, expected: string): Promise<boolean> {
 
 async function markIndeterminate(key: string): Promise<boolean> {
   try {
-    await redis.set(
-      key,
-      `${INDETERMINATE_PREFIX}${instanceId}#${incarnationId}`,
-      { EX: INDETERMINATE_TTL },
-    );
+    const result = await redis.eval(MARK_INDETERMINATE_SCRIPT, {
+      keys: [key],
+      arguments: [
+        processingValue(),
+        `${INDETERMINATE_PREFIX}${instanceId}#${incarnationId}`,
+        String(INDETERMINATE_TTL),
+      ],
+    });
+    if (result !== 1) {
+      // A successor owns the key now. Reported as not persisted, which is the
+      // conservative reading: a retry may well be safe (if what is sitting there
+      // is a cached result, it gets that result back instead of sending), but we
+      // cannot tell that from a successor's own in-flight marker, and the caller
+      // uses this to decide whether to issue `retry-after`.
+      logger.warn(
+        "[withIdempotency] %s moved on before it could be marked indeterminate",
+        key,
+      );
+      return false;
+    }
     return true;
   } catch (error) {
     // Leave the `processing:` marker in place rather than releasing: it 409s

--- a/src/helpers/withIdempotency.ts
+++ b/src/helpers/withIdempotency.ts
@@ -6,6 +6,13 @@ import redis from "@/lib/redis";
 
 const IDEMPOTENCY_TTL = 600;
 const PROCESSING_PREFIX = "processing:";
+// Marks work that threw in a way that leaves the outcome unknowable — a send
+// that timed out is still parked inside the socket's keystore mutex and may
+// yet reach WhatsApp. Deleting the key would make the request freely
+// retryable and risk a duplicate; leaving the `processing:` marker would 409
+// every retry for the full TTL with no way to tell why. Neither is right, so
+// the state is recorded distinctly and the caller decides what to answer.
+const INDETERMINATE_PREFIX = "indeterminate:";
 
 // The in-flight marker carries the holder's instance id AND a per-process
 // incarnation token ("processing:<instanceId>#<incarnationId>") so a different
@@ -42,11 +49,19 @@ export type IdempotencyResult<T> =
   | { status: "executed"; value: T }
   | { status: "cached"; value: T }
   | { status: "processing" }
+  | { status: "indeterminate" }
   | { status: "failed" };
+
+export interface IdempotencyOptions {
+  // Predicate for "the work threw, but it may still take effect". Returning
+  // true records the indeterminate marker instead of releasing the lock.
+  isIndeterminate?: (error: unknown) => boolean;
+}
 
 export async function withIdempotency<T>(
   key: string | null,
   fn: () => Promise<T | null>,
+  options?: IdempotencyOptions,
 ): Promise<IdempotencyResult<T>> {
   if (!key) {
     const value = await fn();
@@ -59,8 +74,8 @@ export async function withIdempotency<T>(
   if (outcome.status === "cached") {
     return { status: "cached", value: outcome.value };
   }
-  if (outcome.status === "processing") {
-    return { status: "processing" };
+  if (outcome.status === "processing" || outcome.status === "indeterminate") {
+    return { status: outcome.status };
   }
 
   // outcome.status === "owned": we hold the lock, run the work.
@@ -77,7 +92,11 @@ export async function withIdempotency<T>(
 
     return { status: "executed", value };
   } catch (error) {
-    await releaseLock(key);
+    if (options?.isIndeterminate?.(error)) {
+      await markIndeterminate(key);
+    } else {
+      await releaseLock(key);
+    }
     throw error;
   }
 }
@@ -85,7 +104,8 @@ export async function withIdempotency<T>(
 type AcquireOutcome<T> =
   | { status: "owned" }
   | { status: "cached"; value: T }
-  | { status: "processing" };
+  | { status: "processing" }
+  | { status: "indeterminate" };
 
 async function acquireOrSteal<T>(key: string): Promise<AcquireOutcome<T>> {
   if (await acquireLock(key)) {
@@ -115,6 +135,12 @@ async function acquireOrSteal<T>(key: string): Promise<AcquireOutcome<T>> {
   // Our own genuine in-flight request (exact match incl. our incarnation).
   if (current === processingValue()) {
     return { status: "processing" };
+  }
+
+  // An unknown outcome stays unknown: deliberately no steal path here, since a
+  // dead holder tells us nothing about whether its send reached WhatsApp.
+  if (current.startsWith(INDETERMINATE_PREFIX)) {
+    return { status: "indeterminate" };
   }
 
   const holder = parseHolder(current);
@@ -227,6 +253,27 @@ async function stealLock(key: string, expected: string): Promise<boolean> {
       errorToString(error),
     );
     return false;
+  }
+}
+
+async function markIndeterminate(key: string): Promise<void> {
+  try {
+    await redis.set(
+      key,
+      `${INDETERMINATE_PREFIX}${instanceId}#${incarnationId}`,
+      { EX: IDEMPOTENCY_TTL },
+    );
+  } catch (error) {
+    // Leave the `processing:` marker in place rather than releasing: it 409s
+    // the retry for the rest of the TTL, which is the safe direction here —
+    // releasing would let the retry duplicate a message that may already have
+    // gone out. The warn is what tells an operator why the 409 says
+    // "processing" for a request that is no longer running.
+    logger.warn(
+      "[withIdempotency] failed to mark %s indeterminate: %s",
+      key,
+      errorToString(error),
+    );
   }
 }
 

--- a/src/helpers/withIdempotency.ts
+++ b/src/helpers/withIdempotency.ts
@@ -12,6 +12,16 @@ const IDEMPOTENCY_TTL = 600;
 // the human who has to reconcile it. At 600s a send that finally landed 11 minutes late
 // would find its marker gone and let a retry duplicate the message, which is the one
 // outcome the marker exists to prevent.
+//
+// 24h is a bound, not a proof. What actually ends the danger is the socket dying,
+// since a parked send cannot reach WhatsApp once its socket is gone; the longest
+// wedge observed in production was 6h08, and the mutex-acquire timeout shortens
+// the wait further whenever it is enabled. It is NOT bounded with the
+// BAILEYS_TX_ACQUIRE_TIMEOUT_MS=0 kill switch thrown, so a socket wedged past a
+// full day under that setting could see a retry go out beside a send that later
+// lands. The alternative is a marker with no expiry, which trades a documented,
+// bounded risk for unbounded key growth; this is the deliberate side of that
+// trade, and the kill switch carries the caveat.
 const INDETERMINATE_TTL = 86_400;
 const PROCESSING_PREFIX = "processing:";
 // Marks work that threw in a way that leaves the outcome unknowable — a send
@@ -64,13 +74,6 @@ export interface IdempotencyOptions {
   // Predicate for "the work threw, but it may still take effect". Returning
   // true records the indeterminate marker instead of releasing the lock.
   isIndeterminate?: (error: unknown) => boolean;
-  // Proceed even when a previous attempt left an indeterminate marker. Only for
-  // callers whose retry cannot produce a second message — a caller-reserved
-  // WhatsApp id, which the server dedupes on. Without this the marker is a dead
-  // end: it outlives the retries by design, so every later attempt is refused
-  // for as long as it stands, including the one that reserved an id precisely
-  // so it could be safely repeated.
-  overrideIndeterminate?: boolean;
 }
 
 export async function withIdempotency<T>(
@@ -85,7 +88,7 @@ export async function withIdempotency<T>(
       : { status: "failed" };
   }
 
-  const outcome = await acquireOrSteal<T>(key, options?.overrideIndeterminate);
+  const outcome = await acquireOrSteal<T>(key);
   if (outcome.status === "cached") {
     return { status: "cached", value: outcome.value };
   }
@@ -122,10 +125,7 @@ type AcquireOutcome<T> =
   | { status: "processing" }
   | { status: "indeterminate" };
 
-async function acquireOrSteal<T>(
-  key: string,
-  overrideIndeterminate?: boolean,
-): Promise<AcquireOutcome<T>> {
+async function acquireOrSteal<T>(key: string): Promise<AcquireOutcome<T>> {
   if (await acquireLock(key)) {
     return { status: "owned" };
   }
@@ -155,19 +155,15 @@ async function acquireOrSteal<T>(
     return { status: "processing" };
   }
 
-  // An unknown outcome stays unknown for anyone who could duplicate by retrying:
-  // deliberately no steal-on-dead-holder path here, since a dead holder tells us
-  // nothing about whether its send reached WhatsApp. The one caller allowed past
-  // is the one whose retry cannot produce a second message, and for it the marker
-  // is not information worth keeping — it is the thing standing between a stuck
-  // message and the safe resend that clears it.
+  // An unknown outcome stays unknown, for everyone. No steal-on-dead-holder path,
+  // since a dead holder tells us nothing about whether its send reached WhatsApp
+  // — and no caller override either: a marker is only ever written for a send
+  // that had NO reserved id (see isIndeterminate at the send route), so the
+  // WhatsApp key that attempt used is unknown to us. A retry supplying a freshly
+  // reserved id lands on a DIFFERENT key, which is a second message, not a
+  // deduplicated one.
   if (current.startsWith(INDETERMINATE_PREFIX)) {
-    if (!overrideIndeterminate) {
-      return { status: "indeterminate" };
-    }
-    return (await stealLock(key, current))
-      ? { status: "owned" }
-      : { status: "processing" };
+    return { status: "indeterminate" };
   }
 
   const holder = parseHolder(current);

--- a/src/helpers/withIdempotency.ts
+++ b/src/helpers/withIdempotency.ts
@@ -64,6 +64,13 @@ export interface IdempotencyOptions {
   // Predicate for "the work threw, but it may still take effect". Returning
   // true records the indeterminate marker instead of releasing the lock.
   isIndeterminate?: (error: unknown) => boolean;
+  // Proceed even when a previous attempt left an indeterminate marker. Only for
+  // callers whose retry cannot produce a second message — a caller-reserved
+  // WhatsApp id, which the server dedupes on. Without this the marker is a dead
+  // end: it outlives the retries by design, so every later attempt is refused
+  // for as long as it stands, including the one that reserved an id precisely
+  // so it could be safely repeated.
+  overrideIndeterminate?: boolean;
 }
 
 export async function withIdempotency<T>(
@@ -78,7 +85,7 @@ export async function withIdempotency<T>(
       : { status: "failed" };
   }
 
-  const outcome = await acquireOrSteal<T>(key);
+  const outcome = await acquireOrSteal<T>(key, options?.overrideIndeterminate);
   if (outcome.status === "cached") {
     return { status: "cached", value: outcome.value };
   }
@@ -115,7 +122,10 @@ type AcquireOutcome<T> =
   | { status: "processing" }
   | { status: "indeterminate" };
 
-async function acquireOrSteal<T>(key: string): Promise<AcquireOutcome<T>> {
+async function acquireOrSteal<T>(
+  key: string,
+  overrideIndeterminate?: boolean,
+): Promise<AcquireOutcome<T>> {
   if (await acquireLock(key)) {
     return { status: "owned" };
   }
@@ -145,10 +155,19 @@ async function acquireOrSteal<T>(key: string): Promise<AcquireOutcome<T>> {
     return { status: "processing" };
   }
 
-  // An unknown outcome stays unknown: deliberately no steal path here, since a
-  // dead holder tells us nothing about whether its send reached WhatsApp.
+  // An unknown outcome stays unknown for anyone who could duplicate by retrying:
+  // deliberately no steal-on-dead-holder path here, since a dead holder tells us
+  // nothing about whether its send reached WhatsApp. The one caller allowed past
+  // is the one whose retry cannot produce a second message, and for it the marker
+  // is not information worth keeping — it is the thing standing between a stuck
+  // message and the safe resend that clears it.
   if (current.startsWith(INDETERMINATE_PREFIX)) {
-    return { status: "indeterminate" };
+    if (!overrideIndeterminate) {
+      return { status: "indeterminate" };
+    }
+    return (await stealLock(key, current))
+      ? { status: "owned" }
+      : { status: "processing" };
   }
 
   const holder = parseHolder(current);

--- a/src/helpers/withTimeout.spec.ts
+++ b/src/helpers/withTimeout.spec.ts
@@ -54,4 +54,56 @@ describe("withTimeout", () => {
       process.off("unhandledRejection", onUnhandled);
     }
   });
+
+  // Both halves of the late settlement reach the caller, and they are told
+  // apart by the argument: an operation that fails slowly leaves the queue
+  // exactly like one that succeeds slowly, but only the success is evidence a
+  // message went out.
+  it("reports a late settlement, with the error when it failed", async () => {
+    const settled: unknown[] = [];
+    let resolveLate: (value: string) => void = () => {};
+    const late = withTimeout(
+      "send",
+      10,
+      () =>
+        new Promise<string>((resolve) => {
+          resolveLate = resolve;
+        }),
+      (error) => settled.push(error ?? "ok"),
+    );
+    await expect(late).rejects.toBeInstanceOf(OperationTimeoutError);
+    resolveLate("done");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(settled).toEqual(["ok"]);
+
+    const failure = new Error("upload failed");
+    let rejectLate: (error: Error) => void = () => {};
+    const lateFailure = withTimeout(
+      "send",
+      10,
+      () =>
+        new Promise<never>((_, reject) => {
+          rejectLate = reject;
+        }),
+      (error) => settled.push(error ?? "ok"),
+    );
+    await expect(lateFailure).rejects.toBeInstanceOf(OperationTimeoutError);
+    rejectLate(failure);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(settled).toEqual(["ok", failure]);
+  });
+
+  // A settlement BEFORE the deadline is the caller's own return value; firing
+  // the callback for it would report every ordinary send as a late one.
+  it("does not report a settlement that beat the deadline", async () => {
+    const settled: unknown[] = [];
+    await withTimeout(
+      "send",
+      1000,
+      async () => "done",
+      () => settled.push("late"),
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(settled).toEqual([]);
+  });
 });

--- a/src/helpers/withTimeout.spec.ts
+++ b/src/helpers/withTimeout.spec.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "bun:test";
+import { OperationTimeoutError, withTimeout } from "@/helpers/withTimeout";
+
+describe("withTimeout", () => {
+  it("resolves when the work finishes before the deadline", async () => {
+    await expect(withTimeout("op", 1000, async () => "done")).resolves.toBe(
+      "done",
+    );
+  });
+
+  it("propagates a rejection from the work untouched", async () => {
+    const error = new Error("boom");
+    await expect(
+      withTimeout("op", 1000, async () => {
+        throw error;
+      }),
+    ).rejects.toBe(error);
+  });
+
+  it("rejects with OperationTimeoutError when the work never settles", async () => {
+    const promise = withTimeout("send", 10, () => new Promise<never>(() => {}));
+    await expect(promise).rejects.toBeInstanceOf(OperationTimeoutError);
+    await promise.catch((error: OperationTimeoutError) => {
+      expect(error.operation).toBe("send");
+      expect(error.timeoutMs).toBe(10);
+    });
+  });
+
+  // The timed-out operation stays parked in the keystore mutex and may reject
+  // minutes later. Without the internal `.catch`, that lands as an unhandled
+  // rejection long after the request was already answered.
+  it("does not surface a late rejection as an unhandled rejection", async () => {
+    const unhandled: unknown[] = [];
+    const onUnhandled = (reason: unknown) => unhandled.push(reason);
+    process.on("unhandledRejection", onUnhandled);
+
+    try {
+      let rejectLate: (error: Error) => void = () => {};
+      const promise = withTimeout(
+        "send",
+        10,
+        () =>
+          new Promise<never>((_, reject) => {
+            rejectLate = reject;
+          }),
+      );
+
+      await expect(promise).rejects.toBeInstanceOf(OperationTimeoutError);
+      rejectLate(new Error("late failure"));
+      await new Promise((resolve) => setTimeout(resolve, 20));
+
+      expect(unhandled).toEqual([]);
+    } finally {
+      process.off("unhandledRejection", onUnhandled);
+    }
+  });
+});

--- a/src/helpers/withTimeout.ts
+++ b/src/helpers/withTimeout.ts
@@ -20,20 +20,34 @@ export class OperationTimeoutError extends Error {
 // an unhandled rejection long after we already answered the caller; and the
 // timer is always cleared, so a 45s handle does not sit on the event loop for
 // every single send.
+//
+// `onLateResolve` is how a caller learns the abandoned operation eventually
+// succeeded. Without it a circuit breaker built on these timeouts can only ever
+// open: the success that would close it is precisely the one this function has
+// already stopped reporting.
 export function withTimeout<T>(
   operation: string,
   timeoutMs: number,
   fn: () => Promise<T>,
+  onLateResolve?: () => void,
 ): Promise<T> {
+  let timedOut = false;
   const underlying = fn();
-  underlying.catch(() => {});
+  underlying.then(
+    () => {
+      if (timedOut) {
+        onLateResolve?.();
+      }
+    },
+    () => {},
+  );
 
   let timer: ReturnType<typeof setTimeout> | undefined;
   const deadline = new Promise<never>((_, reject) => {
-    timer = setTimeout(
-      () => reject(new OperationTimeoutError(operation, timeoutMs)),
-      timeoutMs,
-    );
+    timer = setTimeout(() => {
+      timedOut = true;
+      reject(new OperationTimeoutError(operation, timeoutMs));
+    }, timeoutMs);
     timer.unref?.();
   });
 

--- a/src/helpers/withTimeout.ts
+++ b/src/helpers/withTimeout.ts
@@ -21,25 +21,36 @@ export class OperationTimeoutError extends Error {
 // timer is always cleared, so a 45s handle does not sit on the event loop for
 // every single send.
 //
-// `onLateResolve` is how a caller learns the abandoned operation eventually
-// succeeded. Without it a circuit breaker built on these timeouts can only ever
-// open: the success that would close it is precisely the one this function has
+// `onLateSettle` is how a caller learns the abandoned operation eventually
+// finished. Without it a circuit breaker built on these timeouts can only ever
+// open: the outcome that would close it is precisely the one this function has
 // already stopped reporting.
+//
+// It fires on rejection too, with the error, and that half is not decoration:
+// an operation that fails slowly (a stalled media upload, say) leaves the queue
+// exactly like one that succeeds slowly. Reporting only successes latches a
+// breaker on a connection where nothing is parked at all. The error is passed
+// through rather than swallowed so the caller can tell an ordinary failure from
+// one that reports the resource is still wedged.
 export function withTimeout<T>(
   operation: string,
   timeoutMs: number,
   fn: () => Promise<T>,
-  onLateResolve?: () => void,
+  onLateSettle?: (error?: unknown) => void,
 ): Promise<T> {
   let timedOut = false;
   const underlying = fn();
   underlying.then(
     () => {
       if (timedOut) {
-        onLateResolve?.();
+        onLateSettle?.();
       }
     },
-    () => {},
+    (error: unknown) => {
+      if (timedOut) {
+        onLateSettle?.(error ?? new Error(`${operation} failed`));
+      }
+    },
   );
 
   let timer: ReturnType<typeof setTimeout> | undefined;

--- a/src/helpers/withTimeout.ts
+++ b/src/helpers/withTimeout.ts
@@ -1,0 +1,45 @@
+export class OperationTimeoutError extends Error {
+  readonly operation: string;
+  readonly timeoutMs: number;
+
+  constructor(operation: string, timeoutMs: number) {
+    super(`${operation} timed out after ${timeoutMs}ms`);
+    this.name = "OperationTimeoutError";
+    this.operation = operation;
+    this.timeoutMs = timeoutMs;
+  }
+}
+
+// Bounds how long we wait on `fn`, NOT how long `fn` runs: there is no
+// cancellation token to hand Baileys, so a timed-out send stays parked inside
+// the socket's keystore mutex and settles (or never does) on its own. Callers
+// must treat a timeout as "outcome unknown", never as "did not happen".
+//
+// Two details that are easy to get wrong and both bite in production:
+// the losing promise is silenced, so its eventual rejection does not surface as
+// an unhandled rejection long after we already answered the caller; and the
+// timer is always cleared, so a 45s handle does not sit on the event loop for
+// every single send.
+export function withTimeout<T>(
+  operation: string,
+  timeoutMs: number,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const underlying = fn();
+  underlying.catch(() => {});
+
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const deadline = new Promise<never>((_, reject) => {
+    timer = setTimeout(
+      () => reject(new OperationTimeoutError(operation, timeoutMs)),
+      timeoutMs,
+    );
+    timer.unref?.();
+  });
+
+  return Promise.race([underlying, deadline]).finally(() => {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  });
+}

--- a/src/helpers/withTimeout.ts
+++ b/src/helpers/withTimeout.ts
@@ -36,14 +36,17 @@ export function withTimeout<T>(
   operation: string,
   timeoutMs: number,
   fn: () => Promise<T>,
-  onLateSettle?: (error?: unknown) => void,
+  onLateSettle?: (error?: unknown, value?: T) => void,
 ): Promise<T> {
   let timedOut = false;
   const underlying = fn();
   underlying.then(
-    () => {
+    (value) => {
       if (timedOut) {
-        onLateSettle?.();
+        // The value comes with it: the caller's success path never ran, so
+        // anything it would have recorded from the result is only available
+        // here. For a send that is the message id WhatsApp actually used.
+        onLateSettle?.(undefined, value);
       }
     },
     (error: unknown) => {

--- a/src/proxy/app.ts
+++ b/src/proxy/app.ts
@@ -50,11 +50,16 @@ const proxyApp = new Elysia()
   })
   // Public: served locally, mirrors the worker surface.
   .use(statusController)
+  // Per-instance, like connectionCount: a proxy holds no sockets, so both are
+  // structurally zero here. Deliberately not a fan-out aggregate — this is what
+  // the container healthcheck hits, and making it depend on every worker being
+  // reachable would fail the proxy for a worker's problem.
   .get("/cluster/health", () => ({
     instanceId,
     role,
     connectionCount: 0,
     draining: false,
+    stalledConnectionCount: 0,
   }))
   // Admin fan-out: a logout-all must reach every worker.
   .group("/admin", (app) =>

--- a/src/proxy/router.spec.ts
+++ b/src/proxy/router.spec.ts
@@ -229,6 +229,34 @@ describe("proxy router", () => {
       expect(response.headers.get("retry-after")).toBe("5");
     });
 
+    // Owner loss is the state /restart was added for, so it is the one state
+    // where 503ing it is self-defeating: the worker it lands on force-acquires
+    // a dead owner's lease immediately, while a 503 leaves the caller waiting
+    // out the lease TTL with no way to act.
+    it.each(["", "/import-session", "/restart"])(
+      "places a POST %s on a live worker when the recorded owner is dead",
+      async (suffix) => {
+        getLease.mockResolvedValue({ owner: "worker-dead", epoch: 1 });
+        getInstance.mockResolvedValue(null);
+        listLiveInstances.mockResolvedValue([
+          instanceInfo("worker-1", { connectionCount: 10 }),
+          instanceInfo("worker-2", { connectionCount: 3 }),
+        ]);
+
+        const response = await forwardByPhone(
+          PHONE,
+          makeRequest(
+            `/connections/${encodeURIComponent(PHONE)}${suffix}`,
+            "POST",
+            "{}",
+          ),
+        );
+
+        expect(response.status).toBe(200);
+        expect(fetchCalls[0].url.startsWith("http://worker-2:3025")).toBe(true);
+      },
+    );
+
     it("re-routes once when the worker answers 421 with the real owner", async () => {
       getLease.mockResolvedValue({ owner: "worker-1", epoch: 1 });
       getInstance.mockImplementation(async (id: string) =>

--- a/src/proxy/router.spec.ts
+++ b/src/proxy/router.spec.ts
@@ -184,6 +184,33 @@ describe("proxy router", () => {
       expect(fetchCalls[0].url.startsWith("http://worker-2:3025")).toBe(true);
     });
 
+    // The worker treats these three POSTs as explicit takeovers, resolving
+    // ownership in the coordinator rather than trusting the proxy's route
+    // table. The proxy has to agree, or a suffix the worker would take over is
+    // unreachable exactly when it is needed: /restart exists for connections
+    // whose owner is gone, and 404ing it in that state defeats the route.
+    it.each(["/import-session", "/restart"])(
+      "places an unowned %s on a live worker instead of 404ing it",
+      async (suffix) => {
+        listLiveInstances.mockResolvedValue([
+          instanceInfo("worker-1", { connectionCount: 10 }),
+          instanceInfo("worker-2", { connectionCount: 3 }),
+        ]);
+
+        const response = await forwardByPhone(
+          PHONE,
+          makeRequest(
+            `/connections/${encodeURIComponent(PHONE)}${suffix}`,
+            "POST",
+            "{}",
+          ),
+        );
+
+        expect(response.status).toBe(200);
+        expect(fetchCalls[0].url.startsWith("http://worker-2:3025")).toBe(true);
+      },
+    );
+
     it("returns 503 with retry-after when the owner stopped heartbeating", async () => {
       // Lease alive, instance gone: crashed owner, failover still pending.
       getLease.mockResolvedValue({ owner: "worker-dead", epoch: 1 });

--- a/src/proxy/router.ts
+++ b/src/proxy/router.ts
@@ -141,7 +141,22 @@ export async function forwardByPhone(
 
   if (resolution.status === "owner-dead") {
     invalidateTarget(phoneNumber);
-    return serviceUnavailable();
+    // A placement POST is the one request that can repair this state, so it is
+    // the one request that must not be refused here: the worker it lands on
+    // force-acquires a dead owner's lease immediately (acquireExplicitLease
+    // skips the live-owner guard once the registry says the owner stopped
+    // heartbeating). A 503 keeps the only route out of owner loss shut until
+    // the lease expires on its own — and /restart joined this list precisely
+    // for owner loss, so it would be refused in the exact state it exists for.
+    if (!isConnectPost) {
+      return serviceUnavailable();
+    }
+    logger.info(
+      "[proxy] owner %s for %s is dead; placing %s on a live worker",
+      resolution.ownerInstanceId,
+      phoneNumber,
+      path,
+    );
   }
 
   let target: RouteTarget | null = null;

--- a/src/proxy/router.ts
+++ b/src/proxy/router.ts
@@ -110,20 +110,32 @@ async function sendToTarget(
   }
 }
 
+// The POSTs a worker treats as explicit takeovers (see TAKEOVER_SUFFIXES in
+// controllers/connections), which is what makes them placements here too: each
+// resolves ownership in the coordinator rather than relying on the proxy's
+// route table, so an unowned phone is something they can act on rather than a
+// 404. /restart especially — it exists for connections whose owner is gone or
+// misbehaving, and 404ing it in exactly that state defeats the route. The two
+// lists have to agree: a suffix the worker will take over but the proxy will
+// not place is unreachable precisely when it is needed.
+const PLACEMENT_SUFFIXES = ["", "/import-session", "/restart"] as const;
+
 // Routes a /connections/:phone request to the owning worker.
-// - No owner: POST /connections/:phone is a new-connection placement (least
-//   loaded worker decides ownership by acquiring the lease itself); anything
-//   else is 404, matching single-instance not-connected behavior.
+// - No owner: a placement POST (see PLACEMENT_SUFFIXES) goes to the least
+//   loaded worker, which decides ownership by acquiring the lease itself;
+//   anything else is 404, matching single-instance not-connected behavior.
 // - 421/409 from the worker means our route was stale (or placement raced):
 //   invalidate, re-resolve via the owner the worker pointed at, re-send ONCE.
 export async function forwardByPhone(
   phoneNumber: string,
   rawRequest: Request,
 ): Promise<Response> {
+  const path = decodeURIComponent(new URL(rawRequest.url).pathname);
   const isConnectPost =
     rawRequest.method === "POST" &&
-    decodeURIComponent(new URL(rawRequest.url).pathname) ===
-      `/connections/${phoneNumber}`;
+    PLACEMENT_SUFFIXES.some(
+      (suffix) => path === `/connections/${phoneNumber}${suffix}`,
+    );
 
   const resolution = await resolvePhoneTarget(phoneNumber);
 

--- a/src/test/preload.ts
+++ b/src/test/preload.ts
@@ -102,6 +102,21 @@ const mockRedis = {
     return stringData.has(key) || hashData.has(key) ? 1 : 0;
   }),
   pExpire: mock(async (_key: string, _ttlMs: number) => 1),
+  // -2 when the key is gone, -1 when it has no expiry, else the duration it was
+  // written with. The fake has no clock, so this is the configured lifetime
+  // rather than a true remaining time; a test that cares pins it per call.
+  pTTL: mock(async (key: string) => {
+    if (!stringData.has(key)) {
+      return -2;
+    }
+    const expiration = expirations.get(key);
+    if (!expiration) {
+      return -1;
+    }
+    return expiration.type === "PX"
+      ? expiration.value
+      : expiration.value * 1000;
+  }),
   ping: mock(async () => "PONG"),
   // Emulates the known Lua scripts (dispatched by distinctive content) so the
   // real redisAuthState/leaseStore code paths behave faithfully in tests.

--- a/src/test/preload.ts
+++ b/src/test/preload.ts
@@ -331,6 +331,7 @@ mock.module("@/config", () => ({
       httpTimeoutMs: 120_000,
       txAcquireTimeoutMs: 300_000,
       txHoldWarnMs: 30_000,
+      audioPreprocessTimeoutMs: 20_000,
       sendTimeoutMs: 45_000,
       sendStallRestartEnabled: false,
       clientVersion: "default",

--- a/src/test/preload.ts
+++ b/src/test/preload.ts
@@ -83,6 +83,10 @@ const mockRedis = {
       stringData.set(key, value);
       if (options?.expiration) {
         expirations.set(key, options.expiration);
+      } else if (options?.EX !== undefined) {
+        // node-redis accepts the TTL either way; recording both is what lets a
+        // spec assert that a marker was written with the lifetime it needs.
+        expirations.set(key, { type: "EX", value: options.EX });
       } else {
         expirations.delete(key);
       }

--- a/src/test/preload.ts
+++ b/src/test/preload.ts
@@ -144,6 +144,22 @@ const mockRedis = {
         return 0;
       }
 
+      // mark-indeterminate (compare-and-set): KEYS=[key],
+      // ARGV=[ourProcessingValue, marker, ttl]. Writes only over our own
+      // processing marker or over nothing, so a successor's cached result
+      // survives.
+      if (script.includes("mark-indeterminate")) {
+        const [key] = keys;
+        const [expected, marker, ttl] = args;
+        const raw = stringData.get(key);
+        if (raw === undefined || raw === expected) {
+          stringData.set(key, marker);
+          expirations.set(key, { type: "EX", value: Number(ttl) });
+          return 1;
+        }
+        return 0;
+      }
+
       // clear-indeterminate (compare-and-delete): KEYS=[key]. Drops the marker
       // only if it is still one, so a late verdict cannot delete a cached result
       // a retry wrote after it. Checked before the generic DEL branch below,

--- a/src/test/preload.ts
+++ b/src/test/preload.ts
@@ -171,15 +171,40 @@ const mockRedis = {
         return 0;
       }
 
-      // clear-indeterminate (compare-and-delete): KEYS=[key]. Drops the marker
-      // only if it is still one, so a late verdict cannot delete a cached result
-      // a retry wrote after it. Checked before the generic DEL branch below,
-      // which would otherwise claim this script.
+      // clear-indeterminate (compare-and-delete): KEYS=[key], ARGV=[marker].
+      // Drops the marker only if it is still the exact one the retracting
+      // attempt wrote, so neither a cached result nor a later attempt's own
+      // marker goes with it. Checked before the generic DEL branch below, which
+      // would otherwise claim this script.
       if (script.includes("clear-indeterminate")) {
-        const raw = stringData.get(keys[0]);
-        if (raw?.startsWith("indeterminate:")) {
+        if (stringData.get(keys[0]) === args[0]) {
           stringData.delete(keys[0]);
           expirations.delete(keys[0]);
+          return 1;
+        }
+        return 0;
+      }
+
+      // send-stall-cas (compare-and-set): KEYS=[key],
+      // ARGV=[expected ("" for absent), value, ttlMs].
+      if (script.includes("send-stall-cas")) {
+        const [key] = keys;
+        const [expected, value, ttl] = args;
+        const raw = stringData.get(key);
+        if ((raw === undefined && expected === "") || raw === expected) {
+          stringData.set(key, value);
+          expirations.set(key, { type: "PX", value: Number(ttl) });
+          return 1;
+        }
+        return 0;
+      }
+
+      // send-stall-cad (compare-and-delete): KEYS=[key], ARGV=[expected].
+      if (script.includes("send-stall-cad")) {
+        const [key] = keys;
+        if (stringData.get(key) === args[0]) {
+          stringData.delete(key);
+          expirations.delete(key);
           return 1;
         }
         return 0;

--- a/src/test/preload.ts
+++ b/src/test/preload.ts
@@ -324,6 +324,11 @@ mock.module("@/config", () => ({
     logLevel: "warn",
     baileys: {
       logLevel: "warn",
+      httpTimeoutMs: 120_000,
+      txAcquireTimeoutMs: 300_000,
+      txHoldWarnMs: 30_000,
+      sendTimeoutMs: 45_000,
+      sendStallRestartEnabled: false,
       clientVersion: "default",
       overrideClientVersion: false,
       ignoreGroupMessages: false,

--- a/src/test/preload.ts
+++ b/src/test/preload.ts
@@ -144,6 +144,20 @@ const mockRedis = {
         return 0;
       }
 
+      // clear-indeterminate (compare-and-delete): KEYS=[key]. Drops the marker
+      // only if it is still one, so a late verdict cannot delete a cached result
+      // a retry wrote after it. Checked before the generic DEL branch below,
+      // which would otherwise claim this script.
+      if (script.includes("clear-indeterminate")) {
+        const raw = stringData.get(keys[0]);
+        if (raw?.startsWith("indeterminate:")) {
+          stringData.delete(keys[0]);
+          expirations.delete(keys[0]);
+          return 1;
+        }
+        return 0;
+      }
+
       // advance-candidate-cas (owner-fenced compare-and-swap on creds):
       // KEYS=[hash, lease], ARGV=[owner, expectedCreds, newCreds, newCursor].
       // Checked before the generic HSET branch because this script also HSETs.

--- a/src/test/preload.ts
+++ b/src/test/preload.ts
@@ -144,17 +144,28 @@ const mockRedis = {
         return 0;
       }
 
-      // mark-indeterminate (compare-and-set): KEYS=[key],
-      // ARGV=[ourProcessingValue, marker, ttl]. Writes only over our own
-      // processing marker or over nothing, so a successor's cached result
-      // survives.
-      if (script.includes("mark-indeterminate")) {
+      // write-if-ours (compare-and-set): KEYS=[key],
+      // ARGV=[ourProcessingValue, value, ttl, heldFlag]. Writes only over our own
+      // processing marker (and only when we actually hold it) or over nothing,
+      // so a successor's lock or cached result survives.
+      if (script.includes("write-if-ours")) {
         const [key] = keys;
-        const [expected, marker, ttl] = args;
+        const [expected, value, ttl, held] = args;
         const raw = stringData.get(key);
-        if (raw === undefined || raw === expected) {
-          stringData.set(key, marker);
+        if (raw === undefined || (held === "1" && raw === expected)) {
+          stringData.set(key, value);
           expirations.set(key, { type: "EX", value: Number(ttl) });
+          return 1;
+        }
+        return 0;
+      }
+
+      // release-if-ours (compare-and-delete): KEYS=[key], ARGV=[ourMarker].
+      if (script.includes("release-if-ours")) {
+        const [key] = keys;
+        if (stringData.get(key) === args[0]) {
+          stringData.delete(key);
+          expirations.delete(key);
           return 1;
         }
         return 0;

--- a/swagger.json
+++ b/swagger.json
@@ -1714,10 +1714,10 @@
             "description": "Message not sent"
           },
           "503": {
-            "description": "Connection is not accepting sends (send stall detected)"
+            "description": "Connection is not accepting sends (send stall detected). Carries `x-baileys-send-state: stalled`, which is what tells this apart from an ordinary 503 (outage, draining proxy): the connection is up and must NOT be marked down."
           },
           "504": {
-            "description": "Send timed out; outcome unknown"
+            "description": "Send timed out; outcome unknown. Carries `retry-after` only when a retry cannot duplicate the message — i.e. a `messageId` or a `chatwootMessageId` was supplied. Otherwise it carries `x-baileys-idempotency-state: unprotected` and no `retry-after`: nothing would stop a retry from sending a second message."
           }
         },
         "requestBody": {
@@ -3602,10 +3602,10 @@
             }
           },
           "503": {
-            "description": "Connection is not accepting sends (send stall detected)"
+            "description": "Connection is not accepting sends (send stall detected). Carries `x-baileys-send-state: stalled`, which is what tells this apart from an ordinary 503 (outage, draining proxy): the connection is up and must NOT be marked down."
           },
           "504": {
-            "description": "Send timed out; outcome unknown"
+            "description": "Send timed out; outcome unknown. Carries `retry-after` only when a retry cannot duplicate the message — i.e. a `messageId` or a `chatwootMessageId` was supplied. Otherwise it carries `x-baileys-idempotency-state: unprotected` and no `retry-after`: nothing would stop a retry from sending a second message."
           }
         },
         "description": "Deletes a message for everyone in the chat. For group messages not sent by you, this requires admin privileges.",
@@ -3823,10 +3823,10 @@
             "description": "Message not edited"
           },
           "503": {
-            "description": "Connection is not accepting sends (send stall detected)"
+            "description": "Connection is not accepting sends (send stall detected). Carries `x-baileys-send-state: stalled`, which is what tells this apart from an ordinary 503 (outage, draining proxy): the connection is up and must NOT be marked down."
           },
           "504": {
-            "description": "Send timed out; outcome unknown"
+            "description": "Send timed out; outcome unknown. Carries `retry-after` only when a retry cannot duplicate the message — i.e. a `messageId` or a `chatwootMessageId` was supplied. Otherwise it carries `x-baileys-idempotency-state: unprotected` and no `retry-after`: nothing would stop a retry from sending a second message."
           }
         },
         "description": "Edits a previously sent message. Only text messages (including captions) can be edited. The message must have been sent by you and must be within the editable time window (approximately 15 minutes).",

--- a/swagger.json
+++ b/swagger.json
@@ -1714,7 +1714,7 @@
             "description": "Message not sent"
           },
           "503": {
-            "description": "Connection is not accepting sends (send stall detected). Carries `x-baileys-send-state: stalled`, which is what tells this apart from an ordinary 503 (outage, draining proxy): the connection is up and must NOT be marked down."
+            "description": "Connection is not accepting sends. Returned when the circuit breaker is open (send stall detected) and when a keystore transaction gives up waiting for its mutex; in the second case the message was definitively not sent. Carries `x-baileys-send-state: stalled`, which is what tells this apart from an ordinary 503 (outage, draining proxy): the connection is up and must NOT be marked down."
           },
           "504": {
             "description": "Send timed out; outcome unknown. Carries `retry-after` only when a retry cannot duplicate the message — i.e. a `messageId` or a `chatwootMessageId` was supplied. Otherwise it carries `x-baileys-idempotency-state: unprotected` and no `retry-after`: nothing would stop a retry from sending a second message."
@@ -3602,7 +3602,7 @@
             }
           },
           "503": {
-            "description": "Connection is not accepting sends (send stall detected). Carries `x-baileys-send-state: stalled`, which is what tells this apart from an ordinary 503 (outage, draining proxy): the connection is up and must NOT be marked down."
+            "description": "Connection is not accepting sends. Returned when the circuit breaker is open (send stall detected) and when a keystore transaction gives up waiting for its mutex; in the second case the message was definitively not sent. Carries `x-baileys-send-state: stalled`, which is what tells this apart from an ordinary 503 (outage, draining proxy): the connection is up and must NOT be marked down."
           },
           "504": {
             "description": "Send timed out; outcome unknown. Carries `retry-after` only when a retry cannot duplicate the message — i.e. a `messageId` or a `chatwootMessageId` was supplied. Otherwise it carries `x-baileys-idempotency-state: unprotected` and no `retry-after`: nothing would stop a retry from sending a second message."
@@ -3823,7 +3823,7 @@
             "description": "Message not edited"
           },
           "503": {
-            "description": "Connection is not accepting sends (send stall detected). Carries `x-baileys-send-state: stalled`, which is what tells this apart from an ordinary 503 (outage, draining proxy): the connection is up and must NOT be marked down."
+            "description": "Connection is not accepting sends. Returned when the circuit breaker is open (send stall detected) and when a keystore transaction gives up waiting for its mutex; in the second case the message was definitively not sent. Carries `x-baileys-send-state: stalled`, which is what tells this apart from an ordinary 503 (outage, draining proxy): the connection is up and must NOT be marked down."
           },
           "504": {
             "description": "Send timed out; outcome unknown. Carries `retry-after` only when a retry cannot duplicate the message — i.e. a `messageId` or a `chatwootMessageId` was supplied. Otherwise it carries `x-baileys-idempotency-state: unprotected` and no `retry-after`: nothing would stop a retry from sending a second message."

--- a/swagger.json
+++ b/swagger.json
@@ -3600,6 +3600,12 @@
                 }
               }
             }
+          },
+          "503": {
+            "description": "Connection is not accepting sends (send stall detected)"
+          },
+          "504": {
+            "description": "Send timed out; outcome unknown"
           }
         },
         "description": "Deletes a message for everyone in the chat. For group messages not sent by you, this requires admin privileges.",
@@ -3815,6 +3821,12 @@
           },
           "500": {
             "description": "Message not edited"
+          },
+          "503": {
+            "description": "Connection is not accepting sends (send stall detected)"
+          },
+          "504": {
+            "description": "Send timed out; outcome unknown"
           }
         },
         "description": "Edits a previously sent message. Only text messages (including captions) can be edited. The message must have been sent by you and must be within the editable time window (approximately 15 minutes).",

--- a/swagger.json
+++ b/swagger.json
@@ -1697,7 +1697,7 @@
             "description": "Phone number not connected"
           },
           "409": {
-            "description": "Message is already being processed, or a previous send timed out with an unknown outcome. `x-baileys-idempotency-state` tells them apart: `processing` vs `indeterminate`."
+            "description": "Message is already being processed, or a previous send timed out with an unknown outcome. `x-baileys-idempotency-state` tells them apart: `processing` vs `indeterminate`. `indeterminate` is not resolved by retrying, under any id or under a new `chatwootMessageId`, because the timed-out attempt reserved no WhatsApp message id and may still be delivered."
           },
           "421": {
             "description": "Misdirected Request — in cluster mode, this instance does not own the connection. The owning instance id is in the x-baileys-owner header; a proxy re-routes the request there. Not returned for the explicit-takeover routes: POST /connections/{phoneNumber}, /import-session and /restart.",

--- a/swagger.json
+++ b/swagger.json
@@ -306,7 +306,7 @@
             }
           },
           "421": {
-            "description": "Misdirected Request — in cluster mode, this instance does not own the connection. The owning instance id is in the x-baileys-owner header; a proxy re-routes the request there. Not returned for POST /connections/{phoneNumber} (explicit takeover).",
+            "description": "Misdirected Request — in cluster mode, this instance does not own the connection. The owning instance id is in the x-baileys-owner header; a proxy re-routes the request there. Not returned for the explicit-takeover routes: POST /connections/{phoneNumber}, /import-session and /restart.",
             "headers": {
               "x-baileys-owner": {
                 "description": "Instance id of the connection owner",
@@ -503,7 +503,7 @@
             "description": "Owned by another live instance (worker role)"
           },
           "421": {
-            "description": "Misdirected Request — in cluster mode, this instance does not own the connection. The owning instance id is in the x-baileys-owner header; a proxy re-routes the request there. Not returned for POST /connections/{phoneNumber} (explicit takeover).",
+            "description": "Misdirected Request — in cluster mode, this instance does not own the connection. The owning instance id is in the x-baileys-owner header; a proxy re-routes the request there. Not returned for the explicit-takeover routes: POST /connections/{phoneNumber}, /import-session and /restart.",
             "headers": {
               "x-baileys-owner": {
                 "description": "Instance id of the connection owner",
@@ -561,7 +561,7 @@
             }
           },
           "421": {
-            "description": "Misdirected Request — in cluster mode, this instance does not own the connection. The owning instance id is in the x-baileys-owner header; a proxy re-routes the request there. Not returned for POST /connections/{phoneNumber} (explicit takeover).",
+            "description": "Misdirected Request — in cluster mode, this instance does not own the connection. The owning instance id is in the x-baileys-owner header; a proxy re-routes the request there. Not returned for the explicit-takeover routes: POST /connections/{phoneNumber}, /import-session and /restart.",
             "headers": {
               "x-baileys-owner": {
                 "description": "Instance id of the connection owner",
@@ -1147,6 +1147,211 @@
         }
       }
     },
+    "/connections/{phoneNumber}/restart": {
+      "post": {
+        "parameters": [
+          {
+            "description": "Phone number for connection. Must have + prefix.",
+            "schema": {
+              "type": "string",
+              "minLength": 6,
+              "maxLength": 16,
+              "pattern": "^\\+\\d{5,15}$",
+              "example": "+551234567890"
+            },
+            "in": "path",
+            "name": "phoneNumber",
+            "required": true
+          }
+        ],
+        "operationId": "postConnectionsByPhoneNumberRestart",
+        "tags": [
+          "Connections"
+        ],
+        "security": [
+          {
+            "xApiKey": []
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Restart accepted; reconnecting"
+          },
+          "403": {
+            "description": "Forbidden — the API key does not own this connection. Returned when a connection is bound to a different API key."
+          },
+          "404": {
+            "description": "No stored session for this phone number"
+          },
+          "409": {
+            "description": "Conflict — in cluster mode, the connection is owned by another live instance (id in the x-baileys-owner header).",
+            "headers": {
+              "x-baileys-owner": {
+                "description": "Instance id of the connection owner",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "421": {
+            "description": "Misdirected Request — in cluster mode, this instance does not own the connection. The owning instance id is in the x-baileys-owner header; a proxy re-routes the request there. Not returned for the explicit-takeover routes: POST /connections/{phoneNumber}, /import-session and /restart.",
+            "headers": {
+              "x-baileys-owner": {
+                "description": "Instance id of the connection owner",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Recreate the socket, keeping the session",
+        "description": "Tears down the live socket and spawns a replacement using the stored session, without clearing auth state — no QR, no re-pairing. Recovers a connection that is receiving and passing health checks but whose sends are wedged.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "reason": {
+                    "maxLength": 200,
+                    "description": "Free-text note recorded in the restart log line",
+                    "example": "send stall",
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "reason": {
+                    "maxLength": 200,
+                    "description": "Free-text note recorded in the restart log line",
+                    "example": "send stall",
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "text/plain": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "reason": {
+                    "maxLength": 200,
+                    "description": "Free-text note recorded in the restart log line",
+                    "example": "send stall",
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/connections/{phoneNumber}/health": {
+      "get": {
+        "parameters": [
+          {
+            "description": "Phone number for connection. Must have + prefix.",
+            "schema": {
+              "type": "string",
+              "minLength": 6,
+              "maxLength": 16,
+              "pattern": "^\\+\\d{5,15}$",
+              "example": "+551234567890"
+            },
+            "in": "path",
+            "name": "phoneNumber",
+            "required": true
+          }
+        ],
+        "operationId": "getConnectionsByPhoneNumberHealth",
+        "tags": [
+          "Connections"
+        ],
+        "security": [
+          {
+            "xApiKey": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Send-side health snapshot",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "connected": {
+                          "type": "boolean"
+                        },
+                        "sendState": {
+                          "type": "string",
+                          "enum": [
+                            "unknown",
+                            "ok",
+                            "degraded",
+                            "stalled"
+                          ],
+                          "description": "'unknown' means no send has been observed on this connection yet",
+                          "example": "ok"
+                        },
+                        "consecutiveSendTimeouts": {
+                          "type": "integer"
+                        },
+                        "lastTrafficAgoMs": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Age of the last message-level traffic, inbound or outbound. Stays fresh on inbound traffic alone, so it does NOT prove sending works."
+                        },
+                        "lastSendCompletedAgoMs": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Age of the last send that completed, i.e. the keystore mutex was free"
+                        },
+                        "lastOutgoingAckAgoMs": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Age of the last WhatsApp acknowledgement of one of our messages — the only end-to-end proof that sending works"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden — the API key does not own this connection. Returned when a connection is bound to a different API key."
+          },
+          "404": {
+            "description": "Phone number not connected"
+          },
+          "421": {
+            "description": "Misdirected Request — in cluster mode, this instance does not own the connection. The owning instance id is in the x-baileys-owner header; a proxy re-routes the request there. Not returned for the explicit-takeover routes: POST /connections/{phoneNumber}, /import-session and /restart.",
+            "headers": {
+              "x-baileys-owner": {
+                "description": "Instance id of the connection owner",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Send-side health for this connection",
+        "description": "Whether this connection is actually able to send, which POST /connections cannot tell you: that path only does a presence update, which does not touch the keystore and therefore passes while sends are wedged. `sendState` is `unknown` when no send has been observed yet — a connection nobody writes to can be stalled and still look perfect, so this never claims health it has not seen."
+      }
+    },
     "/connections/{phoneNumber}/presence": {
       "patch": {
         "parameters": [
@@ -1181,7 +1386,7 @@
             "description": "Forbidden — the API key does not own this connection. Returned when a connection is bound to a different API key."
           },
           "421": {
-            "description": "Misdirected Request — in cluster mode, this instance does not own the connection. The owning instance id is in the x-baileys-owner header; a proxy re-routes the request there. Not returned for POST /connections/{phoneNumber} (explicit takeover).",
+            "description": "Misdirected Request — in cluster mode, this instance does not own the connection. The owning instance id is in the x-baileys-owner header; a proxy re-routes the request there. Not returned for the explicit-takeover routes: POST /connections/{phoneNumber}, /import-session and /restart.",
             "headers": {
               "x-baileys-owner": {
                 "description": "Instance id of the connection owner",
@@ -1323,7 +1528,7 @@
             "description": "Forbidden — the API key does not own this connection. Returned when a connection is bound to a different API key."
           },
           "421": {
-            "description": "Misdirected Request — in cluster mode, this instance does not own the connection. The owning instance id is in the x-baileys-owner header; a proxy re-routes the request there. Not returned for POST /connections/{phoneNumber} (explicit takeover).",
+            "description": "Misdirected Request — in cluster mode, this instance does not own the connection. The owning instance id is in the x-baileys-owner header; a proxy re-routes the request there. Not returned for the explicit-takeover routes: POST /connections/{phoneNumber}, /import-session and /restart.",
             "headers": {
               "x-baileys-owner": {
                 "description": "Instance id of the connection owner",
@@ -1492,10 +1697,10 @@
             "description": "Phone number not connected"
           },
           "409": {
-            "description": "Message is already being processed"
+            "description": "Message is already being processed, or a previous send timed out with an unknown outcome. `x-baileys-idempotency-state` tells them apart: `processing` vs `indeterminate`."
           },
           "421": {
-            "description": "Misdirected Request — in cluster mode, this instance does not own the connection. The owning instance id is in the x-baileys-owner header; a proxy re-routes the request there. Not returned for POST /connections/{phoneNumber} (explicit takeover).",
+            "description": "Misdirected Request — in cluster mode, this instance does not own the connection. The owning instance id is in the x-baileys-owner header; a proxy re-routes the request there. Not returned for the explicit-takeover routes: POST /connections/{phoneNumber}, /import-session and /restart.",
             "headers": {
               "x-baileys-owner": {
                 "description": "Instance id of the connection owner",
@@ -1507,6 +1712,12 @@
           },
           "500": {
             "description": "Message not sent"
+          },
+          "503": {
+            "description": "Connection is not accepting sends (send stall detected)"
+          },
+          "504": {
+            "description": "Send timed out; outcome unknown"
           }
         },
         "requestBody": {
@@ -2681,7 +2892,7 @@
             "description": "Forbidden — the API key does not own this connection. Returned when a connection is bound to a different API key."
           },
           "421": {
-            "description": "Misdirected Request — in cluster mode, this instance does not own the connection. The owning instance id is in the x-baileys-owner header; a proxy re-routes the request there. Not returned for POST /connections/{phoneNumber} (explicit takeover).",
+            "description": "Misdirected Request — in cluster mode, this instance does not own the connection. The owning instance id is in the x-baileys-owner header; a proxy re-routes the request there. Not returned for the explicit-takeover routes: POST /connections/{phoneNumber}, /import-session and /restart.",
             "headers": {
               "x-baileys-owner": {
                 "description": "Instance id of the connection owner",
@@ -2823,7 +3034,7 @@
             "description": "Forbidden — the API key does not own this connection. Returned when a connection is bound to a different API key."
           },
           "421": {
-            "description": "Misdirected Request — in cluster mode, this instance does not own the connection. The owning instance id is in the x-baileys-owner header; a proxy re-routes the request there. Not returned for POST /connections/{phoneNumber} (explicit takeover).",
+            "description": "Misdirected Request — in cluster mode, this instance does not own the connection. The owning instance id is in the x-baileys-owner header; a proxy re-routes the request there. Not returned for the explicit-takeover routes: POST /connections/{phoneNumber}, /import-session and /restart.",
             "headers": {
               "x-baileys-owner": {
                 "description": "Instance id of the connection owner",
@@ -3068,7 +3279,7 @@
             "description": "Forbidden — the API key does not own this connection. Returned when a connection is bound to a different API key."
           },
           "421": {
-            "description": "Misdirected Request — in cluster mode, this instance does not own the connection. The owning instance id is in the x-baileys-owner header; a proxy re-routes the request there. Not returned for POST /connections/{phoneNumber} (explicit takeover).",
+            "description": "Misdirected Request — in cluster mode, this instance does not own the connection. The owning instance id is in the x-baileys-owner header; a proxy re-routes the request there. Not returned for the explicit-takeover routes: POST /connections/{phoneNumber}, /import-session and /restart.",
             "headers": {
               "x-baileys-owner": {
                 "description": "Instance id of the connection owner",
@@ -3237,7 +3448,7 @@
             "description": "Forbidden — the API key does not own this connection. Returned when a connection is bound to a different API key."
           },
           "421": {
-            "description": "Misdirected Request — in cluster mode, this instance does not own the connection. The owning instance id is in the x-baileys-owner header; a proxy re-routes the request there. Not returned for POST /connections/{phoneNumber} (explicit takeover).",
+            "description": "Misdirected Request — in cluster mode, this instance does not own the connection. The owning instance id is in the x-baileys-owner header; a proxy re-routes the request there. Not returned for the explicit-takeover routes: POST /connections/{phoneNumber}, /import-session and /restart.",
             "headers": {
               "x-baileys-owner": {
                 "description": "Instance id of the connection owner",
@@ -3380,7 +3591,7 @@
             "description": "Forbidden — the API key does not own this connection. Returned when a connection is bound to a different API key."
           },
           "421": {
-            "description": "Misdirected Request — in cluster mode, this instance does not own the connection. The owning instance id is in the x-baileys-owner header; a proxy re-routes the request there. Not returned for POST /connections/{phoneNumber} (explicit takeover).",
+            "description": "Misdirected Request — in cluster mode, this instance does not own the connection. The owning instance id is in the x-baileys-owner header; a proxy re-routes the request there. Not returned for the explicit-takeover routes: POST /connections/{phoneNumber}, /import-session and /restart.",
             "headers": {
               "x-baileys-owner": {
                 "description": "Instance id of the connection owner",
@@ -3592,7 +3803,7 @@
             "description": "Forbidden — the API key does not own this connection. Returned when a connection is bound to a different API key."
           },
           "421": {
-            "description": "Misdirected Request — in cluster mode, this instance does not own the connection. The owning instance id is in the x-baileys-owner header; a proxy re-routes the request there. Not returned for POST /connections/{phoneNumber} (explicit takeover).",
+            "description": "Misdirected Request — in cluster mode, this instance does not own the connection. The owning instance id is in the x-baileys-owner header; a proxy re-routes the request there. Not returned for the explicit-takeover routes: POST /connections/{phoneNumber}, /import-session and /restart.",
             "headers": {
               "x-baileys-owner": {
                 "description": "Instance id of the connection owner",
@@ -3901,7 +4112,7 @@
             "description": "Profile picture not found"
           },
           "421": {
-            "description": "Misdirected Request — in cluster mode, this instance does not own the connection. The owning instance id is in the x-baileys-owner header; a proxy re-routes the request there. Not returned for POST /connections/{phoneNumber} (explicit takeover).",
+            "description": "Misdirected Request — in cluster mode, this instance does not own the connection. The owning instance id is in the x-baileys-owner header; a proxy re-routes the request there. Not returned for the explicit-takeover routes: POST /connections/{phoneNumber}, /import-session and /restart.",
             "headers": {
               "x-baileys-owner": {
                 "description": "Instance id of the connection owner",
@@ -3981,7 +4192,7 @@
             "description": "Phone number not connected"
           },
           "421": {
-            "description": "Misdirected Request — in cluster mode, this instance does not own the connection. The owning instance id is in the x-baileys-owner header; a proxy re-routes the request there. Not returned for POST /connections/{phoneNumber} (explicit takeover).",
+            "description": "Misdirected Request — in cluster mode, this instance does not own the connection. The owning instance id is in the x-baileys-owner header; a proxy re-routes the request there. Not returned for the explicit-takeover routes: POST /connections/{phoneNumber}, /import-session and /restart.",
             "headers": {
               "x-baileys-owner": {
                 "description": "Instance id of the connection owner",
@@ -4087,7 +4298,7 @@
             "description": "Phone number not connected"
           },
           "421": {
-            "description": "Misdirected Request — in cluster mode, this instance does not own the connection. The owning instance id is in the x-baileys-owner header; a proxy re-routes the request there. Not returned for POST /connections/{phoneNumber} (explicit takeover).",
+            "description": "Misdirected Request — in cluster mode, this instance does not own the connection. The owning instance id is in the x-baileys-owner header; a proxy re-routes the request there. Not returned for the explicit-takeover routes: POST /connections/{phoneNumber}, /import-session and /restart.",
             "headers": {
               "x-baileys-owner": {
                 "description": "Instance id of the connection owner",
@@ -4161,7 +4372,7 @@
             "description": "Forbidden — the API key does not own this connection. Returned when a connection is bound to a different API key."
           },
           "421": {
-            "description": "Misdirected Request — in cluster mode, this instance does not own the connection. The owning instance id is in the x-baileys-owner header; a proxy re-routes the request there. Not returned for POST /connections/{phoneNumber} (explicit takeover).",
+            "description": "Misdirected Request — in cluster mode, this instance does not own the connection. The owning instance id is in the x-baileys-owner header; a proxy re-routes the request there. Not returned for the explicit-takeover routes: POST /connections/{phoneNumber}, /import-session and /restart.",
             "headers": {
               "x-baileys-owner": {
                 "description": "Instance id of the connection owner",
@@ -4368,7 +4579,7 @@
             "description": "Forbidden — the API key does not own this connection. Returned when a connection is bound to a different API key."
           },
           "421": {
-            "description": "Misdirected Request — in cluster mode, this instance does not own the connection. The owning instance id is in the x-baileys-owner header; a proxy re-routes the request there. Not returned for POST /connections/{phoneNumber} (explicit takeover).",
+            "description": "Misdirected Request — in cluster mode, this instance does not own the connection. The owning instance id is in the x-baileys-owner header; a proxy re-routes the request there. Not returned for the explicit-takeover routes: POST /connections/{phoneNumber}, /import-session and /restart.",
             "headers": {
               "x-baileys-owner": {
                 "description": "Instance id of the connection owner",
@@ -4568,7 +4779,7 @@
             "description": "Forbidden — the API key does not own this connection. Returned when a connection is bound to a different API key."
           },
           "421": {
-            "description": "Misdirected Request — in cluster mode, this instance does not own the connection. The owning instance id is in the x-baileys-owner header; a proxy re-routes the request there. Not returned for POST /connections/{phoneNumber} (explicit takeover).",
+            "description": "Misdirected Request — in cluster mode, this instance does not own the connection. The owning instance id is in the x-baileys-owner header; a proxy re-routes the request there. Not returned for the explicit-takeover routes: POST /connections/{phoneNumber}, /import-session and /restart.",
             "headers": {
               "x-baileys-owner": {
                 "description": "Instance id of the connection owner",
@@ -4615,7 +4826,7 @@
             "description": "Forbidden — the API key does not own this connection. Returned when a connection is bound to a different API key."
           },
           "421": {
-            "description": "Misdirected Request — in cluster mode, this instance does not own the connection. The owning instance id is in the x-baileys-owner header; a proxy re-routes the request there. Not returned for POST /connections/{phoneNumber} (explicit takeover).",
+            "description": "Misdirected Request — in cluster mode, this instance does not own the connection. The owning instance id is in the x-baileys-owner header; a proxy re-routes the request there. Not returned for the explicit-takeover routes: POST /connections/{phoneNumber}, /import-session and /restart.",
             "headers": {
               "x-baileys-owner": {
                 "description": "Instance id of the connection owner",
@@ -4767,7 +4978,7 @@
             "description": "Forbidden — the API key does not own this connection. Returned when a connection is bound to a different API key."
           },
           "421": {
-            "description": "Misdirected Request — in cluster mode, this instance does not own the connection. The owning instance id is in the x-baileys-owner header; a proxy re-routes the request there. Not returned for POST /connections/{phoneNumber} (explicit takeover).",
+            "description": "Misdirected Request — in cluster mode, this instance does not own the connection. The owning instance id is in the x-baileys-owner header; a proxy re-routes the request there. Not returned for the explicit-takeover routes: POST /connections/{phoneNumber}, /import-session and /restart.",
             "headers": {
               "x-baileys-owner": {
                 "description": "Instance id of the connection owner",
@@ -4889,7 +5100,7 @@
             "description": "Forbidden — the API key does not own this connection. Returned when a connection is bound to a different API key."
           },
           "421": {
-            "description": "Misdirected Request — in cluster mode, this instance does not own the connection. The owning instance id is in the x-baileys-owner header; a proxy re-routes the request there. Not returned for POST /connections/{phoneNumber} (explicit takeover).",
+            "description": "Misdirected Request — in cluster mode, this instance does not own the connection. The owning instance id is in the x-baileys-owner header; a proxy re-routes the request there. Not returned for the explicit-takeover routes: POST /connections/{phoneNumber}, /import-session and /restart.",
             "headers": {
               "x-baileys-owner": {
                 "description": "Instance id of the connection owner",
@@ -5005,7 +5216,7 @@
             "description": "Forbidden — the API key does not own this connection. Returned when a connection is bound to a different API key."
           },
           "421": {
-            "description": "Misdirected Request — in cluster mode, this instance does not own the connection. The owning instance id is in the x-baileys-owner header; a proxy re-routes the request there. Not returned for POST /connections/{phoneNumber} (explicit takeover).",
+            "description": "Misdirected Request — in cluster mode, this instance does not own the connection. The owning instance id is in the x-baileys-owner header; a proxy re-routes the request there. Not returned for the explicit-takeover routes: POST /connections/{phoneNumber}, /import-session and /restart.",
             "headers": {
               "x-baileys-owner": {
                 "description": "Instance id of the connection owner",
@@ -5127,7 +5338,7 @@
             "description": "Forbidden — the API key does not own this connection. Returned when a connection is bound to a different API key."
           },
           "421": {
-            "description": "Misdirected Request — in cluster mode, this instance does not own the connection. The owning instance id is in the x-baileys-owner header; a proxy re-routes the request there. Not returned for POST /connections/{phoneNumber} (explicit takeover).",
+            "description": "Misdirected Request — in cluster mode, this instance does not own the connection. The owning instance id is in the x-baileys-owner header; a proxy re-routes the request there. Not returned for the explicit-takeover routes: POST /connections/{phoneNumber}, /import-session and /restart.",
             "headers": {
               "x-baileys-owner": {
                 "description": "Instance id of the connection owner",
@@ -5264,7 +5475,7 @@
             "description": "Forbidden — the API key does not own this connection. Returned when a connection is bound to a different API key."
           },
           "421": {
-            "description": "Misdirected Request — in cluster mode, this instance does not own the connection. The owning instance id is in the x-baileys-owner header; a proxy re-routes the request there. Not returned for POST /connections/{phoneNumber} (explicit takeover).",
+            "description": "Misdirected Request — in cluster mode, this instance does not own the connection. The owning instance id is in the x-baileys-owner header; a proxy re-routes the request there. Not returned for the explicit-takeover routes: POST /connections/{phoneNumber}, /import-session and /restart.",
             "headers": {
               "x-baileys-owner": {
                 "description": "Instance id of the connection owner",
@@ -5372,7 +5583,7 @@
             "description": "Forbidden — the API key does not own this connection. Returned when a connection is bound to a different API key."
           },
           "421": {
-            "description": "Misdirected Request — in cluster mode, this instance does not own the connection. The owning instance id is in the x-baileys-owner header; a proxy re-routes the request there. Not returned for POST /connections/{phoneNumber} (explicit takeover).",
+            "description": "Misdirected Request — in cluster mode, this instance does not own the connection. The owning instance id is in the x-baileys-owner header; a proxy re-routes the request there. Not returned for the explicit-takeover routes: POST /connections/{phoneNumber}, /import-session and /restart.",
             "headers": {
               "x-baileys-owner": {
                 "description": "Instance id of the connection owner",
@@ -5420,7 +5631,7 @@
             "description": "Forbidden — the API key does not own this connection. Returned when a connection is bound to a different API key."
           },
           "421": {
-            "description": "Misdirected Request — in cluster mode, this instance does not own the connection. The owning instance id is in the x-baileys-owner header; a proxy re-routes the request there. Not returned for POST /connections/{phoneNumber} (explicit takeover).",
+            "description": "Misdirected Request — in cluster mode, this instance does not own the connection. The owning instance id is in the x-baileys-owner header; a proxy re-routes the request there. Not returned for the explicit-takeover routes: POST /connections/{phoneNumber}, /import-session and /restart.",
             "headers": {
               "x-baileys-owner": {
                 "description": "Instance id of the connection owner",
@@ -5612,7 +5823,7 @@
             "description": "Forbidden — the API key does not own this connection. Returned when a connection is bound to a different API key."
           },
           "421": {
-            "description": "Misdirected Request — in cluster mode, this instance does not own the connection. The owning instance id is in the x-baileys-owner header; a proxy re-routes the request there. Not returned for POST /connections/{phoneNumber} (explicit takeover).",
+            "description": "Misdirected Request — in cluster mode, this instance does not own the connection. The owning instance id is in the x-baileys-owner header; a proxy re-routes the request there. Not returned for the explicit-takeover routes: POST /connections/{phoneNumber}, /import-session and /restart.",
             "headers": {
               "x-baileys-owner": {
                 "description": "Instance id of the connection owner",
@@ -5681,7 +5892,7 @@
             "description": "Forbidden — the API key does not own this connection. Returned when a connection is bound to a different API key."
           },
           "421": {
-            "description": "Misdirected Request — in cluster mode, this instance does not own the connection. The owning instance id is in the x-baileys-owner header; a proxy re-routes the request there. Not returned for POST /connections/{phoneNumber} (explicit takeover).",
+            "description": "Misdirected Request — in cluster mode, this instance does not own the connection. The owning instance id is in the x-baileys-owner header; a proxy re-routes the request there. Not returned for the explicit-takeover routes: POST /connections/{phoneNumber}, /import-session and /restart.",
             "headers": {
               "x-baileys-owner": {
                 "description": "Instance id of the connection owner",
@@ -5797,7 +6008,7 @@
             "description": "Forbidden — the API key does not own this connection. Returned when a connection is bound to a different API key."
           },
           "421": {
-            "description": "Misdirected Request — in cluster mode, this instance does not own the connection. The owning instance id is in the x-baileys-owner header; a proxy re-routes the request there. Not returned for POST /connections/{phoneNumber} (explicit takeover).",
+            "description": "Misdirected Request — in cluster mode, this instance does not own the connection. The owning instance id is in the x-baileys-owner header; a proxy re-routes the request there. Not returned for the explicit-takeover routes: POST /connections/{phoneNumber}, /import-session and /restart.",
             "headers": {
               "x-baileys-owner": {
                 "description": "Instance id of the connection owner",
@@ -5912,7 +6123,7 @@
             "description": "Forbidden — the API key does not own this connection. Returned when a connection is bound to a different API key."
           },
           "421": {
-            "description": "Misdirected Request — in cluster mode, this instance does not own the connection. The owning instance id is in the x-baileys-owner header; a proxy re-routes the request there. Not returned for POST /connections/{phoneNumber} (explicit takeover).",
+            "description": "Misdirected Request — in cluster mode, this instance does not own the connection. The owning instance id is in the x-baileys-owner header; a proxy re-routes the request there. Not returned for the explicit-takeover routes: POST /connections/{phoneNumber}, /import-session and /restart.",
             "headers": {
               "x-baileys-owner": {
                 "description": "Instance id of the connection owner",
@@ -6028,7 +6239,7 @@
             "description": "Forbidden — the API key does not own this connection. Returned when a connection is bound to a different API key."
           },
           "421": {
-            "description": "Misdirected Request — in cluster mode, this instance does not own the connection. The owning instance id is in the x-baileys-owner header; a proxy re-routes the request there. Not returned for POST /connections/{phoneNumber} (explicit takeover).",
+            "description": "Misdirected Request — in cluster mode, this instance does not own the connection. The owning instance id is in the x-baileys-owner header; a proxy re-routes the request there. Not returned for the explicit-takeover routes: POST /connections/{phoneNumber}, /import-session and /restart.",
             "headers": {
               "x-baileys-owner": {
                 "description": "Instance id of the connection owner",
@@ -6220,7 +6431,7 @@
             "description": "Forbidden — the API key does not own this connection. Returned when a connection is bound to a different API key."
           },
           "421": {
-            "description": "Misdirected Request — in cluster mode, this instance does not own the connection. The owning instance id is in the x-baileys-owner header; a proxy re-routes the request there. Not returned for POST /connections/{phoneNumber} (explicit takeover).",
+            "description": "Misdirected Request — in cluster mode, this instance does not own the connection. The owning instance id is in the x-baileys-owner header; a proxy re-routes the request there. Not returned for the explicit-takeover routes: POST /connections/{phoneNumber}, /import-session and /restart.",
             "headers": {
               "x-baileys-owner": {
                 "description": "Instance id of the connection owner",
@@ -6268,7 +6479,7 @@
             "description": "Forbidden — the API key does not own this connection. Returned when a connection is bound to a different API key."
           },
           "421": {
-            "description": "Misdirected Request — in cluster mode, this instance does not own the connection. The owning instance id is in the x-baileys-owner header; a proxy re-routes the request there. Not returned for POST /connections/{phoneNumber} (explicit takeover).",
+            "description": "Misdirected Request — in cluster mode, this instance does not own the connection. The owning instance id is in the x-baileys-owner header; a proxy re-routes the request there. Not returned for the explicit-takeover routes: POST /connections/{phoneNumber}, /import-session and /restart.",
             "headers": {
               "x-baileys-owner": {
                 "description": "Instance id of the connection owner",
@@ -6387,7 +6598,7 @@
             "description": "Forbidden — the API key does not own this connection. Returned when a connection is bound to a different API key."
           },
           "421": {
-            "description": "Misdirected Request — in cluster mode, this instance does not own the connection. The owning instance id is in the x-baileys-owner header; a proxy re-routes the request there. Not returned for POST /connections/{phoneNumber} (explicit takeover).",
+            "description": "Misdirected Request — in cluster mode, this instance does not own the connection. The owning instance id is in the x-baileys-owner header; a proxy re-routes the request there. Not returned for the explicit-takeover routes: POST /connections/{phoneNumber}, /import-session and /restart.",
             "headers": {
               "x-baileys-owner": {
                 "description": "Instance id of the connection owner",
@@ -6521,7 +6732,7 @@
             "description": "Forbidden — the API key does not own this connection. Returned when a connection is bound to a different API key."
           },
           "421": {
-            "description": "Misdirected Request — in cluster mode, this instance does not own the connection. The owning instance id is in the x-baileys-owner header; a proxy re-routes the request there. Not returned for POST /connections/{phoneNumber} (explicit takeover).",
+            "description": "Misdirected Request — in cluster mode, this instance does not own the connection. The owning instance id is in the x-baileys-owner header; a proxy re-routes the request there. Not returned for the explicit-takeover routes: POST /connections/{phoneNumber}, /import-session and /restart.",
             "headers": {
               "x-baileys-owner": {
                 "description": "Instance id of the connection owner",
@@ -6649,7 +6860,7 @@
             "description": "Forbidden — the API key does not own this connection. Returned when a connection is bound to a different API key."
           },
           "421": {
-            "description": "Misdirected Request — in cluster mode, this instance does not own the connection. The owning instance id is in the x-baileys-owner header; a proxy re-routes the request there. Not returned for POST /connections/{phoneNumber} (explicit takeover).",
+            "description": "Misdirected Request — in cluster mode, this instance does not own the connection. The owning instance id is in the x-baileys-owner header; a proxy re-routes the request there. Not returned for the explicit-takeover routes: POST /connections/{phoneNumber}, /import-session and /restart.",
             "headers": {
               "x-baileys-owner": {
                 "description": "Instance id of the connection owner",
@@ -6777,7 +6988,7 @@
             "description": "Forbidden — the API key does not own this connection. Returned when a connection is bound to a different API key."
           },
           "421": {
-            "description": "Misdirected Request — in cluster mode, this instance does not own the connection. The owning instance id is in the x-baileys-owner header; a proxy re-routes the request there. Not returned for POST /connections/{phoneNumber} (explicit takeover).",
+            "description": "Misdirected Request — in cluster mode, this instance does not own the connection. The owning instance id is in the x-baileys-owner header; a proxy re-routes the request there. Not returned for the explicit-takeover routes: POST /connections/{phoneNumber}, /import-session and /restart.",
             "headers": {
               "x-baileys-owner": {
                 "description": "Instance id of the connection owner",


### PR DESCRIPTION
## The problem

A connection keeps receiving messages, answers every health check and looks healthy in Chatwoot, while nothing an agent sends reaches the customer. No error, no log, no disconnect. Observed 13 times since 28/05/2026 across 8 inboxes, lasting from 6 minutes to 6h08, and recovery today costs a new QR code and a trip to the store's device.

## Diagnosis

Six keystore operations serialize on one `async-mutex` keyed by the connection's own JID, and that mutex has no timeout on acquisition or on hold. Inside it, `resyncAppState` downloads the app-state blob through `getHttpStream`, whose `fetch()` carries no `signal`:

| step | file |
|---|---|
| `resyncAppState` opens the transaction keyed by `meId` | `Socket/chats.js:424` → `544` |
| decodes patches, passing `config.options` | `Socket/chats.js:495` |
| downloads the external blob | `Utils/chat-utils.js:265` → `285` |
| **`fetch()` with no signal, no timeout** | `Utils/messages-media.js:297` |

A parked TLS stream there hangs forever holding the mutex. It explains every symptom: it self-triggers (`resyncAppState` fires on a received `server_sync` notification, unrelated to sending), lasts as long as a dead HTTP connection survives, clears only when the socket is recreated, emits no log, and leaves receiving and IQ queries intact.

The query-IQ path, a failing `commitWithRetry`, a wedged Redis and a non-draining WebSocket were each excluded by the absence of the log line they would have produced.

## What this does

Four layers, from the root cause outward.

**A. Patch the lib** (`patches/`, already 5 hunks in production). Mechanism in the patch, policy in the app, so no magic numbers cross the boundary and a version bump stays a rebase.
- A deadline on `getHttpStream`'s fetch, taken from `socketConfig.options.timeoutMs`. Verified empirically on Bun 1.3.14 that `AbortSignal.timeout` is honored mid-body-streaming, including through `Readable.fromWeb` — the premise the hunk depends on.
- A bounded **wait** on the transaction mutex, never a deadline on the work itself: abandoning a transaction mid-flight would leave Signal ratchet state advanced in memory and uncommitted, which corrupts the session and costs a re-pair. A waiter that times out never enters `txStorage.run`, so it touches no state at all — there is a dedicated test for exactly that.
- The stall report names the *holder*, via a stack captured before `runExclusive`. It is emitted by callback rather than logged in the patch because the logger the lib holds runs at `BAILEYS_LOG_LEVEL`, often `error` in production.

**B. Send timeout + circuit breaker.** Every path through the socket's `sendMessage` is bounded. `Promise.race` cannot cancel, so a timed-out send stays parked in the mutex — the breaker is what keeps that queue from growing with each caller retry, which is what would otherwise fire as a burst of duplicate messages hours later.

**C. `POST /connections/:phone/restart`.** Recreates the socket from the stored session: no QR, no re-pairing. A route rather than a flag on the connect schema, because `POST /connections` requires `webhookUrl` + `webhookVerifyToken` and would overwrite good metadata with whatever an operator typed at 2am.

**D. Watchdog.** 3 consecutive send timeouts **and** a streak lasting 90s **and** a live socket. Consecutive, because the failure is total and one success proves the mutex is free; the duration floor because concurrent sends all expire at the same instant. `lastTrafficAt` deliberately is not the trigger: inbound traffic keeps it fresh while sending is dead, so a "no traffic" watchdog would never fire on this bug.

## API changes

| | |
|---|---|
| `504` | send timed out, outcome unknown |
| `503` | connection known not to be sending |
| `409` + `x-baileys-idempotency-state` | `processing` (lock held) vs `indeterminate` (previous send timed out) |
| `POST /connections/:phone/restart` | 202 / 404 / 409 |
| `GET /connections/:phone/health` | `sendState`, ages of last completed send and last WhatsApp ACK |

`sendState` reports `unknown` when no send has been observed. A connection nobody writes to can be wedged for hours and look perfect, and claiming health we have not seen is worse than admitting the gap.

The idempotency lock gains a third state. On a timeout, deleting the key makes the send freely retryable (duplicate risk) and keeping `processing:` 409s every retry for the full TTL with no way to tell why. The caller decides: with a reserved `messageId` the resend reuses the same WhatsApp `key.id` and WhatsApp dedupes it, so the lock is released; without one it is recorded indeterminate and the caller is told to reconcile.

## Rollout

Both heuristics ship off. `BAILEYS_TX_ACQUIRE_TIMEOUT_MS=300000` is diagnosis-only — high enough that a legitimate `resyncAppState` cannot trip it — and `BAILEYS_SEND_STALL_RESTART_ENABLED=false` means the watchdog detects, logs and emits the webhook without killing a socket. Once a captured `originStack` names the holder, drop the timeout to 90s and enable the restart. Kill switches: `BAILEYS_TX_ACQUIRE_TIMEOUT_MS=0` and the enable flag.

## Tests

654 pass, 0 fail; lint and `tsc --noEmit` clean. The mutex tests use a deep import (`.../lib/Utils/auth-utils.js`), which resolves the real patched file because baileys declares `main` and no `exports`, so the preload's module mock does not intercept it. One test reads the installed file for the `E_TX_MUTEX_TIMEOUT` sentinel, guarding against the number-one failure mode of patch-based fixes: the patch silently not applying.

Depends on nothing. fazer-ai/chatwoot#391, already merged, consumes the new statuses, the header and the webhook.

## What the review rounds changed

31 rounds of automated review ran against this branch. Most of what they found was one defect family — state read before an `await` and still acted on after it — and closing it repeatedly is what the later half of the diff is. The parts worth knowing before reading the code:

**Everything that can outlive its episode re-checks it.** A socket generation stamps every send and every watchdog decision, so a reconnect landing inside a Redis round trip cannot let an old verdict tear down the new socket, spend a backoff strike, or write a cooldown onto a detector that never stalled.

**Every socket-creating path consults the lease.** The watchdog was the last one deciding on local state alone; it now yields through the same `shouldYieldToLeaseOwner` fence the `connectionReplaced` kick uses, read at the last point before the restart. A phone force-taken over by another instance is given up rather than rebuilt against its new owner.

**Only ever write over your own marker, or over nothing.** The idempotency lock fails open by design, so holding a key is not evidence of holding a lock. Acquire now reports `acquired` / `taken` / `failed-open`, the indeterminate marker carries a per-attempt token, and mark, release, cache and retract are all compare-and-set against it. The stall backoff store follows the same rule, because a lease handoff briefly gives that key two writers.

**Nothing claims health it did not observe.** `lastOutgoingAckAt` only moves forward, and only for an update that actually is an acknowledgement — the matcher that parks an unknown id has a side effect, so the evidence is read before it.

**`retry-after` is an instruction, so it is only issued when a retry provably cannot duplicate.** That means a reserved `messageId`, a marker that actually reached Redis, or a mutex-acquire timeout proving the send never entered the transaction. That last one also retracts the marker it made obsolete, which is what lets an operator's resend of the same message go through instead of meeting a 409 for 24h.

**Audio preprocessing is bounded and cancelled.** A PTT runs up to two ffmpeg jobs before the send; they now have their own budget outside the send deadline, and a timeout kills the child rather than leaving it running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013oeXoEGNu94cVXEtMx1rut

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/baileys-api/379)
<!-- Reviewable:end -->

