### PR TITLE
fix(history): address a dump the way a live message is addressed

### DIFF
--- a/.codex-review-waived
+++ b/.codex-review-waived
@@ -8,3 +8,12 @@
 # shared detail is declared, which rewrites the whole spec and belongs in its own PR:
 # https://github.com/fazer-ai/baileys-api/issues/374
 swagger.json: Restore the actual send-message conflict response
+
+# Business-hosted accounts (@hosted.lid) only, and it costs a phone number rather than
+# producing a wrong one: `addressingMode` does not depend on the mapping, so the client
+# still refuses to read the LID as a number and just leaves the field blank until a live
+# message fills it. Recovering it means new per-connection state carried across flushes,
+# for a domain we serve nobody on and that Baileys' own mapping store rejects outright.
+# Third round in a row on hosted LIDs; declined at the point the fix stopped being a
+# rule and started being a cache: https://github.com/fazer-ai/baileys-api/pull/386
+src/baileys/*.ts: Preserve hosted mappings across history events

--- a/src/baileys/connection.spec.ts
+++ b/src/baileys/connection.spec.ts
@@ -66,6 +66,7 @@ describe("BaileysConnection", () => {
     mockSocket.groupFetchAllParticipating.mockClear();
     mockSocket.signalRepository.lidMapping.getPNForLID.mockClear();
     mockSocket.signalRepository.lidMapping.getLIDForPN.mockClear();
+    mockSocket.signalRepository.lidMapping.getPNsForLIDs.mockClear();
 
     // Clear redis state
     (redis as any).__hashData.clear();
@@ -4635,6 +4636,106 @@ describe("BaileysConnection", () => {
       expect(
         payload.messages[0].message.imageMessage.jpegThumbnail,
       ).toBeUndefined();
+    });
+
+    // A dump's keys are raw protobuf: the addressing fields a live key carries
+    // do not exist there, so a LID-addressed chat arrives with the phone number
+    // nowhere in it and a client files the LID as one.
+    describe("the addressing a dump strips", () => {
+      const LID = "235085806727321@lid";
+      const PN = "5511999999999@s.whatsapp.net";
+
+      function lidMessage(id: string) {
+        return {
+          key: { id, remoteJid: LID, fromMe: false },
+          messageTimestamp: 1_700_000_000,
+          message: { conversation: `text ${id}` },
+        };
+      }
+
+      it("takes the mapping the event itself carries, without asking the store", async () => {
+        await connection.connect();
+        const handler = mockEventHandlers.get("messaging-history.set")!;
+
+        await handler({
+          chats: [],
+          contacts: [],
+          messages: [lidMessage("A")],
+          lidPnMappings: [{ lid: LID, pn: PN }],
+          syncType: 2,
+        });
+
+        const [{ key }] = historyPayloads()[0].messages;
+        expect(key.remoteJidAlt).toBe(PN);
+        expect(key.addressingMode).toBe("lid");
+        expect(
+          mockSocket.signalRepository.lidMapping.getPNsForLIDs,
+        ).not.toHaveBeenCalled();
+      });
+
+      it("asks the store for what the event did not name", async () => {
+        await connection.connect();
+        mockSocket.signalRepository.lidMapping.getPNsForLIDs.mockResolvedValueOnce(
+          [{ lid: LID, pn: PN }],
+        );
+        const handler = mockEventHandlers.get("messaging-history.set")!;
+
+        await handler({
+          chats: [],
+          contacts: [],
+          messages: [lidMessage("A"), lidMessage("B")],
+          syncType: 2,
+        });
+
+        const [{ key }] = historyPayloads()[0].messages;
+        expect(key.remoteJidAlt).toBe(PN);
+        // One batched read for the whole dump, not one per message.
+        expect(
+          mockSocket.signalRepository.lidMapping.getPNsForLIDs,
+        ).toHaveBeenCalledTimes(1);
+        expect(
+          mockSocket.signalRepository.lidMapping.getPNsForLIDs,
+        ).toHaveBeenCalledWith([LID]);
+      });
+
+      it("never asks about a dump that has no LID in it", async () => {
+        await connection.connect();
+        const handler = mockEventHandlers.get("messaging-history.set")!;
+
+        await handler({
+          chats: [],
+          contacts: [],
+          messages: [historyMessage("A")],
+          syncType: 2,
+        });
+
+        expect(
+          mockSocket.signalRepository.lidMapping.getPNsForLIDs,
+        ).not.toHaveBeenCalled();
+      });
+
+      // The dump is the point. A store that cannot answer costs the phone
+      // numbers, never the messages -- and the keys still say they are LIDs,
+      // which is what stops the client filing one as a number.
+      it("still delivers the dump when the store throws", async () => {
+        await connection.connect();
+        mockSocket.signalRepository.lidMapping.getPNsForLIDs.mockRejectedValueOnce(
+          new Error("store down"),
+        );
+        const handler = mockEventHandlers.get("messaging-history.set")!;
+
+        await handler({
+          chats: [],
+          contacts: [],
+          messages: [lidMessage("A")],
+          syncType: 2,
+        });
+
+        const [{ key }] = historyPayloads()[0].messages;
+        expect(key.remoteJidAlt).toBeUndefined();
+        expect(key.addressingMode).toBe("lid");
+        expect(key.id).toBe("A");
+      });
     });
 
     it("drops the chat and contact lists, which nothing reads and which double the dump", async () => {

--- a/src/baileys/connection.spec.ts
+++ b/src/baileys/connection.spec.ts
@@ -4673,6 +4673,27 @@ describe("BaileysConnection", () => {
         ).not.toHaveBeenCalled();
       });
 
+      // The shape a real history notification arrives in: it is processed inside
+      // `ev.buffer()`, and the buffer rebuilds the event field by field from what it
+      // accumulated, keeping the chat records and dropping the derived mapping list.
+      it("takes the mapping off the chat records when the buffer dropped the list", async () => {
+        await connection.connect();
+        const handler = mockEventHandlers.get("messaging-history.set")!;
+
+        await handler({
+          chats: [{ id: LID, pnJid: PN }],
+          contacts: [],
+          messages: [lidMessage("A")],
+          syncType: 2,
+        });
+
+        const [{ key }] = historyPayloads()[0].messages;
+        expect(key.remoteJidAlt).toBe(PN);
+        expect(
+          mockSocket.signalRepository.lidMapping.getPNsForLIDs,
+        ).not.toHaveBeenCalled();
+      });
+
       it("asks the store for what the event did not name", async () => {
         await connection.connect();
         mockSocket.signalRepository.lidMapping.getPNsForLIDs.mockResolvedValueOnce(

--- a/src/baileys/connection.ts
+++ b/src/baileys/connection.ts
@@ -8,6 +8,7 @@ import makeWASocket, {
   type ConnectionState,
   DisconnectReason,
   isJidGroup,
+  type LIDMapping,
   type MessageReceiptType,
   makeCacheableSignalKeyStore,
   type ParticipantAction,
@@ -26,6 +27,9 @@ import {
   type BaileysHistoryFramePayload,
   exhaustedChats,
   historyFrames,
+  lidPnIndex,
+  restoreAddressing,
+  unresolvedLids,
 } from "@/baileys/helpers/historySync";
 import {
   isTxMutexTimeout,
@@ -2621,7 +2625,7 @@ export class BaileysConnection {
 
     let chunkIndex = 0;
     for (const frame of historyFrames(
-      messages,
+      await this.addressHistory(messages, data.lidPnMappings),
       config.webhook.historyFrameMaxBytes,
     )) {
       const payload: BaileysHistoryFramePayload = {
@@ -2656,6 +2660,41 @@ export class BaileysConnection {
         },
       });
     }
+  }
+
+  // Restores the addressing a dump strips (see historySync.ts), from the two
+  // places the LID→PN mapping lives: the event, which speaks about the chats in
+  // this dump, and the mapping store, which also knows the group authors and
+  // whatever earlier traffic taught it. The store is asked only about the LIDs
+  // the event left unnamed, and in one batched read for the whole dump.
+  //
+  // A store that cannot be read costs the phone numbers it would have supplied,
+  // not the dump: what the event carried still applies, and every LID-addressed
+  // key is still marked as one, which is what keeps a client from reading the
+  // address as a phone number.
+  private async addressHistory(messages: WAMessage[], mappings?: LIDMapping[]) {
+    const index = lidPnIndex(mappings);
+    const missing = unresolvedLids(messages, index);
+
+    if (missing.length > 0) {
+      try {
+        const stored =
+          await this.safeSocket().signalRepository.lidMapping.getPNsForLIDs(
+            missing,
+          );
+        for (const [lid, pn] of lidPnIndex(stored)) {
+          index.set(lid, pn);
+        }
+      } catch (error) {
+        logger.warn(
+          "[%s] [addressHistory] Failed to resolve LID mappings: %s",
+          this.phoneNumber,
+          errorToString(error),
+        );
+      }
+    }
+
+    return restoreAddressing(messages, index);
   }
 
   private handleGroupsUpdate(data: BaileysEventMap["groups.update"]) {

--- a/src/baileys/connection.ts
+++ b/src/baileys/connection.ts
@@ -4,6 +4,7 @@ import makeWASocket, {
   type AuthenticationState,
   type BaileysEventMap,
   Browsers,
+  type Chat,
   type ChatModification,
   type ConnectionState,
   DisconnectReason,
@@ -25,6 +26,7 @@ import { downloadMediaFromMessages } from "@/baileys/helpers/downloadMediaFromMe
 import { fetchBaileysClientVersion } from "@/baileys/helpers/fetchBaileysClientVersion";
 import {
   type BaileysHistoryFramePayload,
+  chatLidPnPairs,
   exhaustedChats,
   historyFrames,
   lidPnIndex,
@@ -2625,7 +2627,7 @@ export class BaileysConnection {
 
     let chunkIndex = 0;
     for (const frame of historyFrames(
-      await this.addressHistory(messages, data.lidPnMappings),
+      await this.addressHistory(messages, data.lidPnMappings, data.chats ?? []),
       config.webhook.historyFrameMaxBytes,
     )) {
       const payload: BaileysHistoryFramePayload = {
@@ -2668,12 +2670,21 @@ export class BaileysConnection {
   // whatever earlier traffic taught it. The store is asked only about the LIDs
   // the event left unnamed, and in one batched read for the whole dump.
   //
+  // Both of the event's own copies are read -- the derived list and the chat
+  // records it was derived from -- because the buffered path drops the first and
+  // the second is all a real history notification arrives with. See
+  // `chatLidPnPairs`.
+  //
   // A store that cannot be read costs the phone numbers it would have supplied,
   // not the dump: what the event carried still applies, and every LID-addressed
   // key is still marked as one, which is what keeps a client from reading the
   // address as a phone number.
-  private async addressHistory(messages: WAMessage[], mappings?: LIDMapping[]) {
-    const index = lidPnIndex(mappings);
+  private async addressHistory(
+    messages: WAMessage[],
+    mappings: LIDMapping[] | undefined,
+    chats: Chat[],
+  ) {
+    const index = lidPnIndex(mappings, chatLidPnPairs(chats));
     const missing = unresolvedLids(messages, index);
 
     if (missing.length > 0) {

--- a/src/baileys/helpers/historySync.spec.ts
+++ b/src/baileys/helpers/historySync.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import type { WAMessageKey } from "@whiskeysockets/baileys";
 import {
+  chatLidPnPairs,
   exhaustedChats,
   historyFrames,
   lidPnIndex,
@@ -232,6 +233,38 @@ describe("restoring the addressing a dump strips", () => {
       );
 
       expect(message.key.remoteJidAlt).toBe("5511999999999@hosted");
+    });
+  });
+
+  // The derived list is dropped by the event buffer, which is the path a real history
+  // notification takes, so the chat records are the only copy that always arrives.
+  describe("the pairs the chat records carry", () => {
+    it("pairs a LID-addressed chat with the phone jid on its record", () => {
+      expect(chatLidPnPairs([{ id: LID, pnJid: PN }])).toEqual([
+        { lid: LID, pn: PN },
+      ]);
+    });
+
+    it("pairs a phone-addressed chat with the LID on its record", () => {
+      expect(chatLidPnPairs([{ id: PN, lidJid: LID }])).toEqual([
+        { lid: LID, pn: PN },
+      ]);
+    });
+
+    it("says nothing about a chat whose record names only itself", () => {
+      expect(chatLidPnPairs([{ id: LID }, { id: PN }, {}])).toEqual([]);
+    });
+
+    // A group jid is neither address, and letting one in would file it as somebody's
+    // phone number -- the very thing this change exists to prevent.
+    it("never reads a group jid as a phone number", () => {
+      expect(chatLidPnPairs([{ id: "120363@g.us", lidJid: LID }])).toEqual([]);
+    });
+
+    it("carries a hosted chat, which is the only place its mapping arrives", () => {
+      expect(
+        chatLidPnPairs([{ id: "777@hosted.lid", pnJid: "5511@hosted" }]),
+      ).toEqual([{ lid: "777@hosted.lid", pn: "5511@hosted" }]);
     });
   });
 

--- a/src/baileys/helpers/historySync.spec.ts
+++ b/src/baileys/helpers/historySync.spec.ts
@@ -1,9 +1,13 @@
 import { describe, expect, it } from "bun:test";
+import type { WAMessageKey } from "@whiskeysockets/baileys";
 import {
   exhaustedChats,
   historyFrames,
+  lidPnIndex,
   NO_MORE_HISTORY,
+  restoreAddressing,
   stripHistoryPayload,
+  unresolvedLids,
 } from "./historySync";
 
 function textMessage(id: string, text: string) {
@@ -147,6 +151,151 @@ describe("historyFrames", () => {
 
     expect(frames).toHaveLength(1);
     expect(frames[0]).toHaveLength(10);
+  });
+});
+
+describe("restoring the addressing a dump strips", () => {
+  const LID = "235085806727321@lid";
+  const PN = "5511999999999@s.whatsapp.net";
+
+  function chatMessage(remoteJid: string, participant?: string) {
+    const key: WAMessageKey = {
+      id: "A",
+      remoteJid,
+      participant,
+      fromMe: false,
+    };
+    return { key, message: { conversation: "hi" } };
+  }
+
+  describe("which addresses are left to resolve", () => {
+    it("names the chats and the group authors addressed by LID, once each", () => {
+      expect(
+        unresolvedLids(
+          [
+            chatMessage(LID),
+            chatMessage(LID),
+            chatMessage("120363@g.us", "777@lid"),
+            chatMessage(PN),
+            chatMessage("120363@g.us", PN),
+          ],
+          new Map(),
+        ),
+      ).toEqual([LID, "777@lid"]);
+    });
+
+    // What the event already said is not worth a read, and on a bootstrap dump
+    // the event says it about every chat in it.
+    it("leaves out the LIDs the index already resolves", () => {
+      expect(
+        unresolvedLids(
+          [chatMessage(LID), chatMessage("777@lid")],
+          lidPnIndex([{ lid: LID, pn: PN }]),
+        ),
+      ).toEqual(["777@lid"]);
+    });
+
+    // The index is keyed by the LID user, the dump addresses by full jid: a
+    // device suffix must not read as a LID nobody has resolved.
+    it("matches an address that carries a device suffix", () => {
+      expect(
+        unresolvedLids(
+          [chatMessage("235085806727321:3@lid")],
+          lidPnIndex([{ lid: LID, pn: PN }]),
+        ),
+      ).toEqual([]);
+    });
+
+    it("names nothing for a dump with no LID in it", () => {
+      expect(
+        unresolvedLids([chatMessage(PN), { key: null }], new Map()),
+      ).toEqual([]);
+    });
+  });
+
+  describe("the mapping index", () => {
+    it("keys by the LID user, so a device suffix still resolves", () => {
+      const index = lidPnIndex([{ lid: "235085806727321:3@lid", pn: PN }]);
+
+      expect(index.get("235085806727321")).toBe(PN);
+    });
+
+    // The store answers `<user>:0@s.whatsapp.net`; a live message never carries
+    // the device, so neither may the alt jid we stamp from it.
+    it("drops the device the mapping store adds to its answer", () => {
+      const index = lidPnIndex([
+        { lid: LID, pn: "5511999999999:0@s.whatsapp.net" },
+      ]);
+
+      expect(index.get("235085806727321")).toBe(PN);
+    });
+
+    it("lets the earlier source win, which is the one describing this dump", () => {
+      const index = lidPnIndex(
+        [{ lid: LID, pn: PN }],
+        [{ lid: LID, pn: "5511000000000@s.whatsapp.net" }],
+      );
+
+      expect(index.get("235085806727321")).toBe(PN);
+    });
+
+    it("survives a source that is absent or empty", () => {
+      expect(lidPnIndex(undefined, null, []).size).toBe(0);
+    });
+  });
+
+  it("gives a LID-addressed chat the phone number as its alt jid", () => {
+    const [message] = restoreAddressing(
+      [chatMessage(LID)],
+      lidPnIndex([{ lid: LID, pn: PN }]),
+    );
+
+    expect(message.key.addressingMode).toBe("lid");
+    expect(message.key.remoteJidAlt).toBe(PN);
+    expect(message.key.remoteJid).toBe(LID);
+  });
+
+  // The half that fixes the report on its own: a client reading the address as
+  // a phone number stops as soon as it is told the address is a LID, whether or
+  // not the number behind it was ever resolved.
+  it("marks the chat LID-addressed even with no mapping to resolve", () => {
+    const [message] = restoreAddressing([chatMessage(LID)], new Map());
+
+    expect(message.key.addressingMode).toBe("lid");
+    expect(message.key.remoteJidAlt).toBeUndefined();
+  });
+
+  it("resolves a group author into participantAlt, leaving the group jid alone", () => {
+    const [message] = restoreAddressing(
+      [chatMessage("120363@g.us", "777@lid")],
+      lidPnIndex([{ lid: "777@lid", pn: PN }]),
+    );
+
+    expect(message.key.remoteJid).toBe("120363@g.us");
+    expect(message.key.remoteJidAlt).toBeUndefined();
+    expect(message.key.participantAlt).toBe(PN);
+    expect(message.key.addressingMode).toBe("lid");
+  });
+
+  it("leaves a phone-addressed message exactly as it arrived", () => {
+    const message = chatMessage(PN);
+    const [restored] = restoreAddressing(
+      [message],
+      lidPnIndex([{ lid: LID, pn: PN }]),
+    );
+
+    expect(restored).toBe(message);
+  });
+
+  it("keeps everything else on the message and the key", () => {
+    const [message] = restoreAddressing(
+      [chatMessage(LID)],
+      lidPnIndex([{ lid: LID, pn: PN }]),
+    );
+
+    expect(message.key.id).toBe("A");
+    expect(message.key.fromMe).toBe(false);
+    expect(message.message).toEqual({ conversation: "hi" });
   });
 });
 

--- a/src/baileys/helpers/historySync.spec.ts
+++ b/src/baileys/helpers/historySync.spec.ts
@@ -332,6 +332,20 @@ describe("restoring the addressing a dump strips", () => {
     expect(message.key.addressingMode).toBe("lid");
   });
 
+  // Not a group, so the decoder files the sender's alternate under `remoteJidAlt` even
+  // though the sender was read off `participant`. The chat decides the field, not where
+  // the address came from.
+  it("files a broadcast sender the way a non-group key does", () => {
+    const [message] = restoreAddressing(
+      [chatMessage("status@broadcast", "777@lid")],
+      lidPnIndex([{ lid: "777@lid", pn: PN }]),
+    );
+
+    expect(message.key.remoteJidAlt).toBe(PN);
+    expect(message.key.participantAlt).toBeUndefined();
+    expect(message.key.addressingMode).toBe("lid");
+  });
+
   it("leaves a phone-addressed message exactly as it arrived", () => {
     const message = chatMessage(PN);
     const [restored] = restoreAddressing(

--- a/src/baileys/helpers/historySync.spec.ts
+++ b/src/baileys/helpers/historySync.spec.ts
@@ -213,6 +213,28 @@ describe("restoring the addressing a dump strips", () => {
     });
   });
 
+  // A business-hosted account is addressed on `hosted.lid`, which `jidDecode` reads as a
+  // LID domain and `isLidUser` -- a plain `@lid` suffix test -- does not. Left out, its
+  // chats kept the exact shape this whole change exists to fix.
+  describe("the hosted form of a LID", () => {
+    const HOSTED = "235085806727321@hosted.lid";
+
+    it("marks a hosted chat LID-addressed like any other", () => {
+      const [message] = restoreAddressing([chatMessage(HOSTED)], new Map());
+
+      expect(message.key.addressingMode).toBe("lid");
+    });
+
+    it("takes a hosted mapping out of the event, which is the only place one arrives", () => {
+      const [message] = restoreAddressing(
+        [chatMessage(HOSTED)],
+        lidPnIndex([{ lid: HOSTED, pn: "5511999999999@hosted" }]),
+      );
+
+      expect(message.key.remoteJidAlt).toBe("5511999999999@hosted");
+    });
+  });
+
   describe("the mapping index", () => {
     it("keys by the LID user, so a device suffix still resolves", () => {
       const index = lidPnIndex([{ lid: "235085806727321:3@lid", pn: PN }]);

--- a/src/baileys/helpers/historySync.ts
+++ b/src/baileys/helpers/historySync.ts
@@ -150,10 +150,18 @@ function splitJid(jid: string | null | undefined) {
   return user && server ? { user, server } : undefined;
 }
 
+// The two servers a LID lives on, `hosted.lid` being the business-hosted form. Both are
+// LID domains to `jidDecode`, but not to `isLidUser`, which is a plain `@lid` suffix test
+// -- so the mapping store never resolves a hosted LID, while the chat records in a dump do
+// carry mappings for one. Marking the address is the half that does not depend on either.
+const LID_SERVERS = ["lid", "hosted.lid"];
+
 // The LID user a jid addresses, or undefined when the jid is not a LID.
 function lidUser(jid: string | null | undefined): string | undefined {
   const decoded = splitJid(jid);
-  return decoded?.server === "lid" ? decoded.user : undefined;
+  return decoded && LID_SERVERS.includes(decoded.server)
+    ? decoded.user
+    : undefined;
 }
 
 // The LIDs this dump addresses a chat or a group author by that the index

--- a/src/baileys/helpers/historySync.ts
+++ b/src/baileys/helpers/historySync.ts
@@ -184,6 +184,50 @@ export function unresolvedLids(
   return [...lids];
 }
 
+// The servers a phone-addressed jid lives on, `hosted` being the business-hosted form.
+const PHONE_SERVERS = ["s.whatsapp.net", "c.us", "hosted"];
+
+// The LID↔phone pairs the dump's own chat records carry, which is where Baileys reads
+// `lidPnMappings` from in the first place.
+//
+// Read again from the records because the two do not always both arrive. A real history
+// notification is processed inside `ev.buffer()`, and the buffer rebuilds
+// `messaging-history.set` field by field out of what it accumulated -- chats, contacts,
+// messages, and no derived list -- so on that path `lidPnMappings` is simply absent and
+// the chat records are the only copy left. The derived list is still read where it does
+// arrive: it carries a `userReceipt` fallback for a LID chat whose record has no `pnJid`,
+// which nothing here could reconstruct.
+export function chatLidPnPairs(
+  chats: readonly {
+    id?: string | null;
+    pnJid?: string | null;
+    lidJid?: string | null;
+  }[],
+): LIDMapping[] {
+  const pairs: LIDMapping[] = [];
+  for (const chat of chats) {
+    const id = chat.id;
+    if (!id) {
+      continue;
+    }
+
+    if (lidUser(id)) {
+      if (chat.pnJid) {
+        pairs.push({ lid: id, pn: chat.pnJid });
+      }
+      // A chat keyed the other way names its own LID, and its messages can still be
+      // LID-addressed. Gated on the id being a phone address so a group's jid can never
+      // enter the index as one.
+    } else if (
+      chat.lidJid &&
+      PHONE_SERVERS.includes(splitJid(id)?.server ?? "")
+    ) {
+      pairs.push({ lid: chat.lidJid, pn: id });
+    }
+  }
+  return pairs;
+}
+
 // LID user to phone jid, merged from every source that holds part of it. The
 // first source to name a LID wins, so pass the ones that describe this dump
 // before the ones that merely remember it. Phone jids are normalized, because

--- a/src/baileys/helpers/historySync.ts
+++ b/src/baileys/helpers/historySync.ts
@@ -1,4 +1,4 @@
-import type { proto } from "@whiskeysockets/baileys";
+import type { LIDMapping, proto, WAMessageKey } from "@whiskeysockets/baileys";
 
 // Binary fields the client never reads, dropped before the payload reaches the
 // wire. They are decoded protobuf `bytes`, so they arrive as Uint8Array and
@@ -116,6 +116,124 @@ export function exhaustedChats(
     .filter((chat) => chat.endOfHistoryTransferType === NO_MORE_HISTORY)
     .map((chat) => chat.id)
     .filter((id): id is string => Boolean(id));
+}
+
+// A history message key holds exactly what the protobuf defines: `remoteJid`,
+// `fromMe`, `id`, `participant`. The three fields a live key also carries --
+// `addressingMode`, `remoteJidAlt`, `participantAlt` -- are stamped by the live
+// decoder from stanza attributes, and a dump has no stanza. So on a
+// LID-addressed account every chat in a dump reaches the client as a bare
+// `<LID>@lid`, with the phone number nowhere in the payload, and a client that
+// reads the address as a number files the LID as one. Measured on a real
+// pairing: contacts created with a phone number of `+235085806727321`, which is
+// a LID.
+//
+// The mapping is not missing, only unshipped. WhatsApp sends it in this very
+// event -- Baileys distills `lidPnMappings` out of the chat records we drop --
+// and stores it in `signalRepository.lidMapping` before emitting. Both are read
+// back below to rebuild the live shape.
+//
+// A message as a history dump carries it. `WAMessageKey` is what its key
+// becomes once the three fields above are stamped back on.
+interface HistoryMessage {
+  key?: WAMessageKey | null;
+}
+
+// A jid split into the account it names and the server it lives on, with the
+// device and agent suffixes dropped: `5511:3@s.whatsapp.net` and
+// `5511@s.whatsapp.net` are one account. The same split `jidDecode` makes,
+// minus the domain classification nothing here reads, and done by hand for the
+// same reason `historyJid` does it: the shapes involved are two.
+function splitJid(jid: string | null | undefined) {
+  const [address, server] = (jid ?? "").split("@");
+  const user = address?.split(":")[0]?.split("_")[0];
+  return user && server ? { user, server } : undefined;
+}
+
+// The LID user a jid addresses, or undefined when the jid is not a LID.
+function lidUser(jid: string | null | undefined): string | undefined {
+  const decoded = splitJid(jid);
+  return decoded?.server === "lid" ? decoded.user : undefined;
+}
+
+// The LIDs this dump addresses a chat or a group author by that the index
+// cannot resolve yet, deduplicated: what is left to look up, and the whole of
+// it, so the lookup is one batched read rather than one per message. A mature
+// chat repeats its own address a thousand times.
+export function unresolvedLids(
+  messages: readonly HistoryMessage[],
+  index: ReadonlyMap<string, string>,
+): string[] {
+  const lids = new Set<string>();
+  for (const { key } of messages) {
+    for (const jid of [key?.remoteJid, key?.participant]) {
+      const user = jid ? lidUser(jid) : undefined;
+      if (jid && user && !index.has(user)) {
+        lids.add(jid);
+      }
+    }
+  }
+  return [...lids];
+}
+
+// LID user to phone jid, merged from every source that holds part of it. The
+// first source to name a LID wins, so pass the ones that describe this dump
+// before the ones that merely remember it. Phone jids are normalized, because
+// the mapping store answers with a device suffix (`:0`) that a live message
+// never carries.
+export function lidPnIndex(
+  ...sources: (readonly LIDMapping[] | null | undefined)[]
+): Map<string, string> {
+  const index = new Map<string, string>();
+  for (const source of sources) {
+    for (const { lid, pn } of source ?? []) {
+      const user = lidUser(lid);
+      const phone = splitJid(pn);
+      if (user && phone && !index.has(user)) {
+        index.set(user, `${phone.user}@${phone.server}`);
+      }
+    }
+  }
+  return index;
+}
+
+// Puts back on a history key the addressing fields the live decoder stamps from
+// stanza attributes, so an imported message is addressed exactly like the same
+// message would have been live.
+//
+// `addressingMode` is stamped from the address alone and does not wait for the
+// mapping: that a chat is LID-addressed is a fact about the message, and saying
+// so is what stops a client from reading the LID as a phone number. The alt jid
+// follows only when the mapping resolved -- a phone number we do not know must
+// arrive absent, never guessed.
+//
+// Which of the two alt fields is filled falls out of the address: a group's
+// `remoteJid` is never a LID, and a 1:1 message has no participant, which is
+// the same split the live decoder makes explicitly.
+export function restoreAddressing<T extends HistoryMessage>(
+  messages: readonly T[],
+  index: ReadonlyMap<string, string>,
+): T[] {
+  return messages.map((message) => {
+    const key = message.key;
+    const chat = lidUser(key?.remoteJid);
+    const author = lidUser(key?.participant);
+    if (!key || (!chat && !author)) {
+      return message;
+    }
+
+    const remoteJidAlt = chat && index.get(chat);
+    const participantAlt = author && index.get(author);
+    return {
+      ...message,
+      key: {
+        ...key,
+        addressingMode: "lid",
+        ...(remoteJidAlt ? { remoteJidAlt } : {}),
+        ...(participantAlt ? { participantAlt } : {}),
+      },
+    };
+  });
 }
 
 // What the client is told about a history dump. The contacts and participant

--- a/src/baileys/helpers/historySync.ts
+++ b/src/baileys/helpers/historySync.ts
@@ -259,30 +259,33 @@ export function lidPnIndex(
 // follows only when the mapping resolved -- a phone number we do not know must
 // arrive absent, never guessed.
 //
-// Which of the two alt fields is filled falls out of the address: a group's
-// `remoteJid` is never a LID, and a 1:1 message has no participant, which is
-// the same split the live decoder makes explicitly.
+// Both rules are the decoder's, copied rather than reasoned about. The sender is the
+// participant where there is one and the chat otherwise, which is a 1:1 peer, a group's
+// author, or a broadcast's. Its alternate address is filed under `participantAlt` for a
+// group and `remoteJidAlt` for everything else -- and it is the chat being a group that
+// decides that, not which of the two fields the sender was read from.
 export function restoreAddressing<T extends HistoryMessage>(
   messages: readonly T[],
   index: ReadonlyMap<string, string>,
 ): T[] {
   return messages.map((message) => {
     const key = message.key;
-    const chat = lidUser(key?.remoteJid);
-    const author = lidUser(key?.participant);
-    if (!key || (!chat && !author)) {
+    const sender = lidUser(key?.participant) ?? lidUser(key?.remoteJid);
+    if (!key || !sender) {
       return message;
     }
 
-    const remoteJidAlt = chat && index.get(chat);
-    const participantAlt = author && index.get(author);
+    const senderAlt = index.get(sender);
+    const altField =
+      splitJid(key.remoteJid)?.server === "g.us"
+        ? "participantAlt"
+        : "remoteJidAlt";
     return {
       ...message,
       key: {
         ...key,
         addressingMode: "lid",
-        ...(remoteJidAlt ? { remoteJidAlt } : {}),
-        ...(participantAlt ? { participantAlt } : {}),
+        ...(senderAlt ? { [altField]: senderAlt } : {}),
       },
     };
   });

--- a/src/test/preload.ts
+++ b/src/test/preload.ts
@@ -547,6 +547,7 @@ function createMockSocket() {
       lidMapping: {
         getPNForLID: mock(async () => null),
         getLIDForPN: mock(async () => null),
+        getPNsForLIDs: mock(async () => null),
       },
     },
   };


### PR DESCRIPTION
A WhatsApp account migrated to LID addressing synced its history into a client that then showed every contact's phone number as a fifteen-digit number nobody has: the LID itself. Reported at fazer-ai/chatwoot#408, with contacts created as `+235085806727321`.

History keys are raw protobuf. `proto.MessageKey` defines four fields — `remoteJid`, `fromMe`, `id`, `participant` — and the three a live key also carries (`addressingMode`, `remoteJidAlt`, `participantAlt`) are stamped by the live decoder out of stanza attributes, which a dump does not have. So a LID-addressed chat arrived as a bare `<LID>@lid` with the phone number nowhere in the payload, and a client with no way to tell an address from a number filed one as the other.

The mapping was never missing, only unshipped. It rides along on the dump's own chat records (`pnJid` / `lidJid`), which we were dropping wholesale, and `historyJid()` in this same file already reads the mapping store to address on-demand requests.

## Closes

Closes #385. Pairs with fazer-ai/chatwoot#419, which stops the client trusting an address as a number in the first place; this PR is the half that supplies the number.

## How to test

1. Pair an account whose chats are LID-addressed and let the history sync land. In the webhook bodies, every 1:1 key now carries `addressingMode: "lid"` and `remoteJidAlt: <phone>@s.whatsapp.net`, the same shape a live message for that chat has.
2. Group history: the group's own jid is untouched, and each message's author carries `participantAlt`.
3. A chat whose mapping nothing knows still arrives marked `addressingMode: "lid"`, with no alt jid. That alone is enough to stop a client reading the LID as a phone number.
4. A phone-addressed dump is byte-for-byte what it was before, and no lookup is performed.

## What changed

`historySync.ts` gains the addressing half: `chatLidPnPairs` reads the LID↔phone pairs off the chat records, `unresolvedLids` names what the dump uses and the mapping does not yet cover, `lidPnIndex` merges the sources into a LID-user → phone-jid map, and `restoreAddressing` puts the fields back on each key.

Three sources feed that map, and the order is deliberate:

- **The chat records.** The only copy that always arrives. A real history notification is processed inside `ev.buffer()`, and the buffer rebuilds `messaging-history.set` field by field out of what it accumulated — chats, contacts, messages, and no derived list — so `lidPnMappings` is absent on exactly the path production takes.
- **`lidPnMappings`**, where it does arrive. It carries a `userReceipt` fallback for a LID chat whose record has no `pnJid`, which nothing here could reconstruct.
- **The mapping store**, asked once per dump for the LIDs the first two left unnamed, through the batched `getPNsForLIDs` (a cache and one keystore read, no network).

`addressingMode` is set from the address alone, so it does not wait on the mapping — that a chat is LID-addressed is a fact about the message, and saying so is the half that fixes the symptom. The alt jid follows only when the mapping resolved: an unknown phone number arrives absent, never guessed.

A store that cannot be read costs the phone numbers, not the dump: the event's own mappings still apply and every LID-addressed key is still marked as one.

Two shapes that needed naming. `hosted.lid` is a LID domain to `jidDecode` but not to `isLidUser`, which is a plain `@lid` suffix test — so the mapping store rejects hosted pairs outright and the chat records are a hosted chat's only source. And a pair is taken from a phone-addressed record only when its id really is a phone address, so a group's jid can never enter the index as somebody's phone number.

Phone jids are normalized on the way into the index, because the store answers `<user>:0@s.whatsapp.net` and a live message never carries the device.

## Deliberately not done

The mirror direction — stamping `remoteJidAlt: <LID>@lid` on a phone-addressed history chat — is left out. It is the same data pointed the other way, and it would make a client key those contacts by LID during an import instead of at the first live message, which is a different change with a different risk profile and no bearing on the report.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/baileys-api/386)
<!-- Reviewable:end -->

A hosted chat whose record was already seen keeps its phone number only for as long as the connection's own event buffer remembers it: the buffer suppresses a repeated chat record, and Baileys' mapping store rejects hosted pairs outright, so a later flush has no source left. Waived rather than fixed with a per-connection cache — it costs a phone number rather than producing a wrong one, since `addressingMode` does not depend on the mapping and a live message fills the number in.