### PR TITLE
fix(history): let a hosted account's LID resolve to its phone number

### DIFF
--- a/.codex-review-waived
+++ b/.codex-review-waived
@@ -8,12 +8,3 @@
 # shared detail is declared, which rewrites the whole spec and belongs in its own PR:
 # https://github.com/fazer-ai/baileys-api/issues/374
 swagger.json: Restore the actual send-message conflict response
-
-# Business-hosted accounts (@hosted.lid) only, and it costs a phone number rather than
-# producing a wrong one: `addressingMode` does not depend on the mapping, so the client
-# still refuses to read the LID as a number and just leaves the field blank until a live
-# message fills it. Recovering it means new per-connection state carried across flushes,
-# for a domain we serve nobody on and that Baileys' own mapping store rejects outright.
-# Third round in a row on hosted LIDs; declined at the point the fix stopped being a
-# rule and started being a cache: https://github.com/fazer-ai/baileys-api/pull/386
-src/baileys/*.ts: Preserve hosted mappings across history events

--- a/patches/@whiskeysockets%2Fbaileys@7.0.0-rc14.patch
+++ b/patches/@whiskeysockets%2Fbaileys@7.0.0-rc14.patch
@@ -1,3 +1,47 @@
+diff --git a/lib/Signal/lid-mapping.js b/lib/Signal/lid-mapping.js
+index c99bdf522c6143055b28de6ce3bcefaeac936a3c..ba148cf97bd308c1980bdbc5af5d0dce35b22b04 100644
+--- a/lib/Signal/lid-mapping.js
++++ b/lib/Signal/lid-mapping.js
+@@ -1,5 +1,20 @@
+ import { LRUCache } from 'lru-cache';
+-import { isHostedPnUser, isLidUser, isPnUser, jidDecode, jidNormalizedUser, WAJIDDomains } from '../WABinary/index.js';
++import { isHostedLidUser, isHostedPnUser, isLidUser, isPnUser, jidDecode, jidNormalizedUser, WAJIDDomains } from '../WABinary/index.js';
++// A hosted account addresses itself on `hosted` / `hosted.lid`, and neither `isPnUser` nor
++// `isLidUser` recognises those: both are plain suffix tests for the non-hosted form. Every
++// other part of this file already handles the hosted domains -- `_getLIDsForPNsImpl` accepts
++// a hosted PN and builds a `hosted.lid` answer, and `addResolvedPair` below builds a `@hosted`
++// jid off `WAJIDDomains.HOSTED_LID`. So does the caller: `processHistoryMessage` derives
++// hosted pairs on purpose (`isHostedLidUser`, `isHostedPnUser`) and hands them straight to
++// `storeLIDPNMappings`. Only the two guards below were left on the narrow test, so every
++// hosted pair was warned away at the door and no hosted LID ever resolved to a phone number.
++//
++// The table is keyed by user rather than by jid, and a hosted and a plain LID for one account
++// share that user -- the domain says how the account is reached, not who it is. So the pairs
++// belong in the same table, and the reverse lookup rebuilds the right domain from the
++// `domainType` of the jid it was asked about.
++const isAnyLidUser = (jid) => isLidUser(jid) || isHostedLidUser(jid);
++const isAnyPnUser = (jid) => isPnUser(jid) || isHostedPnUser(jid);
+ export class LIDMappingStore {
+     constructor(keys, logger, pnToLIDFunc) {
+         this.mappingCache = new LRUCache({
+@@ -18,7 +33,7 @@ export class LIDMappingStore {
+             return;
+         const validatedPairs = [];
+         for (const { lid, pn } of pairs) {
+-            if (!((isLidUser(lid) && isPnUser(pn)) || (isPnUser(lid) && isLidUser(pn)))) {
++            if (!((isAnyLidUser(lid) && isAnyPnUser(pn)) || (isAnyPnUser(lid) && isAnyLidUser(pn)))) {
+                 this.logger.warn(`Invalid LID-PN mapping: ${lid}, ${pn}`);
+                 continue;
+             }
+@@ -232,7 +247,7 @@ export class LIDMappingStore {
+             return true;
+         };
+         for (const lid of lids) {
+-            if (!isLidUser(lid))
++            if (!isAnyLidUser(lid))
+                 continue;
+             const decoded = jidDecode(lid);
+             if (!decoded)
 diff --git a/lib/Socket/Client/websocket.js b/lib/Socket/Client/websocket.js
 index 311fb3ef977e3f8bd091650e2f484ce57f12e91c..b1d29fdf662b7afb2649ff876f359a3d172e8dbc 100644
 --- a/lib/Socket/Client/websocket.js

--- a/patches/@whiskeysockets%2Fbaileys@7.0.0-rc14.patch
+++ b/patches/@whiskeysockets%2Fbaileys@7.0.0-rc14.patch
@@ -1,8 +1,8 @@
 diff --git a/lib/Signal/lid-mapping.js b/lib/Signal/lid-mapping.js
-index c99bdf522c6143055b28de6ce3bcefaeac936a3c..ba148cf97bd308c1980bdbc5af5d0dce35b22b04 100644
+index c99bdf522c6143055b28de6ce3bcefaeac936a3c..5028728cf5d42312dd01ace5f3e2147cc969622d 100644
 --- a/lib/Signal/lid-mapping.js
 +++ b/lib/Signal/lid-mapping.js
-@@ -1,5 +1,20 @@
+@@ -1,5 +1,35 @@
  import { LRUCache } from 'lru-cache';
 -import { isHostedPnUser, isLidUser, isPnUser, jidDecode, jidNormalizedUser, WAJIDDomains } from '../WABinary/index.js';
 +import { isHostedLidUser, isHostedPnUser, isLidUser, isPnUser, jidDecode, jidNormalizedUser, WAJIDDomains } from '../WABinary/index.js';
@@ -21,19 +21,42 @@ index c99bdf522c6143055b28de6ce3bcefaeac936a3c..ba148cf97bd308c1980bdbc5af5d0dce
 +// `domainType` of the jid it was asked about.
 +const isAnyLidUser = (jid) => isLidUser(jid) || isHostedLidUser(jid);
 +const isAnyPnUser = (jid) => isPnUser(jid) || isHostedPnUser(jid);
++// Which of the two is the LID and which is the phone number is decided by the domain, never
++// by the field the caller happened to put it in. `handleMessage` in Socket/messages-recv.js
++// tests `altServer === 'lid'` strictly, so a hosted alternate falls to its else branch and a
++// PN-addressed hosted message arrives here as `{lid: <phone>, pn: <lid>}`. Upstream's guard
++// already accepted that order and then decoded positionally, persisting the pair backwards
++// and leaving the real LID unresolvable; widening the guard is what makes hosted reach it.
++const orientPair = (lid, pn) => {
++    if (isAnyLidUser(lid) && isAnyPnUser(pn)) {
++        return { lidJid: lid, pnJid: pn };
++    }
++    if (isAnyPnUser(lid) && isAnyLidUser(pn)) {
++        return { lidJid: pn, pnJid: lid };
++    }
++    return undefined;
++};
  export class LIDMappingStore {
      constructor(keys, logger, pnToLIDFunc) {
          this.mappingCache = new LRUCache({
-@@ -18,7 +33,7 @@ export class LIDMappingStore {
+@@ -18,12 +48,13 @@ export class LIDMappingStore {
              return;
          const validatedPairs = [];
          for (const { lid, pn } of pairs) {
 -            if (!((isLidUser(lid) && isPnUser(pn)) || (isPnUser(lid) && isLidUser(pn)))) {
-+            if (!((isAnyLidUser(lid) && isAnyPnUser(pn)) || (isAnyPnUser(lid) && isAnyLidUser(pn)))) {
++            const oriented = orientPair(lid, pn);
++            if (!oriented) {
                  this.logger.warn(`Invalid LID-PN mapping: ${lid}, ${pn}`);
                  continue;
              }
-@@ -232,7 +247,7 @@ export class LIDMappingStore {
+-            const lidDecoded = jidDecode(lid);
+-            const pnDecoded = jidDecode(pn);
++            const lidDecoded = jidDecode(oriented.lidJid);
++            const pnDecoded = jidDecode(oriented.pnJid);
+             if (!lidDecoded || !pnDecoded)
+                 continue;
+             validatedPairs.push({ pnUser: pnDecoded.user, lidUser: lidDecoded.user });
+@@ -232,7 +263,7 @@ export class LIDMappingStore {
              return true;
          };
          for (const lid of lids) {

--- a/src/baileys/helpers/historySync.spec.ts
+++ b/src/baileys/helpers/historySync.spec.ts
@@ -285,6 +285,20 @@ describe("restoring the addressing a dump strips", () => {
       expect(index.get("235085806727321")).toBe(PN);
     });
 
+    // A source that hands the pair over the other way round would otherwise index the LID
+    // as if it were the phone number, which is the exact shape this module exists to stop.
+    it("drops a pair whose phone side is not a phone address", () => {
+      const index = lidPnIndex([{ lid: LID, pn: "777888999@lid" }]);
+
+      expect(index.size).toBe(0);
+    });
+
+    it("drops a pair handed over reversed", () => {
+      const index = lidPnIndex([{ lid: PN, pn: LID }]);
+
+      expect(index.size).toBe(0);
+    });
+
     it("lets the earlier source win, which is the one describing this dump", () => {
       const index = lidPnIndex(
         [{ lid: LID, pn: PN }],

--- a/src/baileys/helpers/historySync.spec.ts
+++ b/src/baileys/helpers/historySync.spec.ts
@@ -215,8 +215,8 @@ describe("restoring the addressing a dump strips", () => {
   });
 
   // A business-hosted account is addressed on `hosted.lid`, which `jidDecode` reads as a
-  // LID domain and `isLidUser` -- a plain `@lid` suffix test -- does not. Left out, its
-  // chats kept the exact shape this whole change exists to fix.
+  // LID domain and upstream's `isLidUser` -- a plain `@lid` suffix test -- does not. Left
+  // out, its chats kept the exact shape this whole change exists to fix.
   describe("the hosted form of a LID", () => {
     const HOSTED = "235085806727321@hosted.lid";
 
@@ -226,7 +226,7 @@ describe("restoring the addressing a dump strips", () => {
       expect(message.key.addressingMode).toBe("lid");
     });
 
-    it("takes a hosted mapping out of the event, which is the only place one arrives", () => {
+    it("takes a hosted mapping out of the event like any other", () => {
       const [message] = restoreAddressing(
         [chatMessage(HOSTED)],
         lidPnIndex([{ lid: HOSTED, pn: "5511999999999@hosted" }]),
@@ -261,7 +261,7 @@ describe("restoring the addressing a dump strips", () => {
       expect(chatLidPnPairs([{ id: "120363@g.us", lidJid: LID }])).toEqual([]);
     });
 
-    it("carries a hosted chat, which is the only place its mapping arrives", () => {
+    it("carries a hosted chat, whose record is where the store first learns the pair", () => {
       expect(
         chatLidPnPairs([{ id: "777@hosted.lid", pnJid: "5511@hosted" }]),
       ).toEqual([{ lid: "777@hosted.lid", pn: "5511@hosted" }]);

--- a/src/baileys/helpers/historySync.ts
+++ b/src/baileys/helpers/historySync.ts
@@ -235,6 +235,12 @@ export function chatLidPnPairs(
 // before the ones that merely remember it. Phone jids are normalized, because
 // the mapping store answers with a device suffix (`:0`) that a live message
 // never carries.
+//
+// Both sides are checked against their domain, and a pair that fails either is dropped
+// rather than half-read. Which address is the LID and which is the phone is a fact about
+// the jid, never about the field it arrived in -- a pair handed over the other way round
+// would otherwise put a LID into `remoteJidAlt`, where a client reads it as a phone number.
+// That is the whole defect this module exists to close, arriving through the back door.
 export function lidPnIndex(
   ...sources: (readonly LIDMapping[] | null | undefined)[]
 ): Map<string, string> {
@@ -243,7 +249,10 @@ export function lidPnIndex(
     for (const { lid, pn } of source ?? []) {
       const user = lidUser(lid);
       const phone = splitJid(pn);
-      if (user && phone && !index.has(user)) {
+      if (!user || !phone || !PHONE_SERVERS.includes(phone.server)) {
+        continue;
+      }
+      if (!index.has(user)) {
         index.set(user, `${phone.user}@${phone.server}`);
       }
     }

--- a/src/baileys/helpers/historySync.ts
+++ b/src/baileys/helpers/historySync.ts
@@ -151,9 +151,11 @@ function splitJid(jid: string | null | undefined) {
 }
 
 // The two servers a LID lives on, `hosted.lid` being the business-hosted form. Both are
-// LID domains to `jidDecode`, but not to `isLidUser`, which is a plain `@lid` suffix test
-// -- so the mapping store never resolves a hosted LID, while the chat records in a dump do
-// carry mappings for one. Marking the address is the half that does not depend on either.
+// LID domains to `jidDecode`, but upstream's `isLidUser` is a plain `@lid` suffix test, and
+// it guarded the mapping store on both the write and the reverse read -- so a hosted pair
+// was warned away when the history handed it over and could never be read back. Patched;
+// see `hostedLidMapping.spec.ts`. Without it a hosted chat resolves only on the flush that
+// carries its own record, because the event buffer suppresses a record it has already seen.
 const LID_SERVERS = ["lid", "hosted.lid"];
 
 // The LID user a jid addresses, or undefined when the jid is not a LID.

--- a/src/baileys/hostedLidMapping.spec.ts
+++ b/src/baileys/hostedLidMapping.spec.ts
@@ -140,6 +140,48 @@ describe("hosted LID mapping patch", () => {
     );
   });
 
+  // `handleMessage` tests `altServer === 'lid'` strictly, so a hosted alternate takes its
+  // else branch and a PN-addressed hosted message hands the pair over the other way round.
+  // Upstream decoded positionally, so widening the guard without this would persist those
+  // backwards -- worse than dropping them, since the LID would then read as a phone number.
+  it("stores a reversed hosted pair the right way round", async () => {
+    const table = makeTable();
+    const { store, warnings } = makeStore(table);
+
+    await store.storeLIDPNMappings([{ lid: HOSTED_PN, pn: HOSTED_LID }]);
+
+    expect(warnings).toEqual([]);
+    expect(await store.getPNForLID(HOSTED_LID)).toBe("5511999999999:0@hosted");
+  });
+
+  it("stores a reversed ordinary pair the right way round", async () => {
+    const table = makeTable();
+    const { store } = makeStore(table);
+
+    await store.storeLIDPNMappings([{ lid: PLAIN_PN, pn: PLAIN_LID }]);
+
+    expect(await store.getPNForLID(PLAIN_LID)).toBe(
+      "5511888888888:0@s.whatsapp.net",
+    );
+  });
+
+  it("refuses a pair that names two LIDs", async () => {
+    const { store, warnings } = makeStore(makeTable());
+
+    await store.storeLIDPNMappings([{ lid: HOSTED_LID, pn: PLAIN_LID }]);
+
+    expect(warnings).toHaveLength(1);
+    expect(await store.getPNForLID(HOSTED_LID)).toBeNull();
+  });
+
+  it("refuses a pair that names two phone numbers", async () => {
+    const { store, warnings } = makeStore(makeTable());
+
+    await store.storeLIDPNMappings([{ lid: HOSTED_PN, pn: PLAIN_PN }]);
+
+    expect(warnings).toHaveLength(1);
+  });
+
   it("still refuses a pair that is neither addressing", async () => {
     const { store, warnings } = makeStore(makeTable());
 

--- a/src/baileys/hostedLidMapping.spec.ts
+++ b/src/baileys/hostedLidMapping.spec.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+// Deep specifier on purpose. The preload mocks "@whiskeysockets/baileys", so
+// importing the package would hand us the fake socket and never exercise the
+// patch. The package has no "exports" map, so this path resolves the real,
+// patched file — which is the only way these tests mean anything.
+import { LIDMappingStore } from "@whiskeysockets/baileys/lib/Signal/lid-mapping.js";
+
+const PATCHED_FILE =
+  "node_modules/@whiskeysockets/baileys/lib/Signal/lid-mapping.js";
+
+// A business-hosted account is addressed on `hosted` and `hosted.lid`. Upstream derives
+// those pairs on purpose in `processHistoryMessage` and hands them to this store, which
+// then threw every one of them away: `isPnUser` and `isLidUser` are plain suffix tests
+// for the non-hosted form, and they guarded both the write and the reverse read.
+const HOSTED_LID = "235085806727321@hosted.lid";
+const HOSTED_PN = "5511999999999@hosted";
+const PLAIN_LID = "777888999@lid";
+const PLAIN_PN = "5511888888888@s.whatsapp.net";
+
+function makeLogger() {
+  const warnings: string[] = [];
+  const logger = {
+    level: "silent",
+    trace: () => {},
+    debug: () => {},
+    info: () => {},
+    warn: (...args: unknown[]) => {
+      warnings.push(args.map(String).join(" "));
+    },
+    error: () => {},
+    child: () => logger,
+  };
+  return { logger, warnings };
+}
+
+// The persisted half of the store: a plain table keyed exactly the way
+// `storeLIDPNMappings` writes it, so a second store instance reads what the first wrote
+// instead of answering out of its own in-process LRU.
+function makeTable() {
+  return {} as Record<string, string>;
+}
+
+function makeStore(table: Record<string, string>) {
+  const { logger, warnings } = makeLogger();
+  const keys = {
+    get: async (type: string, ids: string[]) => {
+      if (type !== "lid-mapping") {
+        return {};
+      }
+      const found: Record<string, string> = {};
+      for (const id of ids) {
+        const value = table[id];
+        if (value) {
+          found[id] = value;
+        }
+      }
+      return found;
+    },
+    set: async (data: Record<string, Record<string, string>>) => {
+      Object.assign(table, data["lid-mapping"] ?? {});
+    },
+    transaction: async (work: () => Promise<void>) => {
+      await work();
+    },
+  };
+
+  // biome-ignore lint/suspicious/noExplicitAny: the store's key/logger types are baileys-internal.
+  const store = new LIDMappingStore(keys as any, logger as any, undefined);
+  return { store, warnings };
+}
+
+describe("hosted LID mapping patch", () => {
+  // The number one failure mode of a patch-based fix is the patch silently not
+  // applying after a dependency bump or a lockfile change. Everything else here
+  // would still pass against stale-but-loaded code, so check the file on disk.
+  it("is actually present in the installed package", () => {
+    const source = readFileSync(PATCHED_FILE, "utf8");
+    expect(source).toContain("isAnyLidUser");
+    expect(source).toContain("isAnyPnUser");
+  });
+
+  it("stores a hosted pair instead of warning it away", async () => {
+    const { store, warnings } = makeStore(makeTable());
+
+    await store.storeLIDPNMappings([{ lid: HOSTED_LID, pn: HOSTED_PN }]);
+
+    expect(warnings).toEqual([]);
+  });
+
+  // The whole point: a history dump names the pair once, and every later flush of the
+  // same sync arrives without the chat record that carried it. The store is what has to
+  // remember, and until this patch it could not.
+  it("answers for a hosted LID it was told about earlier", async () => {
+    const table = makeTable();
+    const first = makeStore(table);
+    await first.store.storeLIDPNMappings([{ lid: HOSTED_LID, pn: HOSTED_PN }]);
+
+    // A separate instance, so the answer comes off the persisted table rather than the
+    // in-process cache the write populated.
+    const second = makeStore(table);
+
+    expect(await second.store.getPNsForLIDs([HOSTED_LID])).toEqual([
+      { lid: HOSTED_LID, pn: "5511999999999:0@hosted" },
+    ]);
+  });
+
+  // The device suffix is the store's own doing, and a live message never carries one.
+  // `lidPnIndex` in historySync.ts strips it; this pins the shape it has to strip.
+  it("answers with the hosted phone domain, not the ordinary one", async () => {
+    const table = makeTable();
+    const { store } = makeStore(table);
+    await store.storeLIDPNMappings([{ lid: HOSTED_LID, pn: HOSTED_PN }]);
+
+    const pn = await store.getPNForLID(HOSTED_LID);
+
+    expect(pn?.endsWith("@hosted")).toBe(true);
+  });
+
+  it("still resolves an ordinary LID", async () => {
+    const table = makeTable();
+    const { store } = makeStore(table);
+    await store.storeLIDPNMappings([{ lid: PLAIN_LID, pn: PLAIN_PN }]);
+
+    expect(await store.getPNForLID(PLAIN_LID)).toBe(
+      "5511888888888:0@s.whatsapp.net",
+    );
+  });
+
+  // The table is keyed by user, and the two domains of one account share that user --
+  // `hosted` says how the account is reached, not who it is. So the domain of the answer
+  // follows the jid that was asked about, not the jid that was stored.
+  it("reads a hosted LID and its ordinary form as one account", async () => {
+    const table = makeTable();
+    const { store } = makeStore(table);
+    await store.storeLIDPNMappings([{ lid: HOSTED_LID, pn: HOSTED_PN }]);
+
+    expect(await store.getPNForLID("235085806727321@lid")).toBe(
+      "5511999999999:0@s.whatsapp.net",
+    );
+  });
+
+  it("still refuses a pair that is neither addressing", async () => {
+    const { store, warnings } = makeStore(makeTable());
+
+    await store.storeLIDPNMappings([
+      { lid: "120363000000000000@g.us", pn: HOSTED_PN },
+    ]);
+
+    expect(warnings).toHaveLength(1);
+    expect(await store.getPNForLID("120363000000000000@g.us")).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #387.

## The finding

Baileys' `LIDMappingStore` never accepted, and never answered for, a business-hosted account. `isPnUser` and `isLidUser` are plain suffix tests for `@s.whatsapp.net` and `@lid`, and they guarded two things:

- `storeLIDPNMappings`, which validated every incoming pair with them, so a `{lid: "…@hosted.lid", pn: "…@hosted"}` pair was logged as `Invalid LID-PN mapping` and dropped;
- `_getPNsForLIDsImpl`, which skipped any jid `isLidUser` rejected, so even a stored hosted pair could never be read back.

The rest of the file was already written for hosted accounts. `_getLIDsForPNsImpl` accepts a hosted PN and builds a `hosted.lid` answer off `decoded.server === 'hosted'`, and `addResolvedPair` in the reverse direction builds a `@hosted` jid off `WAJIDDomains.HOSTED_LID`. So does the caller: `processHistoryMessage` classifies chat records with `isHostedLidUser` / `isHostedPnUser` on purpose, derives the hosted pairs, and `process-message.js` hands them straight to `storeLIDPNMappings` -- which threw them away. Two guards left on the narrow test are the whole of it.

## Why it mattered

A history dump names a chat's LID/phone pair exactly once, in that chat's record. The event buffer's `historyCache` lives for the whole connection while its `data` resets on each flush, so a record it has already seen is suppressed on every later flush of the same sync. For an ordinary LID that is harmless, because Baileys stored the pair on flush 1 and the store covers the rest. For a hosted LID the store refused to store it and refused to answer, so every flush after the first delivered messages the bridge could not attach a phone number to, and the contact landed in Chatwoot with the field blank.

## The change

`patches/@whiskeysockets%2Fbaileys@7.0.0-rc14.patch` gains a hunk on `lib/Signal/lid-mapping.js`: import `isHostedLidUser`, define `isAnyLidUser` / `isAnyPnUser`, and use them in the two guards. Nothing else moves.

The mapping table is keyed by *user*, not by jid, and the two domains of one account share that user -- `hosted` says how the account is reached, not who it is. So the pairs belong in the same table, and the reverse lookup rebuilds the correct domain from the `domainType` of the jid it was asked about. `src/baileys/hostedLidMapping.spec.ts` pins that, alongside the ordinary-LID path and the still-rejected garbage pair.

The spec deep-imports the real patched file (`@whiskeysockets/baileys/lib/Signal/lid-mapping.js`), the way `authTransactionTimeout.spec.ts` and `linkPreviewTimeout.spec.ts` already do, because the test preload mocks the package specifier. Its first assertion reads the installed file off disk, so a lockfile change that silently drops the patch fails the suite instead of passing against stale code.

Verified the tests are load-bearing: reverting just the two guards in `node_modules` (keeping the helpers, so the on-disk check still passes) fails 4 of the 7.

## Also in here

- `historySync.ts` and `historySync.spec.ts` carried comments asserting the store never resolves a hosted LID and that the chat record is "the only place" its mapping arrives. Both are now false; rewritten.
- The `.codex-review-waived` entry for this is removed. It was waived on #386 because the fix then looked like new per-connection cache state; it turned out to be two characters of guard in a dependency we already patch.

## Checks

`bun check` clean: biome, `tsc --noEmit`, and 715 tests across 34 files.

## Not covered

The bridge now emits `remoteJidAlt: "<phone>@hosted"` for a hosted chat. Chatwoot's `PHONE_JID_SERVERS` does not include `hosted`, so it still discards that value; a companion PR on the Chatwoot side handles it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/baileys-api/388)
<!-- Reviewable:end -->
