### PR TITLE
fix(messages): deliver the edit a contact makes, instead of a blob

### DIFF
--- a/.codex-review-waived
+++ b/.codex-review-waived
@@ -17,3 +17,9 @@ swagger.json: Restore the actual send-message conflict response
 # Third round in a row on hosted LIDs; declined at the point the fix stopped being a
 # rule and started being a cache: https://github.com/fazer-ai/baileys-api/pull/386
 src/baileys/*.ts: Preserve hosted mappings across history events
+# Ordering across a connection handoff: editDeliveryQueue and editedAt are
+# connection-local, and a handoff leaves the old connection draining while the
+# new one runs. Deliberately not fixed here; the reasoning, the cost of a shared
+# guard and the correction path (the consumer, which knows what it applied) are
+# in fazer-ai/baileys-api#393.
+src/baileys/connection.ts: Preserve edit ordering across connection handoffs

--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,11 @@ BAILEYS_TX_ACQUIRE_TIMEOUT_MS=300000
 BAILEYS_TX_HOLD_WARN_MS=30000
 # Deadline on a single send. Must be lower than PROXY_REQUEST_TIMEOUT_MS.
 BAILEYS_SEND_TIMEOUT_MS=45000
+# How long delivering a message may wait on the message-secret store, which is
+# what makes a contact's edit decryptable later. Filing one is a side effect of
+# delivery, never a reason to withhold the message: a Redis disconnect parks the
+# command on node-redis's offline queue until it reconnects.
+BAILEYS_MESSAGE_SECRET_STORE_TIMEOUT_MS=5000
 # Allow a connection whose sends keep timing out to recreate its own socket.
 # Off by default: turn it on after watching the detector fire only on the real
 # pattern. Detection, logging and the webhook run either way.

--- a/src/baileys/connection.spec.ts
+++ b/src/baileys/connection.spec.ts
@@ -686,7 +686,9 @@ describe("BaileysConnection", () => {
       const encIv = randomBytes(12);
       const key = messageEditKey({
         ...senders,
-        origMsgId: ORIG_ID,
+        // The derivation is bound to the message being edited, so it follows
+        // the target key rather than the default one.
+        origMsgId: targetKey.id as string,
         messageSecret,
       });
       const cipher = createCipheriv("aes-256-gcm", key, encIv);
@@ -946,7 +948,7 @@ describe("BaileysConnection", () => {
       await drain();
 
       expect(
-        (redis as any).__stringData.has(
+        (redis as any).__hashData.has(
           messageSecretKey("+5511999999999", ORIG_ID),
         ),
       ).toBe(true);
@@ -1044,16 +1046,16 @@ describe("BaileysConnection", () => {
     // queued behind its delivery slot.
     it("still delivers the batch when the secret store never answers", async () => {
       await connect();
-      const realSet = (redis as any).set;
+      const realSet = (redis as any).hSet;
       const realTimeout = config.baileys.messageSecretStoreTimeoutMs;
       // Never settles, which is exactly what an offline queue does.
-      (redis as any).set = mock(() => new Promise(() => {}));
+      (redis as any).hSet = mock(() => new Promise(() => {}));
       (config.baileys as any).messageSecretStoreTimeoutMs = 20;
 
       try {
         await deliver([original()]);
       } finally {
-        (redis as any).set = realSet;
+        (redis as any).hSet = realSet;
         (config.baileys as any).messageSecretStoreTimeoutMs = realTimeout;
       }
 
@@ -1142,7 +1144,7 @@ describe("BaileysConnection", () => {
       await drain();
 
       expect(
-        (redis as any).__stringData.has(
+        (redis as any).__hashData.has(
           messageSecretKey("+5511999999999", ORIG_ID),
         ),
       ).toBe(false);
@@ -1154,9 +1156,9 @@ describe("BaileysConnection", () => {
     // connection from the drain set and exited on top of the message.
     it("counts a batch waiting on the secret store as work to drain", async () => {
       await connect();
-      const realSet = (redis as any).set;
+      const realSet = (redis as any).hSet;
       let releaseSet: (() => void) | undefined;
-      (redis as any).set = mock(
+      (redis as any).hSet = mock(
         () =>
           new Promise<void>((resolve) => {
             releaseSet = resolve;
@@ -1173,7 +1175,7 @@ describe("BaileysConnection", () => {
         releaseSet?.();
         await delivery;
       } finally {
-        (redis as any).set = realSet;
+        (redis as any).hSet = realSet;
       }
 
       await drain();
@@ -1182,9 +1184,9 @@ describe("BaileysConnection", () => {
 
     it("counts a dump waiting on the secret store as work to drain", async () => {
       await connect();
-      const realSet = (redis as any).set;
+      const realSet = (redis as any).hSet;
       let releaseSet: (() => void) | undefined;
-      (redis as any).set = mock(
+      (redis as any).hSet = mock(
         () =>
           new Promise<void>((resolve) => {
             releaseSet = resolve;
@@ -1207,7 +1209,7 @@ describe("BaileysConnection", () => {
         releaseSet?.();
         await delivery;
       } finally {
-        (redis as any).set = realSet;
+        (redis as any).hSet = realSet;
       }
 
       await drain();
@@ -1239,7 +1241,7 @@ describe("BaileysConnection", () => {
       expect(messages[0].message.conversation).toBe("oi editado");
       // Still not worth storing: nothing can edit it again.
       expect(
-        (redis as any).__stringData.has(
+        (redis as any).__hashData.has(
           messageSecretKey("+5511999999999", ORIG_ID),
         ),
       ).toBe(false);
@@ -1254,9 +1256,9 @@ describe("BaileysConnection", () => {
       await deliver([original()]);
       fetchCalls.length = 0;
 
-      const realSet = (redis as any).set;
+      const realSet = (redis as any).hSet;
       let releaseSet: (() => void) | undefined;
-      (redis as any).set = mock(
+      (redis as any).hSet = mock(
         () =>
           new Promise<void>((resolve) => {
             releaseSet = resolve;
@@ -1290,7 +1292,7 @@ describe("BaileysConnection", () => {
         releaseSet?.();
         await stalls;
       } finally {
-        (redis as any).set = realSet;
+        (redis as any).hSet = realSet;
       }
       await drain();
 
@@ -1309,7 +1311,7 @@ describe("BaileysConnection", () => {
     // cannot cancel, so a long outage would retain one command per message.
     it("does not queue a secret write while the store is disconnected", async () => {
       await connect();
-      const before = (redis as any).set.mock.calls.length;
+      const before = (redis as any).hSet.mock.calls.length;
       (redis as any).isReady = false;
 
       try {
@@ -1318,7 +1320,7 @@ describe("BaileysConnection", () => {
         (redis as any).isReady = true;
       }
 
-      expect((redis as any).set.mock.calls.length).toBe(before);
+      expect((redis as any).hSet.mock.calls.length).toBe(before);
       const upsert = fetchCalls.find((c) =>
         c.body?.includes('"event":"messages.upsert"'),
       );
@@ -1463,12 +1465,9 @@ describe("BaileysConnection", () => {
       await connect();
       // Filed by an earlier connection: the store is all this one inherits.
       const own = "89572297961476@lid";
-      (redis as any).__stringData.set(
+      (redis as any).__hashData.set(
         messageSecretKey("+5511999999999", ORIG_ID),
-        JSON.stringify({
-          secret: Buffer.from(messageSecret).toString("base64"),
-          senders: [],
-        }),
+        new Map([["secret", Buffer.from(messageSecret).toString("base64")]]),
       );
 
       const handler = mockEventHandlers.get("messages.upsert")!;
@@ -1687,6 +1686,78 @@ describe("BaileysConnection", () => {
       expect(texts).toEqual(["segunda"]);
     });
 
+    // Ordering is only owed to two edits of the SAME message. A single chain for
+    // the connection would put one edit's retry ladder, minutes long, in front
+    // of every other chat's edits, for an ordering none of them need.
+    it("delivers an edit for another message while one is stuck retrying", async () => {
+      await connect();
+      const OTHER_ID = "3EB0AAAAAAAAAAAAAAAAAA";
+      await deliver([
+        original(),
+        { ...original(), key: { ...original().key, id: OTHER_ID } },
+      ]);
+      fetchCalls.length = 0;
+
+      let releaseStuck: (() => void) | undefined;
+      const stuck = new Promise<void>((resolve) => {
+        releaseStuck = resolve;
+      });
+      const realFetch = globalThis.fetch;
+      globalThis.fetch = mock(async (url: any, init?: RequestInit) => {
+        const body = init?.body as string;
+        if (
+          body?.includes('"event":"messages.update"') &&
+          body.includes(ORIG_ID)
+        ) {
+          await stuck;
+        }
+        return realFetch(url, init);
+      }) as any;
+
+      const handler = mockEventHandlers.get("messages.upsert")!;
+      try {
+        const blocked = handler({
+          type: "notify",
+          messages: [edit("presa", undefined, { id: "edit-1" })],
+        });
+        await new Promise((r) => setImmediate(r));
+
+        await handler({
+          type: "notify",
+          messages: [
+            edit("livre", undefined, {
+              id: "edit-2",
+              targetKey: {
+                remoteJid: "89572297961476@lid",
+                fromMe: true,
+                id: OTHER_ID,
+              },
+            }),
+          ],
+        });
+        // Still stuck, and the other message's edit is already out. Polled
+        // rather than waited on: the stuck chain never settles, so there is no
+        // promise to await, only a bound on how long the free one may take.
+        const updates = () =>
+          fetchCalls.filter((c) =>
+            c.body?.includes('"event":"messages.update"'),
+          );
+        for (let tick = 0; tick < 50 && updates().length === 0; tick += 1) {
+          await new Promise((r) => setImmediate(r));
+        }
+        const delivered = fetchCalls
+          .filter((c) => c.body?.includes('"event":"messages.update"'))
+          .map((c) => JSON.parse(c.body).data[0].key.id);
+        expect(delivered).toEqual([OTHER_ID]);
+
+        releaseStuck?.();
+        await blocked;
+        await drain();
+      } finally {
+        globalThis.fetch = realFetch;
+      }
+    });
+
     // Baileys builds a chat's history array newest-first (it keeps msgs[0] as
     // "the most recent message in the chat"), so walking it straight applies the
     // newest replacement and then overwrites it with an older one.
@@ -1762,11 +1833,16 @@ describe("BaileysConnection", () => {
       });
       await drain();
 
-      const stored = JSON.parse(
-        (redis as any).__stringData.get(
-          messageSecretKey("+5511999999999", ORIG_ID),
-        ),
-      );
+      const stored = {
+        senders: [
+          ...((redis as any).__hashData.get(
+            messageSecretKey("+5511999999999", ORIG_ID),
+          ) as Map<string, string>),
+        ]
+          .map(([field]) => field)
+          .filter((field) => field.startsWith("jid:"))
+          .map((field) => field.slice("jid:".length)),
+      };
       expect(stored.senders).toEqual([CHAT, CHAT_PN]);
     });
 

--- a/src/baileys/connection.spec.ts
+++ b/src/baileys/connection.spec.ts
@@ -730,15 +730,19 @@ describe("BaileysConnection", () => {
       }
     }
 
-    beforeEach(() => {
+    // `mockSocket` is a proxy onto the LATEST socket makeWASocket produced, so
+    // the account JIDs have to be set after connecting: assigning them in a
+    // beforeEach writes them to the socket the connection is about to replace.
+    async function connect() {
+      await connection.connect();
       mockSocket.user = {
         id: "5511999999999:12@s.whatsapp.net",
         lid: "89572297961476@lid",
       };
-    });
+    }
 
     it("delivers the edit as a messages.update against the original", async () => {
-      await connection.connect();
+      await connect();
 
       await deliver([original()]);
       await deliver([edit("oi editado")]);
@@ -756,7 +760,7 @@ describe("BaileysConnection", () => {
     });
 
     it("does not forward the encrypted node as a message", async () => {
-      await connection.connect();
+      await connect();
 
       await deliver([original()]);
       fetchCalls.length = 0;
@@ -770,7 +774,7 @@ describe("BaileysConnection", () => {
     // The batch is not all-or-nothing: a real message sharing the frame with an
     // edit still has to arrive.
     it("keeps the other messages in the same batch", async () => {
-      await connection.connect();
+      await connect();
 
       await deliver([original()]);
       fetchCalls.length = 0;
@@ -794,7 +798,7 @@ describe("BaileysConnection", () => {
     // original this instance never saw is undecryptable. Dropping it is still
     // better than the bubble: there is no content to show either way.
     it("drops an edit whose original it never saw", async () => {
-      await connection.connect();
+      await connect();
 
       await deliver([edit("oi editado")]);
 
@@ -804,7 +808,7 @@ describe("BaileysConnection", () => {
     // LID migration means the same person is addressed two ways and only one of
     // them went into the derivation; the tag check makes trying both safe.
     it("finds the key when the derivation used the phone-number JID", async () => {
-      await connection.connect();
+      await connect();
 
       await deliver([original()]);
       await deliver([
@@ -825,7 +829,7 @@ describe("BaileysConnection", () => {
     // itself. Delivering an update alongside the message it edits was what four
     // rounds of barriers and chains were built to sequence.
     it("applies an edit to a message in its own batch, with no update event", async () => {
-      await connection.connect();
+      await connect();
 
       await deliver([original(), edit("oi editado")]);
 
@@ -844,7 +848,7 @@ describe("BaileysConnection", () => {
     // secret suspends before sendToWebhook counts anything. A shutdown reading
     // the count in that gap would exit on top of the edit.
     it("counts a pending edit as work a graceful shutdown must drain", async () => {
-      await connection.connect();
+      await connect();
       await deliver([original()]);
 
       const handler = mockEventHandlers.get("messages.upsert")!;
@@ -859,7 +863,7 @@ describe("BaileysConnection", () => {
     // re-reading the message afterwards to file it finds nothing — and the NEXT
     // edit to that message arrives with no key.
     it("keeps a repaired message decryptable for its next edit", async () => {
-      await connection.connect();
+      await connect();
 
       await deliver([original(), edit("primeira")]);
       fetchCalls.length = 0;
@@ -879,7 +883,7 @@ describe("BaileysConnection", () => {
     // the target exists both are answered 200, so a first edit working through
     // a retry can land after a second and the older text wins.
     it("delivers two edits of one message in order, even when the first retries", async () => {
-      await connection.connect();
+      await connect();
       await deliver([original()]);
       fetchCalls.length = 0;
 
@@ -924,7 +928,7 @@ describe("BaileysConnection", () => {
     // arrives, not the fifteen minutes an author has to create the edit: the
     // edit is valid when created and only replayed to us much later.
     it("keeps the secret of a dump message older than the edit window", async () => {
-      await connection.connect();
+      await connect();
       const historyHandler = mockEventHandlers.get("messaging-history.set")!;
 
       await historyHandler({
@@ -947,7 +951,7 @@ describe("BaileysConnection", () => {
     // straight out of the batch loop: a disconnect at the wrong moment silently
     // dropped every ordinary message that shared the frame with an edit.
     it("keeps delivering the batch when the secret lookup fails", async () => {
-      await connection.connect();
+      await connect();
       await deliver([original()]);
       fetchCalls.length = 0;
       // Swapped and restored by hand rather than with spyOn: the redis module is
@@ -981,7 +985,7 @@ describe("BaileysConnection", () => {
     // A wrapper keeps its context outside itself, so normalizing walks straight
     // past the secret and every edit to a disappearing message stops decrypting.
     it("files the secret of a message wrapped as ephemeral", async () => {
-      await connection.connect();
+      await connect();
       const wrapped = original();
 
       await deliver([
@@ -1004,7 +1008,7 @@ describe("BaileysConnection", () => {
     // original whose edit window is still open, and the live edit that follows
     // has nothing to decrypt with unless the dump was read for secrets too.
     it("files the secret of a message that arrived in a history dump", async () => {
-      await connection.connect();
+      await connect();
       const historyHandler = mockEventHandlers.get("messaging-history.set")!;
 
       // A dump carries the secret on the WebMessageInfo, not in the content.
@@ -1034,7 +1038,7 @@ describe("BaileysConnection", () => {
     // reconnects, and unbounded that would hold the message AND every edit
     // queued behind its delivery slot.
     it("still delivers the batch when the secret store never answers", async () => {
-      await connection.connect();
+      await connect();
       const realSet = (redis as any).set;
       const realTimeout = config.baileys.messageSecretStoreTimeoutMs;
       // Never settles, which is exactly what an offline queue does.
@@ -1060,7 +1064,7 @@ describe("BaileysConnection", () => {
     // one. There is nothing left to repair in place by then, but the secret was
     // filed, so the edit is still readable and goes out as a live update.
     it("sends a dump edit whose original arrived in an earlier dump", async () => {
-      await connection.connect();
+      await connect();
       const historyHandler = mockEventHandlers.get("messaging-history.set")!;
 
       await historyHandler({
@@ -1094,7 +1098,7 @@ describe("BaileysConnection", () => {
     // importer decides its own ordering, so an update would race the very write
     // it targets.
     it("applies an edit inside a dump to the message it edits", async () => {
-      await connection.connect();
+      await connect();
       const historyHandler = mockEventHandlers.get("messaging-history.set")!;
 
       await historyHandler({
@@ -1120,7 +1124,7 @@ describe("BaileysConnection", () => {
     // A full archive still reaches back past any replay window. Filing those
     // secrets leaves a keyspace nothing can ever read.
     it("does not file the secret of a message too old to still be replayed", async () => {
-      await connection.connect();
+      await connect();
       const historyHandler = mockEventHandlers.get("messaging-history.set")!;
 
       await historyHandler({
@@ -1144,7 +1148,7 @@ describe("BaileysConnection", () => {
     // whole write: a handoff or SIGTERM landing on a slow Redis dropped this
     // connection from the drain set and exited on top of the message.
     it("counts a batch waiting on the secret store as work to drain", async () => {
-      await connection.connect();
+      await connect();
       const realSet = (redis as any).set;
       let releaseSet: (() => void) | undefined;
       (redis as any).set = mock(
@@ -1172,7 +1176,7 @@ describe("BaileysConnection", () => {
     });
 
     it("counts a dump waiting on the secret store as work to drain", async () => {
-      await connection.connect();
+      await connect();
       const realSet = (redis as any).set;
       let releaseSet: (() => void) | undefined;
       (redis as any).set = mock(
@@ -1210,7 +1214,7 @@ describe("BaileysConnection", () => {
     // that edit is decryptable right there. Letting the retention filter shrink
     // the in-batch map loses an edit whose key was in hand.
     it("applies an in-batch edit to an original too old to file", async () => {
-      await connection.connect();
+      await connect();
       const historyHandler = mockEventHandlers.get("messaging-history.set")!;
 
       await historyHandler({
@@ -1241,7 +1245,7 @@ describe("BaileysConnection", () => {
     // split can suspend: an older edit behind a slow secret write would reach
     // the queue after a newer edit that arrived later, and the older text wins.
     it("queues an edit ahead of a later one even when its batch stalls", async () => {
-      await connection.connect();
+      await connect();
       await deliver([original()]);
       fetchCalls.length = 0;
 
@@ -1299,7 +1303,7 @@ describe("BaileysConnection", () => {
     // down and replays them on reconnect. withTimeout stops us awaiting; it
     // cannot cancel, so a long outage would retain one command per message.
     it("does not queue a secret write while the store is disconnected", async () => {
-      await connection.connect();
+      await connect();
       const before = (redis as any).set.mock.calls.length;
       (redis as any).isReady = false;
 
@@ -1323,7 +1327,7 @@ describe("BaileysConnection", () => {
     // resolving LIDs finds nothing, and that miss is final: the edit emits
     // nothing, so there is no 404 and no retry to recover it.
     it("waits for a dump still filing the secret before looking it up", async () => {
-      await connection.connect();
+      await connect();
 
       let releaseAddressing: (() => void) | undefined;
       mockSocket.signalRepository.lidMapping.getPNsForLIDs.mockImplementationOnce(
@@ -1364,11 +1368,93 @@ describe("BaileysConnection", () => {
       ).toBe("oi editado");
     });
 
+    // Nothing this connection can do guarantees arrival order: the callbacks run
+    // concurrently, a dump resolves addressing before it knows what it holds,
+    // and a retried delivery lands after one that was not retried. So the guard
+    // is on the outcome: an older edit changes nothing, however it got here.
+    it("ignores an edit older than one already applied", async () => {
+      await connect();
+      await deliver([original()]);
+      await deliver([edit("segunda", undefined, { id: "edit-2" })]);
+      fetchCalls.length = 0;
+
+      await deliver([
+        edit("primeira", undefined, { id: "edit-1", ageSeconds: 30 }),
+      ]);
+
+      expect(
+        fetchCalls.some((c) => c.body?.includes('"event":"messages.update"')),
+      ).toBe(false);
+    });
+
+    // Two edits stamped in the same second carry no order of their own, so the
+    // guard has to let both through and leave the queue to order them.
+    it("still delivers a second edit stamped in the same second", async () => {
+      await connect();
+      await deliver([original()]);
+      await deliver([edit("primeira", undefined, { id: "edit-1" })]);
+      fetchCalls.length = 0;
+
+      await deliver([edit("segunda", undefined, { id: "edit-2" })]);
+
+      const update = fetchCalls.find((c) =>
+        c.body?.includes('"event":"messages.update"'),
+      );
+      expect(
+        JSON.parse(update?.body as string).data[0].update.message.editedMessage
+          .message.conversation,
+      ).toBe("segunda");
+    });
+
+    // A handoff clears the socket and leaves the queued webhooks draining. An
+    // edit still in that queue derives its key from the account's own JIDs, and
+    // reading them off a socket that is gone yields no candidate at all.
+    it("derives a fromMe edit's key after the socket is gone", async () => {
+      await connect();
+      await deliver([
+        {
+          ...original(),
+          key: { ...original().key, fromMe: true },
+        },
+      ]);
+      fetchCalls.length = 0;
+
+      const handler = mockEventHandlers.get("messages.upsert")!;
+      const own = "89572297961476@lid";
+      const delivery = handler({
+        type: "notify",
+        messages: [
+          {
+            ...edit("oi editado", { origMsgSender: own, editSender: own }),
+            key: {
+              remoteJid: CHAT,
+              fromMe: true,
+              id: "edit-1",
+            },
+          },
+        ],
+      });
+      // The socket goes while the edit is still queued, which is exactly what a
+      // handoff does.
+      (connection as any).socket = undefined;
+      await delivery;
+      await drain();
+
+      const update = fetchCalls.find((c) =>
+        c.body?.includes('"event":"messages.update"'),
+      );
+      expect(update).toBeDefined();
+      expect(
+        JSON.parse(update?.body as string).data[0].update.message.editedMessage
+          .message.conversation,
+      ).toBe("oi editado");
+    });
+
     // Baileys builds a chat's history array newest-first (it keeps msgs[0] as
     // "the most recent message in the chat"), so walking it straight applies the
     // newest replacement and then overwrites it with an older one.
     it("applies the newest edit last when a dump carries two of them", async () => {
-      await connection.connect();
+      await connect();
       const historyHandler = mockEventHandlers.get("messaging-history.set")!;
 
       await historyHandler({
@@ -1397,7 +1483,7 @@ describe("BaileysConnection", () => {
     // drops the wrapper, and the consumer reads what looks like an ordinary,
     // non-disappearing message.
     it("keeps the disappearing-message wrapper when repairing in place", async () => {
-      await connection.connect();
+      await connect();
       const wrapped = original();
 
       await deliver([
@@ -1426,7 +1512,7 @@ describe("BaileysConnection", () => {
     // it records half the candidates, and an edit derived from the form that
     // was dropped never verifies.
     it("files both JID forms of an author a dump addressed by LID alone", async () => {
-      await connection.connect();
+      await connect();
       const historyHandler = mockEventHandlers.get("messaging-history.set")!;
 
       await historyHandler({
@@ -1448,7 +1534,7 @@ describe("BaileysConnection", () => {
     });
 
     it("keeps an encrypted edit out of the history frame", async () => {
-      await connection.connect();
+      await connect();
       const historyHandler = mockEventHandlers.get("messaging-history.set")!;
 
       await historyHandler({

--- a/src/baileys/connection.spec.ts
+++ b/src/baileys/connection.spec.ts
@@ -730,6 +730,36 @@ describe("BaileysConnection", () => {
     // An edit is delivered outside the callback that saw it, so waiting a tick
     // is not enough — wait for the connection to report nothing pending, which
     // is the same count a graceful shutdown drains on.
+    // The store writes through a transaction, so what has to be held is exec,
+    // not the command that was queued into it.
+    function stallSecretStore(): {
+      release: () => void;
+      restore: () => void;
+    } {
+      const realMulti = (redis as any).multi;
+      let release: (() => void) | undefined;
+      const held = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      (redis as any).multi = mock(() => {
+        const chain: any = {
+          hSet: () => chain,
+          expire: () => chain,
+          exec: async () => {
+            await held;
+            return [];
+          },
+        };
+        return chain;
+      });
+      return {
+        release: () => release?.(),
+        restore: () => {
+          (redis as any).multi = realMulti;
+        },
+      };
+    }
+
     async function drain() {
       await new Promise((r) => setImmediate(r));
       while (connection.inFlightWebhooks > 0) {
@@ -1046,16 +1076,15 @@ describe("BaileysConnection", () => {
     // queued behind its delivery slot.
     it("still delivers the batch when the secret store never answers", async () => {
       await connect();
-      const realSet = (redis as any).hSet;
+      const stalled = stallSecretStore();
       const realTimeout = config.baileys.messageSecretStoreTimeoutMs;
-      // Never settles, which is exactly what an offline queue does.
-      (redis as any).hSet = mock(() => new Promise(() => {}));
+      // Never released, which is exactly what an offline queue does.
       (config.baileys as any).messageSecretStoreTimeoutMs = 20;
 
       try {
         await deliver([original()]);
       } finally {
-        (redis as any).hSet = realSet;
+        stalled.restore();
         (config.baileys as any).messageSecretStoreTimeoutMs = realTimeout;
       }
 
@@ -1156,14 +1185,7 @@ describe("BaileysConnection", () => {
     // connection from the drain set and exited on top of the message.
     it("counts a batch waiting on the secret store as work to drain", async () => {
       await connect();
-      const realSet = (redis as any).hSet;
-      let releaseSet: (() => void) | undefined;
-      (redis as any).hSet = mock(
-        () =>
-          new Promise<void>((resolve) => {
-            releaseSet = resolve;
-          }),
-      );
+      const stalled = stallSecretStore();
 
       try {
         const handler = mockEventHandlers.get("messages.upsert")!;
@@ -1172,10 +1194,10 @@ describe("BaileysConnection", () => {
 
         expect(connection.inFlightWebhooks).toBeGreaterThan(0);
 
-        releaseSet?.();
+        stalled.release();
         await delivery;
       } finally {
-        (redis as any).hSet = realSet;
+        stalled.restore();
       }
 
       await drain();
@@ -1184,14 +1206,7 @@ describe("BaileysConnection", () => {
 
     it("counts a dump waiting on the secret store as work to drain", async () => {
       await connect();
-      const realSet = (redis as any).hSet;
-      let releaseSet: (() => void) | undefined;
-      (redis as any).hSet = mock(
-        () =>
-          new Promise<void>((resolve) => {
-            releaseSet = resolve;
-          }),
-      );
+      const stalled = stallSecretStore();
 
       try {
         const historyHandler = mockEventHandlers.get("messaging-history.set")!;
@@ -1206,10 +1221,10 @@ describe("BaileysConnection", () => {
 
         expect(connection.inFlightWebhooks).toBeGreaterThan(0);
 
-        releaseSet?.();
+        stalled.release();
         await delivery;
       } finally {
-        (redis as any).hSet = realSet;
+        stalled.restore();
       }
 
       await drain();
@@ -1256,14 +1271,7 @@ describe("BaileysConnection", () => {
       await deliver([original()]);
       fetchCalls.length = 0;
 
-      const realSet = (redis as any).hSet;
-      let releaseSet: (() => void) | undefined;
-      (redis as any).hSet = mock(
-        () =>
-          new Promise<void>((resolve) => {
-            releaseSet = resolve;
-          }),
-      );
+      const stalled = stallSecretStore();
 
       const handler = mockEventHandlers.get("messages.upsert")!;
       try {
@@ -1289,10 +1297,10 @@ describe("BaileysConnection", () => {
           messages: [edit("segunda", undefined, { id: "edit-2" })],
         });
 
-        releaseSet?.();
+        stalled.release();
         await stalls;
       } finally {
-        (redis as any).hSet = realSet;
+        stalled.restore();
       }
       await drain();
 
@@ -1311,7 +1319,7 @@ describe("BaileysConnection", () => {
     // cannot cancel, so a long outage would retain one command per message.
     it("does not queue a secret write while the store is disconnected", async () => {
       await connect();
-      const before = (redis as any).hSet.mock.calls.length;
+      const before = (redis as any).multi.mock.calls.length;
       (redis as any).isReady = false;
 
       try {
@@ -1320,7 +1328,7 @@ describe("BaileysConnection", () => {
         (redis as any).isReady = true;
       }
 
-      expect((redis as any).hSet.mock.calls.length).toBe(before);
+      expect((redis as any).multi.mock.calls.length).toBe(before);
       const upsert = fetchCalls.find((c) =>
         c.body?.includes('"event":"messages.upsert"'),
       );

--- a/src/baileys/connection.spec.ts
+++ b/src/baileys/connection.spec.ts
@@ -18,6 +18,10 @@ import * as baileysModule from "@whiskeysockets/baileys";
 import { WAMessageStatus } from "@whiskeysockets/baileys";
 import { proto as realProto } from "@whiskeysockets/baileys/WAProto/index.js";
 import { messageEditKey } from "@/baileys/helpers/decryptMessageEdit";
+import {
+  MESSAGE_SECRET_TTL_SECONDS,
+  messageSecretKey,
+} from "@/baileys/helpers/messageSecretStore";
 import { preprocessAudio } from "@/baileys/helpers/preprocessAudio";
 import { clusterKeys } from "@/cluster/keys";
 import * as sendStallStore from "@/cluster/sendStallStore";
@@ -643,6 +647,22 @@ describe("BaileysConnection", () => {
       };
     }
 
+    // The same message as a history dump delivers it: the secret on the
+    // WebMessageInfo rather than in the content, and no `remoteJidAlt` — a dump
+    // strips the addressing, which `addressHistory` puts back.
+    //
+    // The timestamp is relative to now because a dump's secrets are only filed
+    // while an edit could still target them; a fixed epoch would pass today and
+    // start failing an hour from now.
+    function dumped(ageSeconds = 60) {
+      return {
+        key: { remoteJid: CHAT, fromMe: false, id: ORIG_ID },
+        messageTimestamp: Math.floor(Date.now() / 1000) - ageSeconds,
+        message: { conversation: "oi" },
+        messageSecret,
+      };
+    }
+
     // Seals a replacement body the way the sending client does: HKDF over the
     // original's secret bound to both parties, then AES-256-GCM with the tag
     // appended.
@@ -873,14 +893,7 @@ describe("BaileysConnection", () => {
       await historyHandler({
         chats: [],
         contacts: [],
-        messages: [
-          {
-            key: { remoteJid: CHAT, fromMe: false, id: ORIG_ID },
-            messageTimestamp: 1788389210,
-            message: { conversation: "oi" },
-            messageSecret,
-          },
-        ],
+        messages: [dumped()],
         syncType: 3,
         isLatest: true,
       });
@@ -898,6 +911,128 @@ describe("BaileysConnection", () => {
       ).toBe("oi editado");
     });
 
+    // Baileys does not await its listeners, so two upsert callbacks can be in
+    // flight at once and awaiting inside one orders nothing against the other.
+    // The edit has to wait on the upsert deliveries that were already running,
+    // not just on its own batch.
+    it("holds an edit behind an upsert still in flight from an earlier callback", async () => {
+      await connection.connect();
+      const handler = mockEventHandlers.get("messages.upsert")!;
+      let releaseUpsert: (() => void) | undefined;
+      const slowUpsert = new Promise<void>((resolve) => {
+        releaseUpsert = resolve;
+      });
+      const realFetch = globalThis.fetch;
+      globalThis.fetch = mock(async (url: any, init?: RequestInit) => {
+        if ((init?.body as string)?.includes('"event":"messages.upsert"')) {
+          await slowUpsert;
+        }
+        return realFetch(url, init);
+      }) as any;
+
+      // Not awaited: this is the callback that is still running when the next
+      // one arrives, which is the whole situation under test.
+      const first = handler({ type: "notify", messages: [original()] });
+      await new Promise((r) => setImmediate(r));
+      await handler({ type: "notify", messages: [edit("oi editado")] });
+      await new Promise((r) => setImmediate(r));
+
+      expect(
+        fetchCalls.some((c) => c.body?.includes('"event":"messages.update"')),
+      ).toBe(false);
+
+      releaseUpsert?.();
+      await first;
+      while (connection.inFlightWebhooks > 0) {
+        await new Promise((r) => setImmediate(r));
+      }
+      globalThis.fetch = realFetch;
+
+      const upsertAt = fetchCalls.findIndex((c) =>
+        c.body?.includes('"event":"messages.upsert"'),
+      );
+      const updateAt = fetchCalls.findIndex((c) =>
+        c.body?.includes('"event":"messages.update"'),
+      );
+      expect(updateAt).toBeGreaterThan(upsertAt);
+    });
+
+    // A dump is repaired in place rather than re-narrated as an update: an
+    // importer decides its own ordering, so an update would race the very write
+    // it targets.
+    it("applies an edit inside a dump to the message it edits", async () => {
+      await connection.connect();
+      const historyHandler = mockEventHandlers.get("messaging-history.set")!;
+
+      await historyHandler({
+        chats: [],
+        contacts: [],
+        messages: [dumped(), edit("oi editado")],
+        syncType: 3,
+        isLatest: true,
+      });
+      await new Promise((r) => setImmediate(r));
+
+      const frame = fetchCalls.find((c) =>
+        c.body?.includes('"event":"messaging-history.set"'),
+      );
+      const messages = JSON.parse(frame?.body as string).data.messages;
+      expect(messages).toHaveLength(1);
+      expect(messages[0].message.conversation).toBe("oi editado");
+      expect(
+        fetchCalls.some((c) => c.body?.includes('"event":"messages.update"')),
+      ).toBe(false);
+    });
+
+    // A full archive carries messages whose edit window closed long ago. Filing
+    // their secrets spends a round trip each and leaves a keyspace nothing can
+    // ever read.
+    it("does not file the secret of a message too old to still be edited", async () => {
+      await connection.connect();
+      const historyHandler = mockEventHandlers.get("messaging-history.set")!;
+
+      await historyHandler({
+        chats: [],
+        contacts: [],
+        messages: [dumped(MESSAGE_SECRET_TTL_SECONDS + 60)],
+        syncType: 2,
+        isLatest: true,
+      });
+      await new Promise((r) => setImmediate(r));
+
+      expect(
+        (redis as any).__stringData.has(
+          messageSecretKey("+5511999999999", ORIG_ID),
+        ),
+      ).toBe(false);
+    });
+
+    // A dump strips the addressing, and the second JID form is exactly what the
+    // stored author candidates are for. Filing before `addressHistory` restores
+    // it records half the candidates, and an edit derived from the form that
+    // was dropped never verifies.
+    it("files both JID forms of an author a dump addressed by LID alone", async () => {
+      await connection.connect();
+      const historyHandler = mockEventHandlers.get("messaging-history.set")!;
+
+      await historyHandler({
+        chats: [],
+        contacts: [],
+        messages: [dumped()],
+        lidPnMappings: [{ lid: CHAT, pn: CHAT_PN }],
+        syncType: 3,
+        isLatest: true,
+      });
+      await new Promise((r) => setImmediate(r));
+
+      const stored = JSON.parse(
+        (redis as any).__stringData.get(
+          messageSecretKey("+5511999999999", ORIG_ID),
+        ),
+      );
+      expect(stored.senders).toEqual([CHAT, CHAT_PN]);
+    });
+
     it("keeps an encrypted edit out of the history frame", async () => {
       await connection.connect();
       const historyHandler = mockEventHandlers.get("messaging-history.set")!;
@@ -905,15 +1040,7 @@ describe("BaileysConnection", () => {
       await historyHandler({
         chats: [],
         contacts: [],
-        messages: [
-          {
-            key: { remoteJid: CHAT, fromMe: false, id: ORIG_ID },
-            messageTimestamp: 1788389210,
-            message: { conversation: "oi" },
-            messageSecret,
-          },
-          edit("oi editado"),
-        ],
+        messages: [dumped(), edit("oi editado")],
         syncType: 3,
         isLatest: true,
       });

--- a/src/baileys/connection.spec.ts
+++ b/src/baileys/connection.spec.ts
@@ -1832,6 +1832,126 @@ describe("BaileysConnection", () => {
       ).toBe(true);
     });
 
+    // Skipping a protected candidate means "evict one" can evict none, and the
+    // map would then sit above the cap for the life of the connection: every
+    // later claim adds one and removes one.
+    it("trims back to the cap once the protected deliveries settle", async () => {
+      await connect();
+      const held = new Promise<void>(() => {});
+      for (let i = 0; i < 1500; i += 1) {
+        (connection as any).editDeliveries.set(`held-${i}`, held);
+        (connection as any).claimEditPosition(`held-${i}`, {
+          at: 1,
+          seq: i + 1,
+          rank: 0,
+        });
+      }
+      // Nothing was evictable while they were all in flight, which is correct.
+      expect((connection as any).editedAt.size).toBe(1500);
+
+      (connection as any).editDeliveries.clear();
+      (connection as any).claimEditPosition("after", {
+        at: 2,
+        seq: 5000,
+        rank: 0,
+      });
+
+      expect((connection as any).editedAt.size).toBe(1000);
+    });
+
+    // Baileys still turns a plaintext MESSAGE_EDIT into a messages.update, in
+    // the very shape the encrypted path synthesises. An encrypted edit sitting
+    // in the retry ladder has to see that one too, or it puts its older text
+    // back over it.
+    it("abandons an encrypted edit overtaken by a plaintext one", async () => {
+      await connect();
+      await deliver([original()]);
+      fetchCalls.length = 0;
+
+      const realRetries = config.webhook.retryPolicy.maxRetries;
+      (config.webhook.retryPolicy as any).maxRetries = 3;
+      let releaseFirst: (() => void) | undefined;
+      const firstAttempt = new Promise<void>((resolve) => {
+        releaseFirst = resolve;
+      });
+      let encryptedAttempts = 0;
+      const realFetch = globalThis.fetch;
+      globalThis.fetch = mock(async (url: any, init?: RequestInit) => {
+        const body = init?.body as string;
+        if (body?.includes('"event":"messages.update"')) {
+          if (body.includes("primeira")) {
+            encryptedAttempts += 1;
+            if (encryptedAttempts === 1) {
+              await firstAttempt;
+            }
+            // The consumer has not written the original yet.
+            return new Response("", { status: 404 });
+          }
+          return new Response("", { status: 200 });
+        }
+        return realFetch(url, init);
+      }) as any;
+
+      try {
+        const retrying = mockEventHandlers.get("messages.upsert")!({
+          type: "notify",
+          messages: [edit("primeira", undefined, { id: "edit-1" })],
+        });
+        await new Promise((r) => setImmediate(r));
+        expect(encryptedAttempts).toBe(1);
+
+        // Straight off Baileys' plaintext MESSAGE_EDIT branch.
+        await mockEventHandlers.get("messages.update")!([
+          {
+            key: { remoteJid: CHAT, fromMe: false, id: ORIG_ID },
+            update: {
+              message: {
+                editedMessage: { message: { conversation: "segunda" } },
+              },
+              messageTimestamp: Math.floor(Date.now() / 1000),
+            },
+          },
+        ]);
+
+        releaseFirst?.();
+        await retrying;
+        await drain();
+      } finally {
+        globalThis.fetch = realFetch;
+        (config.webhook.retryPolicy as any).maxRetries = realRetries;
+      }
+
+      // The first attempt was already on the wire before the plaintext edit
+      // existed; no retry of it may follow.
+      expect(encryptedAttempts).toBe(1);
+    });
+
+    // The same guard in reverse: the plaintext path can also be the older of
+    // the two, and relaying it would revert the encrypted edit already applied.
+    it("drops a plaintext edit older than the encrypted one applied", async () => {
+      await connect();
+      await deliver([original()]);
+      await deliver([edit("segunda", undefined, { id: "edit-1" })]);
+      fetchCalls.length = 0;
+
+      await mockEventHandlers.get("messages.update")!([
+        {
+          key: { remoteJid: CHAT, fromMe: false, id: ORIG_ID },
+          update: {
+            message: {
+              editedMessage: { message: { conversation: "primeira" } },
+            },
+            messageTimestamp: Math.floor(Date.now() / 1000) - 60,
+          },
+        },
+      ]);
+      await drain();
+
+      expect(
+        fetchCalls.some((c) => c.body?.includes('"event":"messages.update"')),
+      ).toBe(false);
+    });
+
     // Baileys builds a chat's history array newest-first (it keeps msgs[0] as
     // "the most recent message in the chat"), so walking it straight applies the
     // newest replacement and then overwrites it with an older one.

--- a/src/baileys/connection.spec.ts
+++ b/src/baileys/connection.spec.ts
@@ -1450,6 +1450,65 @@ describe("BaileysConnection", () => {
       ).toBe("oi editado");
     });
 
+    // The connection that filed the secret is not always the one that delivers
+    // the edit. A fresh connection whose first edit targets an earlier
+    // connection's message has never read its own JIDs, so if it only reads
+    // them after the awaits it reads them from a socket a handoff already took.
+    it("derives a fromMe edit's key on a connection that saw nothing before it", async () => {
+      await connect();
+      // Filed by an earlier connection: the store is all this one inherits.
+      const own = "89572297961476@lid";
+      (redis as any).__stringData.set(
+        messageSecretKey("+5511999999999", ORIG_ID),
+        JSON.stringify({
+          secret: Buffer.from(messageSecret).toString("base64"),
+          senders: [],
+        }),
+      );
+
+      const handler = mockEventHandlers.get("messages.upsert")!;
+      const delivery = handler({
+        type: "notify",
+        messages: [
+          {
+            ...edit("oi editado", { origMsgSender: own, editSender: own }),
+            key: { remoteJid: CHAT, fromMe: true, id: "edit-1" },
+          },
+        ],
+      });
+      (connection as any).socket = undefined;
+      await delivery;
+      await drain();
+
+      const update = fetchCalls.find((c) =>
+        c.body?.includes('"event":"messages.update"'),
+      );
+      expect(update).toBeDefined();
+      expect(
+        JSON.parse(update?.body as string).data[0].update.message.editedMessage
+          .message.conversation,
+      ).toBe("oi editado");
+    });
+
+    // The intake chain aggregates, and an aggregate resolves to a value holding
+    // the previous one. Left unflattened it nests one array per event handled
+    // and keeps every one alive for the life of the connection.
+    it("does not accumulate a value across intakes", async () => {
+      await connect();
+
+      for (let i = 0; i < 5; i += 1) {
+        await deliver([
+          {
+            key: { remoteJid: CHAT, fromMe: false, id: `plain-${i}` },
+            messageTimestamp: Math.floor(Date.now() / 1000),
+            message: { conversation: "oi" },
+          },
+        ]);
+      }
+
+      await expect((connection as any).secretIntake).resolves.toBeUndefined();
+    });
+
     // Baileys builds a chat's history array newest-first (it keeps msgs[0] as
     // "the most recent message in the chat"), so walking it straight applies the
     // newest replacement and then overwrites it with an older one.

--- a/src/baileys/connection.spec.ts
+++ b/src/baileys/connection.spec.ts
@@ -785,6 +785,147 @@ describe("BaileysConnection", () => {
           .message.conversation,
       ).toBe("oi editado");
     });
+
+    // An offline burst consolidates a message and its edit into ONE upsert.
+    // Each webhook delivery runs its own retry loop with no ordering between
+    // them, so an update sent first can reach the consumer before the message
+    // it edits exists there — and be rejected as targeting an unknown id.
+    it("sends the batch before an edit of a message inside it", async () => {
+      await connection.connect();
+
+      await deliver([original(), edit("oi editado")]);
+
+      const upsertAt = fetchCalls.findIndex((c) =>
+        c.body?.includes('"event":"messages.upsert"'),
+      );
+      const updateAt = fetchCalls.findIndex((c) =>
+        c.body?.includes('"event":"messages.update"'),
+      );
+      expect(upsertAt).toBeGreaterThanOrEqual(0);
+      expect(updateAt).toBeGreaterThan(upsertAt);
+    });
+
+    // The lookup is the one step that talks to Redis, and it used to throw
+    // straight out of the batch loop: a disconnect at the wrong moment silently
+    // dropped every ordinary message that shared the frame with an edit.
+    it("keeps delivering the batch when the secret lookup fails", async () => {
+      await connection.connect();
+      await deliver([original()]);
+      fetchCalls.length = 0;
+      // Swapped and restored by hand rather than with spyOn: the redis module is
+      // already a mock, and restoring a spy over one leaves it answering
+      // undefined for every later test in the file.
+      const realGet = (redis as any).get;
+      (redis as any).get = mock(async () => {
+        throw new Error("redis is down");
+      });
+
+      try {
+        await deliver([
+          edit("oi editado"),
+          {
+            key: { remoteJid: CHAT, fromMe: false, id: "other-1" },
+            message: { conversation: "outra" },
+          },
+        ]);
+      } finally {
+        (redis as any).get = realGet;
+      }
+
+      const upsert = fetchCalls.find((c) =>
+        c.body?.includes('"event":"messages.upsert"'),
+      );
+      expect(JSON.parse(upsert?.body as string).data.messages[0].key.id).toBe(
+        "other-1",
+      );
+    });
+
+    // A wrapper keeps its context outside itself, so normalizing walks straight
+    // past the secret and every edit to a disappearing message stops decrypting.
+    it("files the secret of a message wrapped as ephemeral", async () => {
+      await connection.connect();
+      const wrapped = original();
+
+      await deliver([
+        {
+          ...wrapped,
+          message: {
+            messageContextInfo: { messageSecret },
+            ephemeralMessage: { message: { conversation: "oi" } },
+          },
+        },
+      ]);
+      await deliver([edit("oi editado")]);
+
+      expect(
+        fetchCalls.some((c) => c.body?.includes('"event":"messages.update"')),
+      ).toBe(true);
+    });
+
+    // A dump is the other route a message arrives by. A reconnect can replay an
+    // original whose edit window is still open, and the live edit that follows
+    // has nothing to decrypt with unless the dump was read for secrets too.
+    it("files the secret of a message that arrived in a history dump", async () => {
+      await connection.connect();
+      const historyHandler = mockEventHandlers.get("messaging-history.set")!;
+
+      // A dump carries the secret on the WebMessageInfo, not in the content.
+      await historyHandler({
+        chats: [],
+        contacts: [],
+        messages: [
+          {
+            key: { remoteJid: CHAT, fromMe: false, id: ORIG_ID },
+            messageTimestamp: 1788389210,
+            message: { conversation: "oi" },
+            messageSecret,
+          },
+        ],
+        syncType: 3,
+        isLatest: true,
+      });
+      await new Promise((r) => setImmediate(r));
+      fetchCalls.length = 0;
+
+      await deliver([edit("oi editado")]);
+
+      const update = fetchCalls.find((c) =>
+        c.body?.includes('"event":"messages.update"'),
+      );
+      expect(
+        JSON.parse(update?.body as string).data[0].update.message.editedMessage
+          .message.conversation,
+      ).toBe("oi editado");
+    });
+
+    it("keeps an encrypted edit out of the history frame", async () => {
+      await connection.connect();
+      const historyHandler = mockEventHandlers.get("messaging-history.set")!;
+
+      await historyHandler({
+        chats: [],
+        contacts: [],
+        messages: [
+          {
+            key: { remoteJid: CHAT, fromMe: false, id: ORIG_ID },
+            messageTimestamp: 1788389210,
+            message: { conversation: "oi" },
+            messageSecret,
+          },
+          edit("oi editado"),
+        ],
+        syncType: 3,
+        isLatest: true,
+      });
+      await new Promise((r) => setImmediate(r));
+
+      const frame = fetchCalls.find((c) =>
+        c.body?.includes('"event":"messaging-history.set"'),
+      );
+      const messages = JSON.parse(frame?.body as string).data.messages;
+      expect(messages).toHaveLength(1);
+      expect(messages[0].key.id).toBe(ORIG_ID);
+    });
   });
 
   describe("traffic tracking", () => {

--- a/src/baileys/connection.spec.ts
+++ b/src/baileys/connection.spec.ts
@@ -13,8 +13,11 @@ import {
 const fetchCalls: Array<{ url: string; body: string }> = [];
 const originalFetch = globalThis.fetch;
 
+import { createCipheriv, randomBytes } from "node:crypto";
 import * as baileysModule from "@whiskeysockets/baileys";
 import { WAMessageStatus } from "@whiskeysockets/baileys";
+import { proto as realProto } from "@whiskeysockets/baileys/WAProto/index.js";
+import { messageEditKey } from "@/baileys/helpers/decryptMessageEdit";
 import { preprocessAudio } from "@/baileys/helpers/preprocessAudio";
 import { clusterKeys } from "@/cluster/keys";
 import * as sendStallStore from "@/cluster/sendStallStore";
@@ -610,6 +613,177 @@ describe("BaileysConnection", () => {
         await new Promise((r) => setImmediate(r));
       }
       expect(fetchCalls.some((c) => c.body?.includes('"epoch"'))).toBe(false);
+    });
+  });
+
+  // WhatsApp stopped sending message edits as a plaintext protocolMessage and
+  // now encrypts them under the ORIGINAL message's secret. Baileys has no
+  // handler for that node, so without this the raw blob reaches the webhook as
+  // an ordinary message and every consumer renders it as unsupported content —
+  // while the edit itself is lost.
+  describe("encrypted message edits", () => {
+    const CHAT = "167392323834034@lid";
+    const CHAT_PN = "553499503261@s.whatsapp.net";
+    const ORIG_ID = "3EB078E05D8F792B76A79F";
+    const messageSecret = new Uint8Array(32).fill(11);
+
+    function original() {
+      return {
+        key: {
+          remoteJid: CHAT,
+          remoteJidAlt: CHAT_PN,
+          fromMe: false,
+          id: ORIG_ID,
+        },
+        messageTimestamp: 1788389210,
+        message: {
+          conversation: "oi",
+          messageContextInfo: { messageSecret },
+        },
+      };
+    }
+
+    // Seals a replacement body the way the sending client does: HKDF over the
+    // original's secret bound to both parties, then AES-256-GCM with the tag
+    // appended.
+    function edit(
+      text: string,
+      senders = { origMsgSender: CHAT, editSender: CHAT },
+    ) {
+      const encIv = randomBytes(12);
+      const key = messageEditKey({
+        ...senders,
+        origMsgId: ORIG_ID,
+        messageSecret,
+      });
+      const cipher = createCipheriv("aes-256-gcm", key, encIv);
+      cipher.setAAD(Buffer.alloc(0));
+      const body = Buffer.concat([
+        cipher.update(
+          realProto.Message.encode(
+            realProto.Message.fromObject({ conversation: text }),
+          ).finish(),
+        ),
+        cipher.final(),
+      ]);
+
+      return {
+        key: {
+          remoteJid: CHAT,
+          remoteJidAlt: CHAT_PN,
+          fromMe: false,
+          id: "edit-1",
+        },
+        messageTimestamp: 1788389216,
+        message: {
+          secretEncryptedMessage: {
+            targetMessageKey: {
+              remoteJid: "89572297961476@lid",
+              fromMe: true,
+              id: ORIG_ID,
+            },
+            encPayload: Buffer.concat([body, cipher.getAuthTag()]),
+            encIv,
+            secretEncType: 2,
+          },
+        },
+      };
+    }
+
+    async function deliver(messages: unknown[]) {
+      const handler = mockEventHandlers.get("messages.upsert")!;
+      await handler({ type: "notify", messages });
+      await new Promise((r) => setImmediate(r));
+    }
+
+    beforeEach(() => {
+      mockSocket.user = {
+        id: "5511999999999:12@s.whatsapp.net",
+        lid: "89572297961476@lid",
+      };
+    });
+
+    it("delivers the edit as a messages.update against the original", async () => {
+      await connection.connect();
+
+      await deliver([original()]);
+      await deliver([edit("oi editado")]);
+
+      const update = fetchCalls.find((c) =>
+        c.body?.includes('"event":"messages.update"'),
+      );
+      expect(update).toBeDefined();
+      const parsed = JSON.parse(update?.body as string);
+      expect(parsed.data[0].key.id).toBe(ORIG_ID);
+      expect(parsed.data[0].key.fromMe).toBe(false);
+      expect(
+        parsed.data[0].update.message.editedMessage.message.conversation,
+      ).toBe("oi editado");
+    });
+
+    it("does not forward the encrypted node as a message", async () => {
+      await connection.connect();
+
+      await deliver([original()]);
+      fetchCalls.length = 0;
+      await deliver([edit("oi editado")]);
+
+      expect(
+        fetchCalls.some((c) => c.body?.includes('"event":"messages.upsert"')),
+      ).toBe(false);
+    });
+
+    // The batch is not all-or-nothing: a real message sharing the frame with an
+    // edit still has to arrive.
+    it("keeps the other messages in the same batch", async () => {
+      await connection.connect();
+
+      await deliver([original()]);
+      fetchCalls.length = 0;
+      await deliver([
+        edit("oi editado"),
+        {
+          key: { remoteJid: CHAT, fromMe: false, id: "other-1" },
+          message: { conversation: "outra" },
+        },
+      ]);
+
+      const upsert = fetchCalls.find((c) =>
+        c.body?.includes('"event":"messages.upsert"'),
+      );
+      const parsed = JSON.parse(upsert?.body as string);
+      expect(parsed.data.messages).toHaveLength(1);
+      expect(parsed.data.messages[0].key.id).toBe("other-1");
+    });
+
+    // The secret only ever arrives on the original message, so an edit whose
+    // original this instance never saw is undecryptable. Dropping it is still
+    // better than the bubble: there is no content to show either way.
+    it("drops an edit whose original it never saw", async () => {
+      await connection.connect();
+
+      await deliver([edit("oi editado")]);
+
+      expect(fetchCalls).toHaveLength(0);
+    });
+
+    // LID migration means the same person is addressed two ways and only one of
+    // them went into the derivation; the tag check makes trying both safe.
+    it("finds the key when the derivation used the phone-number JID", async () => {
+      await connection.connect();
+
+      await deliver([original()]);
+      await deliver([
+        edit("oi editado", { origMsgSender: CHAT_PN, editSender: CHAT_PN }),
+      ]);
+
+      const update = fetchCalls.find((c) =>
+        c.body?.includes('"event":"messages.update"'),
+      );
+      expect(
+        JSON.parse(update?.body as string).data[0].update.message.editedMessage
+          .message.conversation,
+      ).toBe("oi editado");
     });
   });
 

--- a/src/baileys/connection.spec.ts
+++ b/src/baileys/connection.spec.ts
@@ -672,7 +672,16 @@ describe("BaileysConnection", () => {
       {
         id = "edit-1",
         ageSeconds = 0,
-      }: { id?: string; ageSeconds?: number } = {},
+        targetKey = {
+          remoteJid: "89572297961476@lid",
+          fromMe: true,
+          id: ORIG_ID,
+        },
+      }: {
+        id?: string;
+        ageSeconds?: number;
+        targetKey?: Record<string, unknown>;
+      } = {},
     ) {
       const encIv = randomBytes(12);
       const key = messageEditKey({
@@ -701,11 +710,7 @@ describe("BaileysConnection", () => {
         messageTimestamp: Math.floor(Date.now() / 1000) - ageSeconds,
         message: {
           secretEncryptedMessage: {
-            targetMessageKey: {
-              remoteJid: "89572297961476@lid",
-              fromMe: true,
-              id: ORIG_ID,
-            },
+            targetMessageKey: targetKey,
             encPayload: Buffer.concat([body, cipher.getAuthTag()]),
             encIv,
             secretEncType: 2,
@@ -1507,6 +1512,71 @@ describe("BaileysConnection", () => {
       }
 
       await expect((connection as any).secretIntake).resolves.toBeUndefined();
+    });
+
+    // The batch knows only how ITS copy addressed the author. The store may
+    // hold a form an earlier copy carried, so a local failure is a reason to ask
+    // the store, not a reason to drop the edit.
+    it("falls back to the stored sender forms when the batch cannot decrypt", async () => {
+      await connect();
+      // The live copy taught the store both forms.
+      await deliver([original()]);
+      fetchCalls.length = 0;
+
+      // A second copy of the same message, addressed by LID alone, arrives
+      // alongside an edit whose author WhatsApp named by the phone-number form.
+      // Nothing in this batch knows that form; only the store does.
+      await deliver([
+        { ...dumped(), key: { remoteJid: CHAT, fromMe: false, id: ORIG_ID } },
+        edit(
+          "oi editado",
+          { origMsgSender: CHAT_PN, editSender: CHAT },
+          { targetKey: { remoteJid: CHAT, fromMe: false, id: ORIG_ID } },
+        ),
+      ]);
+
+      const update = fetchCalls.find((c) =>
+        c.body?.includes('"event":"messages.update"'),
+      );
+      expect(update).toBeDefined();
+      expect(
+        JSON.parse(update?.body as string).data[0].update.message.editedMessage
+          .message.conversation,
+      ).toBe("oi editado");
+    });
+
+    // An edit that cannot be read changes nothing, so it must not take the
+    // position: a later, older edit that CAN be read would then be rejected as
+    // superseded by an update nobody ever received.
+    it("lets an older readable edit through after a newer unreadable one", async () => {
+      await connect();
+      await deliver([original()]);
+      fetchCalls.length = 0;
+
+      // Encrypted under a JID neither the batch nor the store ever saw.
+      await deliver([
+        edit(
+          "ilegivel",
+          { origMsgSender: "999@lid", editSender: "999@lid" },
+          { id: "edit-2" },
+        ),
+      ]);
+      expect(
+        fetchCalls.some((c) => c.body?.includes('"event":"messages.update"')),
+      ).toBe(false);
+
+      await deliver([
+        edit("legivel", undefined, { id: "edit-1", ageSeconds: 30 }),
+      ]);
+
+      const update = fetchCalls.find((c) =>
+        c.body?.includes('"event":"messages.update"'),
+      );
+      expect(update).toBeDefined();
+      expect(
+        JSON.parse(update?.body as string).data[0].update.message.editedMessage
+          .message.conversation,
+      ).toBe("legivel");
     });
 
     // Baileys builds a chat's history array newest-first (it keeps msgs[0] as

--- a/src/baileys/connection.spec.ts
+++ b/src/baileys/connection.spec.ts
@@ -1045,6 +1045,71 @@ describe("BaileysConnection", () => {
       expect(texts).toEqual(["primeira", "segunda"]);
     });
 
+    // A callback carrying only an edit has no batch to wait for, so if the
+    // queue position were taken at send time it would reserve ahead of an edit
+    // seen earlier alongside a message — and the older text would land last and
+    // win.
+    it("keeps two edits in the order they arrived, not the order they were sent", async () => {
+      await connection.connect();
+      await deliver([original()]);
+      fetchCalls.length = 0;
+
+      const handler = mockEventHandlers.get("messages.upsert")!;
+      // Not awaited: this callback still has a batch to deliver when the
+      // edit-only one below arrives.
+      const first = handler({
+        type: "notify",
+        messages: [
+          edit("primeira"),
+          {
+            key: { remoteJid: CHAT, fromMe: false, id: "other-1" },
+            message: { conversation: "outra" },
+          },
+        ],
+      });
+      await handler({ type: "notify", messages: [edit("segunda")] });
+      await first;
+      while (connection.inFlightWebhooks > 0) {
+        await new Promise((r) => setImmediate(r));
+      }
+
+      const texts = fetchCalls
+        .filter((c) => c.body?.includes('"event":"messages.update"'))
+        .map(
+          (c) =>
+            JSON.parse(c.body).data[0].update.message.editedMessage.message
+              .conversation,
+        );
+      expect(texts).toEqual(["primeira", "segunda"]);
+    });
+
+    // Filing a secret is a side effect of delivering a message, never a reason
+    // to withhold it: node-redis parks a command on its offline queue until it
+    // reconnects, and unbounded that would hold the message AND every edit
+    // queued behind its delivery slot.
+    it("still delivers the batch when the secret store never answers", async () => {
+      await connection.connect();
+      const realSet = (redis as any).set;
+      const realTimeout = config.baileys.messageSecretStoreTimeoutMs;
+      // Never settles, which is exactly what an offline queue does.
+      (redis as any).set = mock(() => new Promise(() => {}));
+      (config.baileys as any).messageSecretStoreTimeoutMs = 20;
+
+      try {
+        await deliver([original()]);
+      } finally {
+        (redis as any).set = realSet;
+        (config.baileys as any).messageSecretStoreTimeoutMs = realTimeout;
+      }
+
+      const upsert = fetchCalls.find((c) =>
+        c.body?.includes('"event":"messages.upsert"'),
+      );
+      expect(JSON.parse(upsert?.body as string).data.messages[0].key.id).toBe(
+        ORIG_ID,
+      );
+    });
+
     // A sync split across notifications can leave the original in an earlier
     // one. There is nothing left to repair in place by then, but the secret was
     // filed, so the edit is still readable and goes out as a live update.

--- a/src/baileys/connection.spec.ts
+++ b/src/baileys/connection.spec.ts
@@ -639,7 +639,7 @@ describe("BaileysConnection", () => {
           fromMe: false,
           id: ORIG_ID,
         },
-        messageTimestamp: 1788389210,
+        messageTimestamp: Math.floor(Date.now() / 1000),
         message: {
           conversation: "oi",
           messageContextInfo: { messageSecret },
@@ -694,7 +694,7 @@ describe("BaileysConnection", () => {
           fromMe: false,
           id: "edit-1",
         },
-        messageTimestamp: 1788389216,
+        messageTimestamp: Math.floor(Date.now() / 1000),
         message: {
           secretEncryptedMessage: {
             targetMessageKey: {
@@ -713,7 +713,17 @@ describe("BaileysConnection", () => {
     async function deliver(messages: unknown[]) {
       const handler = mockEventHandlers.get("messages.upsert")!;
       await handler({ type: "notify", messages });
+      await drain();
+    }
+
+    // An edit is delivered outside the callback that saw it, so waiting a tick
+    // is not enough — wait for the connection to report nothing pending, which
+    // is the same count a graceful shutdown drains on.
+    async function drain() {
       await new Promise((r) => setImmediate(r));
+      while (connection.inFlightWebhooks > 0) {
+        await new Promise((r) => setImmediate(r));
+      }
     }
 
     beforeEach(() => {
@@ -806,23 +816,39 @@ describe("BaileysConnection", () => {
       ).toBe("oi editado");
     });
 
-    // An offline burst consolidates a message and its edit into ONE upsert.
-    // Each webhook delivery runs its own retry loop with no ordering between
-    // them, so an update sent first can reach the consumer before the message
-    // it edits exists there — and be rejected as targeting an unknown id.
-    it("sends the batch before an edit of a message inside it", async () => {
+    // The common case needs no ordering at all: an offline burst consolidates a
+    // message and its edit into one upsert, and the batch can simply repair
+    // itself. Delivering an update alongside the message it edits was what four
+    // rounds of barriers and chains were built to sequence.
+    it("applies an edit to a message in its own batch, with no update event", async () => {
       await connection.connect();
 
       await deliver([original(), edit("oi editado")]);
 
-      const upsertAt = fetchCalls.findIndex((c) =>
+      const upsert = fetchCalls.find((c) =>
         c.body?.includes('"event":"messages.upsert"'),
       );
-      const updateAt = fetchCalls.findIndex((c) =>
-        c.body?.includes('"event":"messages.update"'),
-      );
-      expect(upsertAt).toBeGreaterThanOrEqual(0);
-      expect(updateAt).toBeGreaterThan(upsertAt);
+      const messages = JSON.parse(upsert?.body as string).data.messages;
+      expect(messages).toHaveLength(1);
+      expect(messages[0].message.conversation).toBe("oi editado");
+      expect(
+        fetchCalls.some((c) => c.body?.includes('"event":"messages.update"')),
+      ).toBe(false);
+    });
+
+    // An edit is delivered outside the callback that saw it, and recalling its
+    // secret suspends before sendToWebhook counts anything. A shutdown reading
+    // the count in that gap would exit on top of the edit.
+    it("counts a pending edit as work a graceful shutdown must drain", async () => {
+      await connection.connect();
+      await deliver([original()]);
+
+      const handler = mockEventHandlers.get("messages.upsert")!;
+      await handler({ type: "notify", messages: [edit("oi editado")] });
+
+      expect(connection.inFlightWebhooks).toBeGreaterThan(0);
+      await drain();
+      expect(connection.inFlightWebhooks).toBe(0);
     });
 
     // The lookup is the one step that talks to Redis, and it used to throw
@@ -911,178 +937,6 @@ describe("BaileysConnection", () => {
       ).toBe("oi editado");
     });
 
-    // Baileys does not await its listeners, so two upsert callbacks can be in
-    // flight at once and awaiting inside one orders nothing against the other.
-    // The edit has to wait on the upsert deliveries that were already running,
-    // not just on its own batch.
-    it("holds an edit behind an upsert still in flight from an earlier callback", async () => {
-      await connection.connect();
-      const handler = mockEventHandlers.get("messages.upsert")!;
-      let releaseUpsert: (() => void) | undefined;
-      const slowUpsert = new Promise<void>((resolve) => {
-        releaseUpsert = resolve;
-      });
-      const realFetch = globalThis.fetch;
-      globalThis.fetch = mock(async (url: any, init?: RequestInit) => {
-        if ((init?.body as string)?.includes('"event":"messages.upsert"')) {
-          await slowUpsert;
-        }
-        return realFetch(url, init);
-      }) as any;
-
-      // Not awaited: this is the callback that is still running when the next
-      // one arrives, which is the whole situation under test.
-      const first = handler({ type: "notify", messages: [original()] });
-      await new Promise((r) => setImmediate(r));
-      await handler({ type: "notify", messages: [edit("oi editado")] });
-      await new Promise((r) => setImmediate(r));
-
-      expect(
-        fetchCalls.some((c) => c.body?.includes('"event":"messages.update"')),
-      ).toBe(false);
-
-      releaseUpsert?.();
-      await first;
-      while (connection.inFlightWebhooks > 0) {
-        await new Promise((r) => setImmediate(r));
-      }
-      globalThis.fetch = realFetch;
-
-      const upsertAt = fetchCalls.findIndex((c) =>
-        c.body?.includes('"event":"messages.upsert"'),
-      );
-      const updateAt = fetchCalls.findIndex((c) =>
-        c.body?.includes('"event":"messages.update"'),
-      );
-      expect(updateAt).toBeGreaterThan(upsertAt);
-    });
-
-    // Everything between the event and the send — filing secrets, downloading
-    // media — is time a competing callback can run in. Tracking the delivery
-    // only at send time leaves that whole span looking idle, and an edit that
-    // arrives inside it overtakes the message it edits.
-    it("holds an edit behind an upsert still busy before its send", async () => {
-      await connection.connect();
-      const handler = mockEventHandlers.get("messages.upsert")!;
-      let releaseFiling: (() => void) | undefined;
-      const slowFiling = new Promise<void>((resolve) => {
-        releaseFiling = resolve;
-      });
-      const realSet = (redis as any).set;
-      (redis as any).set = mock(async (...args: unknown[]) => {
-        await slowFiling;
-        return (realSet as any)(...args);
-      });
-
-      const first = handler({ type: "notify", messages: [original()] });
-      await new Promise((r) => setImmediate(r));
-      await handler({ type: "notify", messages: [edit("oi editado")] });
-      await new Promise((r) => setImmediate(r));
-
-      // The original has not even been sent yet, so nothing may have gone out.
-      expect(fetchCalls).toHaveLength(0);
-
-      releaseFiling?.();
-      await first;
-      while (connection.inFlightWebhooks > 0) {
-        await new Promise((r) => setImmediate(r));
-      }
-      (redis as any).set = realSet;
-
-      const upsertAt = fetchCalls.findIndex((c) =>
-        c.body?.includes('"event":"messages.upsert"'),
-      );
-      const updateAt = fetchCalls.findIndex((c) =>
-        c.body?.includes('"event":"messages.update"'),
-      );
-      expect(upsertAt).toBeGreaterThanOrEqual(0);
-      expect(updateAt).toBeGreaterThan(upsertAt);
-    });
-
-    // The chain has to advance on the DELIVERY, not on the call. Advancing on
-    // the call lets a second edit start while the first is still working
-    // through its retries, and the older text lands last and wins.
-    it("does not start the next edit while the previous one is still delivering", async () => {
-      await connection.connect();
-      await deliver([original()]);
-      fetchCalls.length = 0;
-
-      let releaseFirst: (() => void) | undefined;
-      const slowFirst = new Promise<void>((resolve) => {
-        releaseFirst = resolve;
-      });
-      let updates = 0;
-      const realFetch = globalThis.fetch;
-      globalThis.fetch = mock(async (url: any, init?: RequestInit) => {
-        if ((init?.body as string)?.includes('"event":"messages.update"')) {
-          updates += 1;
-          if (updates === 1) {
-            await slowFirst;
-          }
-        }
-        return realFetch(url, init);
-      }) as any;
-
-      await deliver([edit("primeira")]);
-      await deliver([edit("segunda")]);
-      await new Promise((r) => setImmediate(r));
-
-      expect(updates).toBe(1);
-
-      releaseFirst?.();
-      while (connection.inFlightWebhooks > 0) {
-        await new Promise((r) => setImmediate(r));
-      }
-      globalThis.fetch = realFetch;
-
-      const texts = fetchCalls
-        .filter((c) => c.body?.includes('"event":"messages.update"'))
-        .map(
-          (c) =>
-            JSON.parse(c.body).data[0].update.message.editedMessage.message
-              .conversation,
-        );
-      expect(texts).toEqual(["primeira", "segunda"]);
-    });
-
-    // A callback carrying only an edit has no batch to wait for, so if the
-    // queue position were taken at send time it would reserve ahead of an edit
-    // seen earlier alongside a message — and the older text would land last and
-    // win.
-    it("keeps two edits in the order they arrived, not the order they were sent", async () => {
-      await connection.connect();
-      await deliver([original()]);
-      fetchCalls.length = 0;
-
-      const handler = mockEventHandlers.get("messages.upsert")!;
-      // Not awaited: this callback still has a batch to deliver when the
-      // edit-only one below arrives.
-      const first = handler({
-        type: "notify",
-        messages: [
-          edit("primeira"),
-          {
-            key: { remoteJid: CHAT, fromMe: false, id: "other-1" },
-            message: { conversation: "outra" },
-          },
-        ],
-      });
-      await handler({ type: "notify", messages: [edit("segunda")] });
-      await first;
-      while (connection.inFlightWebhooks > 0) {
-        await new Promise((r) => setImmediate(r));
-      }
-
-      const texts = fetchCalls
-        .filter((c) => c.body?.includes('"event":"messages.update"'))
-        .map(
-          (c) =>
-            JSON.parse(c.body).data[0].update.message.editedMessage.message
-              .conversation,
-        );
-      expect(texts).toEqual(["primeira", "segunda"]);
-    });
-
     // Filing a secret is a side effect of delivering a message, never a reason
     // to withhold it: node-redis parks a command on its offline queue until it
     // reconnects, and unbounded that would hold the message AND every edit
@@ -1123,7 +977,7 @@ describe("BaileysConnection", () => {
         messages: [dumped()],
         syncType: 3,
       });
-      await new Promise((r) => setImmediate(r));
+      await drain();
       fetchCalls.length = 0;
 
       await historyHandler({
@@ -1133,9 +987,7 @@ describe("BaileysConnection", () => {
         syncType: 3,
         isLatest: true,
       });
-      while (connection.inFlightWebhooks > 0) {
-        await new Promise((r) => setImmediate(r));
-      }
+      await drain();
 
       const update = fetchCalls.find((c) =>
         c.body?.includes('"event":"messages.update"'),
@@ -1160,7 +1012,7 @@ describe("BaileysConnection", () => {
         syncType: 3,
         isLatest: true,
       });
-      await new Promise((r) => setImmediate(r));
+      await drain();
 
       const frame = fetchCalls.find((c) =>
         c.body?.includes('"event":"messaging-history.set"'),
@@ -1187,7 +1039,7 @@ describe("BaileysConnection", () => {
         syncType: 2,
         isLatest: true,
       });
-      await new Promise((r) => setImmediate(r));
+      await drain();
 
       expect(
         (redis as any).__stringData.has(
@@ -1212,7 +1064,7 @@ describe("BaileysConnection", () => {
         syncType: 3,
         isLatest: true,
       });
-      await new Promise((r) => setImmediate(r));
+      await drain();
 
       const stored = JSON.parse(
         (redis as any).__stringData.get(
@@ -1233,7 +1085,7 @@ describe("BaileysConnection", () => {
         syncType: 3,
         isLatest: true,
       });
-      await new Promise((r) => setImmediate(r));
+      await drain();
 
       const frame = fetchCalls.find((c) =>
         c.body?.includes('"event":"messaging-history.set"'),

--- a/src/baileys/connection.spec.ts
+++ b/src/baileys/connection.spec.ts
@@ -1205,6 +1205,119 @@ describe("BaileysConnection", () => {
       expect(connection.inFlightWebhooks).toBe(0);
     });
 
+    // An archive reaches back past the window in which a secret is worth
+    // storing, but it can carry an original AND its edit in the same batch, and
+    // that edit is decryptable right there. Letting the retention filter shrink
+    // the in-batch map loses an edit whose key was in hand.
+    it("applies an in-batch edit to an original too old to file", async () => {
+      await connection.connect();
+      const historyHandler = mockEventHandlers.get("messaging-history.set")!;
+
+      await historyHandler({
+        chats: [],
+        contacts: [],
+        messages: [edit("oi editado"), dumped(MESSAGE_SECRET_TTL_SECONDS + 60)],
+        syncType: 2,
+        isLatest: true,
+      });
+      await drain();
+
+      const frame = fetchCalls.find((c) =>
+        c.body?.includes('"event":"messaging-history.set"'),
+      );
+      const messages = JSON.parse(frame?.body as string).data.messages;
+      expect(messages).toHaveLength(1);
+      expect(messages[0].message.conversation).toBe("oi editado");
+      // Still not worth storing: nothing can edit it again.
+      expect(
+        (redis as any).__stringData.has(
+          messageSecretKey("+5511999999999", ORIG_ID),
+        ),
+      ).toBe(false);
+    });
+
+    // Baileys does not await our handler, so two upserts run concurrently. The
+    // queue orders by the moment an edit is put on it, and everything after the
+    // split can suspend: an older edit behind a slow secret write would reach
+    // the queue after a newer edit that arrived later, and the older text wins.
+    it("queues an edit ahead of a later one even when its batch stalls", async () => {
+      await connection.connect();
+      await deliver([original()]);
+      fetchCalls.length = 0;
+
+      const realSet = (redis as any).set;
+      let releaseSet: (() => void) | undefined;
+      (redis as any).set = mock(
+        () =>
+          new Promise<void>((resolve) => {
+            releaseSet = resolve;
+          }),
+      );
+
+      const handler = mockEventHandlers.get("messages.upsert")!;
+      try {
+        // Carries a secret of its own, so its batch parks on the slow write.
+        const stalls = handler({
+          type: "notify",
+          messages: [
+            {
+              key: { remoteJid: CHAT, fromMe: false, id: "other-1" },
+              messageTimestamp: Math.floor(Date.now() / 1000),
+              message: {
+                conversation: "outra",
+                messageContextInfo: { messageSecret },
+              },
+            },
+            edit("primeira", undefined, { id: "edit-1" }),
+          ],
+        });
+        await new Promise((r) => setImmediate(r));
+
+        await handler({
+          type: "notify",
+          messages: [edit("segunda", undefined, { id: "edit-2" })],
+        });
+
+        releaseSet?.();
+        await stalls;
+      } finally {
+        (redis as any).set = realSet;
+      }
+      await drain();
+
+      const texts = fetchCalls
+        .filter((c) => c.body?.includes('"event":"messages.update"'))
+        .map(
+          (c) =>
+            JSON.parse(c.body).data[0].update.message.editedMessage.message
+              .conversation,
+        );
+      expect(texts).toEqual(["primeira", "segunda"]);
+    });
+
+    // node-redis parks commands on an offline queue while the connection is
+    // down and replays them on reconnect. withTimeout stops us awaiting; it
+    // cannot cancel, so a long outage would retain one command per message.
+    it("does not queue a secret write while the store is disconnected", async () => {
+      await connection.connect();
+      const before = (redis as any).set.mock.calls.length;
+      (redis as any).isReady = false;
+
+      try {
+        await deliver([original()]);
+      } finally {
+        (redis as any).isReady = true;
+      }
+
+      expect((redis as any).set.mock.calls.length).toBe(before);
+      const upsert = fetchCalls.find((c) =>
+        c.body?.includes('"event":"messages.upsert"'),
+      );
+      expect(JSON.parse(upsert?.body as string).data.messages[0].key.id).toBe(
+        ORIG_ID,
+      );
+    });
+
     // Baileys builds a chat's history array newest-first (it keeps msgs[0] as
     // "the most recent message in the chat"), so walking it straight applies the
     // newest replacement and then overwrites it with an older one.

--- a/src/baileys/connection.spec.ts
+++ b/src/baileys/connection.spec.ts
@@ -1926,6 +1926,69 @@ describe("BaileysConnection", () => {
       expect(encryptedAttempts).toBe(1);
     });
 
+    // A plaintext edit answered 404 sits in the retry ladder just like an
+    // encrypted one, so it needs the same per-attempt check: an encrypted edit
+    // applied while it sleeps has already sent newer text.
+    it("abandons a plaintext edit whose retry was overtaken", async () => {
+      await connect();
+      await deliver([original()]);
+      fetchCalls.length = 0;
+
+      const realRetries = config.webhook.retryPolicy.maxRetries;
+      (config.webhook.retryPolicy as any).maxRetries = 3;
+      let releaseFirst: (() => void) | undefined;
+      const firstAttempt = new Promise<void>((resolve) => {
+        releaseFirst = resolve;
+      });
+      let plaintextAttempts = 0;
+      const realFetch = globalThis.fetch;
+      globalThis.fetch = mock(async (url: any, init?: RequestInit) => {
+        const body = init?.body as string;
+        if (body?.includes('"event":"messages.update"')) {
+          if (body.includes("primeira")) {
+            plaintextAttempts += 1;
+            if (plaintextAttempts === 1) {
+              await firstAttempt;
+            }
+            return new Response("", { status: 404 });
+          }
+          return new Response("", { status: 200 });
+        }
+        return realFetch(url, init);
+      }) as any;
+
+      try {
+        const retrying = mockEventHandlers.get("messages.update")!([
+          {
+            key: { remoteJid: CHAT, fromMe: false, id: ORIG_ID },
+            update: {
+              message: {
+                editedMessage: { message: { conversation: "primeira" } },
+              },
+              messageTimestamp: Math.floor(Date.now() / 1000) - 60,
+            },
+          },
+        ]);
+        await new Promise((r) => setImmediate(r));
+        expect(plaintextAttempts).toBe(1);
+
+        // Repaired in place, so the newer text is already on its way out.
+        await mockEventHandlers.get("messages.upsert")!({
+          type: "notify",
+          messages: [original(), edit("segunda", undefined, { id: "edit-2" })],
+        });
+
+        releaseFirst?.();
+        await retrying;
+        await drain();
+      } finally {
+        globalThis.fetch = realFetch;
+        (config.webhook.retryPolicy as any).maxRetries = realRetries;
+      }
+
+      expect(plaintextAttempts).toBe(1);
+    });
+
     // The same guard in reverse: the plaintext path can also be the older of
     // the two, and relaying it would revert the encrypted edit already applied.
     it("drops a plaintext edit older than the encrypted one applied", async () => {

--- a/src/baileys/connection.spec.ts
+++ b/src/baileys/connection.spec.ts
@@ -1807,6 +1807,31 @@ describe("BaileysConnection", () => {
       ).toBe(false);
     });
 
+    // The position map is capped, and a history sync touches far more messages
+    // than the cap. Evicting a target whose delivery is still retrying makes the
+    // retry read "nothing applied yet", which is the one answer that lets it
+    // overwrite the newer text.
+    it("keeps the position of a message whose delivery is still running", async () => {
+      await connect();
+      const held = new Promise<void>(() => {});
+      (connection as any).editDeliveries.set(ORIG_ID, held);
+      const position = { at: 1, seq: 1, rank: 0 };
+      (connection as any).claimEditPosition(ORIG_ID, position);
+
+      for (let i = 0; i < 2000; i += 1) {
+        (connection as any).claimEditPosition(`other-${i}`, {
+          at: 2,
+          seq: 2 + i,
+          rank: 0,
+        });
+      }
+
+      expect((connection as any).editedAt.has(ORIG_ID)).toBe(true);
+      expect(
+        (connection as any).editSuperseded(ORIG_ID, { at: 0, seq: 0, rank: 0 }),
+      ).toBe(true);
+    });
+
     // Baileys builds a chat's history array newest-first (it keeps msgs[0] as
     // "the most recent message in the chat"), so walking it straight applies the
     // newest replacement and then overwrites it with an older one.

--- a/src/baileys/connection.spec.ts
+++ b/src/baileys/connection.spec.ts
@@ -851,6 +851,94 @@ describe("BaileysConnection", () => {
       expect(connection.inFlightWebhooks).toBe(0);
     });
 
+    // Applying an edit in place replaces the content that holds the secret, so
+    // re-reading the message afterwards to file it finds nothing — and the NEXT
+    // edit to that message arrives with no key.
+    it("keeps a repaired message decryptable for its next edit", async () => {
+      await connection.connect();
+
+      await deliver([original(), edit("primeira")]);
+      fetchCalls.length = 0;
+      await deliver([edit("segunda")]);
+
+      const update = fetchCalls.find((c) =>
+        c.body?.includes('"event":"messages.update"'),
+      );
+      expect(
+        JSON.parse(update?.body as string).data[0].update.message.editedMessage
+          .message.conversation,
+      ).toBe("segunda");
+    });
+
+    // The protocol orders an edit against the message it edits, by answering
+    // 404 and retrying. It does NOT order two edits of the same message: once
+    // the target exists both are answered 200, so a first edit working through
+    // a retry can land after a second and the older text wins.
+    it("delivers two edits of one message in order, even when the first retries", async () => {
+      await connection.connect();
+      await deliver([original()]);
+      fetchCalls.length = 0;
+
+      let releaseFirst: (() => void) | undefined;
+      const slowFirst = new Promise<void>((resolve) => {
+        releaseFirst = resolve;
+      });
+      let updates = 0;
+      const realFetch = globalThis.fetch;
+      globalThis.fetch = mock(async (url: any, init?: RequestInit) => {
+        if ((init?.body as string)?.includes('"event":"messages.update"')) {
+          updates += 1;
+          if (updates === 1) {
+            await slowFirst;
+          }
+        }
+        return realFetch(url, init);
+      }) as any;
+
+      const handler = mockEventHandlers.get("messages.upsert")!;
+      await handler({ type: "notify", messages: [edit("primeira")] });
+      await handler({ type: "notify", messages: [edit("segunda")] });
+      await new Promise((r) => setImmediate(r));
+
+      expect(updates).toBe(1);
+
+      releaseFirst?.();
+      await drain();
+      globalThis.fetch = realFetch;
+
+      const texts = fetchCalls
+        .filter((c) => c.body?.includes('"event":"messages.update"'))
+        .map(
+          (c) =>
+            JSON.parse(c.body).data[0].update.message.editedMessage.message
+              .conversation,
+        );
+      expect(texts).toEqual(["primeira", "segunda"]);
+    });
+
+    // Retention has to cover how long a disconnect may last before its history
+    // arrives, not the fifteen minutes an author has to create the edit: the
+    // edit is valid when created and only replayed to us much later.
+    it("keeps the secret of a dump message older than the edit window", async () => {
+      await connection.connect();
+      const historyHandler = mockEventHandlers.get("messaging-history.set")!;
+
+      await historyHandler({
+        chats: [],
+        contacts: [],
+        messages: [dumped(6 * 60 * 60)],
+        syncType: 3,
+        isLatest: true,
+      });
+      await drain();
+
+      expect(
+        (redis as any).__stringData.has(
+          messageSecretKey("+5511999999999", ORIG_ID),
+        ),
+      ).toBe(true);
+    });
+
     // The lookup is the one step that talks to Redis, and it used to throw
     // straight out of the batch loop: a disconnect at the wrong moment silently
     // dropped every ordinary message that shared the frame with an edit.
@@ -1025,10 +1113,9 @@ describe("BaileysConnection", () => {
       ).toBe(false);
     });
 
-    // A full archive carries messages whose edit window closed long ago. Filing
-    // their secrets spends a round trip each and leaves a keyspace nothing can
-    // ever read.
-    it("does not file the secret of a message too old to still be edited", async () => {
+    // A full archive still reaches back past any replay window. Filing those
+    // secrets leaves a keyspace nothing can ever read.
+    it("does not file the secret of a message too old to still be replayed", async () => {
       await connection.connect();
       const historyHandler = mockEventHandlers.get("messaging-history.set")!;
 

--- a/src/baileys/connection.spec.ts
+++ b/src/baileys/connection.spec.ts
@@ -20,6 +20,7 @@ import { proto as realProto } from "@whiskeysockets/baileys/WAProto/index.js";
 import { messageEditKey } from "@/baileys/helpers/decryptMessageEdit";
 import {
   MESSAGE_SECRET_TTL_SECONDS,
+  MESSAGE_SECRET_WRITE_SCRIPT,
   messageSecretKey,
 } from "@/baileys/helpers/messageSecretStore";
 import { preprocessAudio } from "@/baileys/helpers/preprocessAudio";
@@ -730,32 +731,28 @@ describe("BaileysConnection", () => {
     // An edit is delivered outside the callback that saw it, so waiting a tick
     // is not enough — wait for the connection to report nothing pending, which
     // is the same count a graceful shutdown drains on.
-    // The store writes through a transaction, so what has to be held is exec,
-    // not the command that was queued into it.
+    // The store writes through one Lua call, so that is what has to be held.
+    // Other scripts keep running: this suite's connection code uses them too.
     function stallSecretStore(): {
       release: () => void;
       restore: () => void;
     } {
-      const realMulti = (redis as any).multi;
+      const realEval = (redis as any).eval;
       let release: (() => void) | undefined;
       const held = new Promise<void>((resolve) => {
         release = resolve;
       });
-      (redis as any).multi = mock(() => {
-        const chain: any = {
-          hSet: () => chain,
-          expire: () => chain,
-          exec: async () => {
-            await held;
-            return [];
-          },
-        };
-        return chain;
+      (redis as any).eval = mock(async (script: string, options?: unknown) => {
+        if (script.trim() === MESSAGE_SECRET_WRITE_SCRIPT) {
+          await held;
+          return 1;
+        }
+        return realEval(script, options);
       });
       return {
         release: () => release?.(),
         restore: () => {
-          (redis as any).multi = realMulti;
+          (redis as any).eval = realEval;
         },
       };
     }
@@ -1319,7 +1316,7 @@ describe("BaileysConnection", () => {
     // cannot cancel, so a long outage would retain one command per message.
     it("does not queue a secret write while the store is disconnected", async () => {
       await connect();
-      const before = (redis as any).multi.mock.calls.length;
+      const before = (redis as any).eval.mock.calls.length;
       (redis as any).isReady = false;
 
       try {
@@ -1328,7 +1325,7 @@ describe("BaileysConnection", () => {
         (redis as any).isReady = true;
       }
 
-      expect((redis as any).multi.mock.calls.length).toBe(before);
+      expect((redis as any).eval.mock.calls.length).toBe(before);
       const upsert = fetchCalls.find((c) =>
         c.body?.includes('"event":"messages.upsert"'),
       );
@@ -1764,6 +1761,50 @@ describe("BaileysConnection", () => {
       } finally {
         globalThis.fetch = realFetch;
       }
+    });
+
+    // One batch can carry two edits of the same message stamped in the same
+    // second, and they do not have to leave by the same route: the newer can
+    // decrypt in place while the older falls back to the stored sender forms
+    // and goes out as an update. Ranked only by (timestamp, event) the older
+    // one does not look superseded, and it reverts the message.
+    it("does not let a deferred edit revert a newer one from its own batch", async () => {
+      await connect();
+      await deliver([original()]);
+      fetchCalls.length = 0;
+
+      const at = Math.floor(Date.now() / 1000);
+      const stamp = (message: any) => ({ ...message, messageTimestamp: at });
+      // Encrypted under a form only the store knows, so it cannot be applied in
+      // place and is handed to the unresolved path.
+      const deferred = stamp(
+        edit(
+          "primeira",
+          { origMsgSender: CHAT_PN, editSender: CHAT },
+          {
+            id: "edit-1",
+            targetKey: { remoteJid: CHAT, fromMe: false, id: ORIG_ID },
+          },
+        ),
+      );
+      const inBatch = stamp(edit("segunda", undefined, { id: "edit-2" }));
+
+      await deliver([
+        { ...dumped(), key: { remoteJid: CHAT, fromMe: false, id: ORIG_ID } },
+        deferred,
+        inBatch,
+      ]);
+
+      const upsert = fetchCalls.find((c) =>
+        c.body?.includes('"event":"messages.upsert"'),
+      );
+      expect(
+        JSON.parse(upsert?.body as string).data.messages[0].message
+          .conversation,
+      ).toBe("segunda");
+      expect(
+        fetchCalls.some((c) => c.body?.includes('"event":"messages.update"')),
+      ).toBe(false);
     });
 
     // Baileys builds a chat's history array newest-first (it keeps msgs[0] as

--- a/src/baileys/connection.spec.ts
+++ b/src/baileys/connection.spec.ts
@@ -1318,6 +1318,52 @@ describe("BaileysConnection", () => {
       );
     });
 
+    // The dump carries the key and the live edit needs it, and Baileys runs the
+    // two callbacks concurrently. A lookup that lands while the dump is still
+    // resolving LIDs finds nothing, and that miss is final: the edit emits
+    // nothing, so there is no 404 and no retry to recover it.
+    it("waits for a dump still filing the secret before looking it up", async () => {
+      await connection.connect();
+
+      let releaseAddressing: (() => void) | undefined;
+      mockSocket.signalRepository.lidMapping.getPNsForLIDs.mockImplementationOnce(
+        async () => {
+          await new Promise<void>((resolve) => {
+            releaseAddressing = resolve;
+          });
+          return null;
+        },
+      );
+
+      const historyHandler = mockEventHandlers.get("messaging-history.set")!;
+      const dump = historyHandler({
+        chats: [],
+        contacts: [],
+        messages: [dumped()],
+        syncType: 3,
+        isLatest: true,
+      });
+      await new Promise((r) => setImmediate(r));
+
+      // Arrives mid-addressing, which is exactly when the key is not filed yet.
+      const handler = mockEventHandlers.get("messages.upsert")!;
+      await handler({ type: "notify", messages: [edit("oi editado")] });
+      await new Promise((r) => setImmediate(r));
+
+      releaseAddressing?.();
+      await dump;
+      await drain();
+
+      const update = fetchCalls.find((c) =>
+        c.body?.includes('"event":"messages.update"'),
+      );
+      expect(update).toBeDefined();
+      expect(
+        JSON.parse(update?.body as string).data[0].update.message.editedMessage
+          .message.conversation,
+      ).toBe("oi editado");
+    });
+
     // Baileys builds a chat's history array newest-first (it keeps msgs[0] as
     // "the most recent message in the chat"), so walking it straight applies the
     // newest replacement and then overwrites it with an older one.

--- a/src/baileys/connection.spec.ts
+++ b/src/baileys/connection.spec.ts
@@ -669,6 +669,10 @@ describe("BaileysConnection", () => {
     function edit(
       text: string,
       senders = { origMsgSender: CHAT, editSender: CHAT },
+      {
+        id = "edit-1",
+        ageSeconds = 0,
+      }: { id?: string; ageSeconds?: number } = {},
     ) {
       const encIv = randomBytes(12);
       const key = messageEditKey({
@@ -692,9 +696,9 @@ describe("BaileysConnection", () => {
           remoteJid: CHAT,
           remoteJidAlt: CHAT_PN,
           fromMe: false,
-          id: "edit-1",
+          id,
         },
-        messageTimestamp: Math.floor(Date.now() / 1000),
+        messageTimestamp: Math.floor(Date.now() / 1000) - ageSeconds,
         message: {
           secretEncryptedMessage: {
             targetMessageKey: {
@@ -1133,6 +1137,129 @@ describe("BaileysConnection", () => {
           messageSecretKey("+5511999999999", ORIG_ID),
         ),
       ).toBe(false);
+    });
+
+    // Filing the secret is a side effect the delivery sits behind, and it talks
+    // to Redis. Until this reservation existed the count stayed at zero for the
+    // whole write: a handoff or SIGTERM landing on a slow Redis dropped this
+    // connection from the drain set and exited on top of the message.
+    it("counts a batch waiting on the secret store as work to drain", async () => {
+      await connection.connect();
+      const realSet = (redis as any).set;
+      let releaseSet: (() => void) | undefined;
+      (redis as any).set = mock(
+        () =>
+          new Promise<void>((resolve) => {
+            releaseSet = resolve;
+          }),
+      );
+
+      try {
+        const handler = mockEventHandlers.get("messages.upsert")!;
+        const delivery = handler({ type: "notify", messages: [original()] });
+        await new Promise((r) => setImmediate(r));
+
+        expect(connection.inFlightWebhooks).toBeGreaterThan(0);
+
+        releaseSet?.();
+        await delivery;
+      } finally {
+        (redis as any).set = realSet;
+      }
+
+      await drain();
+      expect(connection.inFlightWebhooks).toBe(0);
+    });
+
+    it("counts a dump waiting on the secret store as work to drain", async () => {
+      await connection.connect();
+      const realSet = (redis as any).set;
+      let releaseSet: (() => void) | undefined;
+      (redis as any).set = mock(
+        () =>
+          new Promise<void>((resolve) => {
+            releaseSet = resolve;
+          }),
+      );
+
+      try {
+        const historyHandler = mockEventHandlers.get("messaging-history.set")!;
+        const delivery = historyHandler({
+          chats: [],
+          contacts: [],
+          messages: [dumped()],
+          syncType: 3,
+          isLatest: true,
+        });
+        await new Promise((r) => setImmediate(r));
+
+        expect(connection.inFlightWebhooks).toBeGreaterThan(0);
+
+        releaseSet?.();
+        await delivery;
+      } finally {
+        (redis as any).set = realSet;
+      }
+
+      await drain();
+      expect(connection.inFlightWebhooks).toBe(0);
+    });
+
+    // Baileys builds a chat's history array newest-first (it keeps msgs[0] as
+    // "the most recent message in the chat"), so walking it straight applies the
+    // newest replacement and then overwrites it with an older one.
+    it("applies the newest edit last when a dump carries two of them", async () => {
+      await connection.connect();
+      const historyHandler = mockEventHandlers.get("messaging-history.set")!;
+
+      await historyHandler({
+        chats: [],
+        contacts: [],
+        messages: [
+          edit("segunda", undefined, { id: "edit-2" }),
+          edit("primeira", undefined, { id: "edit-1", ageSeconds: 30 }),
+          dumped(60),
+        ],
+        syncType: 3,
+        isLatest: true,
+      });
+      await drain();
+
+      const frame = fetchCalls.find((c) =>
+        c.body?.includes('"event":"messaging-history.set"'),
+      );
+      const messages = JSON.parse(frame?.body as string).data.messages;
+      expect(messages).toHaveLength(1);
+      expect(messages[0].message.conversation).toBe("segunda");
+    });
+
+    // A disappearing message keeps its content inside `ephemeralMessage` and its
+    // context outside it. Assigning the replacement over the whole `message`
+    // drops the wrapper, and the consumer reads what looks like an ordinary,
+    // non-disappearing message.
+    it("keeps the disappearing-message wrapper when repairing in place", async () => {
+      await connection.connect();
+      const wrapped = original();
+
+      await deliver([
+        {
+          ...wrapped,
+          message: {
+            messageContextInfo: { messageSecret },
+            ephemeralMessage: { message: { conversation: "oi" } },
+          },
+        },
+        edit("oi editado"),
+      ]);
+
+      const upsert = fetchCalls.find((c) =>
+        c.body?.includes('"event":"messages.upsert"'),
+      );
+      const messages = JSON.parse(upsert?.body as string).data.messages;
+      expect(messages).toHaveLength(1);
+      expect(messages[0].message.ephemeralMessage.message.conversation).toBe(
+        "oi editado",
+      );
     });
 
     // A dump strips the addressing, and the second JID form is exactly what the

--- a/src/baileys/connection.spec.ts
+++ b/src/baileys/connection.spec.ts
@@ -957,6 +957,130 @@ describe("BaileysConnection", () => {
       expect(updateAt).toBeGreaterThan(upsertAt);
     });
 
+    // Everything between the event and the send — filing secrets, downloading
+    // media — is time a competing callback can run in. Tracking the delivery
+    // only at send time leaves that whole span looking idle, and an edit that
+    // arrives inside it overtakes the message it edits.
+    it("holds an edit behind an upsert still busy before its send", async () => {
+      await connection.connect();
+      const handler = mockEventHandlers.get("messages.upsert")!;
+      let releaseFiling: (() => void) | undefined;
+      const slowFiling = new Promise<void>((resolve) => {
+        releaseFiling = resolve;
+      });
+      const realSet = (redis as any).set;
+      (redis as any).set = mock(async (...args: unknown[]) => {
+        await slowFiling;
+        return (realSet as any)(...args);
+      });
+
+      const first = handler({ type: "notify", messages: [original()] });
+      await new Promise((r) => setImmediate(r));
+      await handler({ type: "notify", messages: [edit("oi editado")] });
+      await new Promise((r) => setImmediate(r));
+
+      // The original has not even been sent yet, so nothing may have gone out.
+      expect(fetchCalls).toHaveLength(0);
+
+      releaseFiling?.();
+      await first;
+      while (connection.inFlightWebhooks > 0) {
+        await new Promise((r) => setImmediate(r));
+      }
+      (redis as any).set = realSet;
+
+      const upsertAt = fetchCalls.findIndex((c) =>
+        c.body?.includes('"event":"messages.upsert"'),
+      );
+      const updateAt = fetchCalls.findIndex((c) =>
+        c.body?.includes('"event":"messages.update"'),
+      );
+      expect(upsertAt).toBeGreaterThanOrEqual(0);
+      expect(updateAt).toBeGreaterThan(upsertAt);
+    });
+
+    // The chain has to advance on the DELIVERY, not on the call. Advancing on
+    // the call lets a second edit start while the first is still working
+    // through its retries, and the older text lands last and wins.
+    it("does not start the next edit while the previous one is still delivering", async () => {
+      await connection.connect();
+      await deliver([original()]);
+      fetchCalls.length = 0;
+
+      let releaseFirst: (() => void) | undefined;
+      const slowFirst = new Promise<void>((resolve) => {
+        releaseFirst = resolve;
+      });
+      let updates = 0;
+      const realFetch = globalThis.fetch;
+      globalThis.fetch = mock(async (url: any, init?: RequestInit) => {
+        if ((init?.body as string)?.includes('"event":"messages.update"')) {
+          updates += 1;
+          if (updates === 1) {
+            await slowFirst;
+          }
+        }
+        return realFetch(url, init);
+      }) as any;
+
+      await deliver([edit("primeira")]);
+      await deliver([edit("segunda")]);
+      await new Promise((r) => setImmediate(r));
+
+      expect(updates).toBe(1);
+
+      releaseFirst?.();
+      while (connection.inFlightWebhooks > 0) {
+        await new Promise((r) => setImmediate(r));
+      }
+      globalThis.fetch = realFetch;
+
+      const texts = fetchCalls
+        .filter((c) => c.body?.includes('"event":"messages.update"'))
+        .map(
+          (c) =>
+            JSON.parse(c.body).data[0].update.message.editedMessage.message
+              .conversation,
+        );
+      expect(texts).toEqual(["primeira", "segunda"]);
+    });
+
+    // A sync split across notifications can leave the original in an earlier
+    // one. There is nothing left to repair in place by then, but the secret was
+    // filed, so the edit is still readable and goes out as a live update.
+    it("sends a dump edit whose original arrived in an earlier dump", async () => {
+      await connection.connect();
+      const historyHandler = mockEventHandlers.get("messaging-history.set")!;
+
+      await historyHandler({
+        chats: [],
+        contacts: [],
+        messages: [dumped()],
+        syncType: 3,
+      });
+      await new Promise((r) => setImmediate(r));
+      fetchCalls.length = 0;
+
+      await historyHandler({
+        chats: [],
+        contacts: [],
+        messages: [edit("oi editado")],
+        syncType: 3,
+        isLatest: true,
+      });
+      while (connection.inFlightWebhooks > 0) {
+        await new Promise((r) => setImmediate(r));
+      }
+
+      const update = fetchCalls.find((c) =>
+        c.body?.includes('"event":"messages.update"'),
+      );
+      expect(
+        JSON.parse(update?.body as string).data[0].update.message.editedMessage
+          .message.conversation,
+      ).toBe("oi editado");
+    });
+
     // A dump is repaired in place rather than re-narrated as an update: an
     // importer decides its own ordering, so an update would race the very write
     // it targets.

--- a/src/baileys/connection.spec.ts
+++ b/src/baileys/connection.spec.ts
@@ -1579,6 +1579,114 @@ describe("BaileysConnection", () => {
       ).toBe("legivel");
     });
 
+    // A 404 puts an edit in the retry ladder for a minute. A batch repairing the
+    // same message meanwhile has already sent the newer text, and the guard
+    // cannot cancel a delivery that already started, only refuse the next one.
+    it("abandons an edit whose retry was overtaken by a repaired batch", async () => {
+      await connect();
+      await deliver([original()]);
+      fetchCalls.length = 0;
+
+      const realRetries = config.webhook.retryPolicy.maxRetries;
+      (config.webhook.retryPolicy as any).maxRetries = 3;
+      let releaseFirst: (() => void) | undefined;
+      const firstAttempt = new Promise<void>((resolve) => {
+        releaseFirst = resolve;
+      });
+      let attempts = 0;
+      const realFetch = globalThis.fetch;
+      globalThis.fetch = mock(async (url: any, init?: RequestInit) => {
+        if ((init?.body as string)?.includes('"event":"messages.update"')) {
+          attempts += 1;
+          if (attempts === 1) {
+            await firstAttempt;
+          }
+          // The consumer has not written the original yet.
+          return new Response("", { status: 404 });
+        }
+        return realFetch(url, init);
+      }) as any;
+
+      const handler = mockEventHandlers.get("messages.upsert")!;
+      try {
+        const retrying = handler({
+          type: "notify",
+          messages: [edit("primeira", undefined, { id: "edit-1" })],
+        });
+        await new Promise((r) => setImmediate(r));
+        expect(attempts).toBe(1);
+
+        // Repaired in place, so the newer text is already on its way out.
+        await handler({
+          type: "notify",
+          messages: [original(), edit("segunda", undefined, { id: "edit-2" })],
+        });
+
+        releaseFirst?.();
+        await retrying;
+        await drain();
+      } finally {
+        globalThis.fetch = realFetch;
+        (config.webhook.retryPolicy as any).maxRetries = realRetries;
+      }
+
+      // The first attempt happened before it could be known to be obsolete; no
+      // retry of it may follow.
+      expect(attempts).toBe(1);
+    });
+
+    // Two dumps whose edits are stamped in the same second are separated only by
+    // the order they arrived in, and the addressing lookup destroys that order:
+    // whichever dump resolves its LIDs first reaches the queue first.
+    it("keeps the later dump's edit when a stalled one carries the same second", async () => {
+      await connect();
+      await deliver([original()]);
+      fetchCalls.length = 0;
+
+      let releaseAddressing: (() => void) | undefined;
+      mockSocket.signalRepository.lidMapping.getPNsForLIDs.mockImplementationOnce(
+        async () => {
+          await new Promise<void>((resolve) => {
+            releaseAddressing = resolve;
+          });
+          return null;
+        },
+      );
+
+      const at = Math.floor(Date.now() / 1000);
+      const stamp = (message: any) => ({ ...message, messageTimestamp: at });
+      const historyHandler = mockEventHandlers.get("messaging-history.set")!;
+
+      const stalled = historyHandler({
+        chats: [],
+        contacts: [],
+        messages: [stamp(edit("primeira", undefined, { id: "edit-1" }))],
+        syncType: 3,
+      });
+      await new Promise((r) => setImmediate(r));
+
+      await historyHandler({
+        chats: [],
+        contacts: [],
+        messages: [stamp(edit("segunda", undefined, { id: "edit-2" }))],
+        syncType: 3,
+        isLatest: true,
+      });
+
+      releaseAddressing?.();
+      await stalled;
+      await drain();
+
+      const texts = fetchCalls
+        .filter((c) => c.body?.includes('"event":"messages.update"'))
+        .map(
+          (c) =>
+            JSON.parse(c.body).data[0].update.message.editedMessage.message
+              .conversation,
+        );
+      expect(texts).toEqual(["segunda"]);
+    });
+
     // Baileys builds a chat's history array newest-first (it keeps msgs[0] as
     // "the most recent message in the chat"), so walking it straight applies the
     // newest replacement and then overwrites it with an older one.

--- a/src/baileys/connection.ts
+++ b/src/baileys/connection.ts
@@ -304,6 +304,9 @@ export class BaileysConnection {
   private sessionEnded = false;
   // Serializes the send-stall verdicts against each other. See reportSendStall.
   private stallReportChain: Promise<unknown> = Promise.resolve();
+  // Serializes encrypted-edit deliveries against each other. See
+  // emitUnresolvedEdits.
+  private editDeliveryQueue: Promise<void> = Promise.resolve();
   private stallStrikeRollback:
     | { previous: SendStallState | null; ttlMs: number | null; wrote: string }
     | undefined;
@@ -2419,10 +2422,10 @@ export class BaileysConnection {
     // Same two steps as a history dump, and deliberately the same code: repair
     // what this batch can repair itself, file the secrets a later edit will
     // need, and let anything left over go out as an ordinary update.
-    const { kept, unresolved } = this.repairSecretMessageEdits(
+    const { kept, unresolved, secrets } = this.repairSecretMessageEdits(
       messagesData.messages,
     );
-    await this.rememberMessageSecretsFor(kept);
+    await this.fileMessageSecrets(secrets);
 
     if (kept.length > 0) {
       if (kept.length !== messagesData.messages.length) {
@@ -2447,65 +2450,87 @@ export class BaileysConnection {
     this.emitUnresolvedEdits(unresolved);
   }
 
-  // Sends the edits this batch could not apply itself, exactly the way Baileys
-  // sends a plaintext one: fire and forget, in arrival order, no queue.
+  // Sends the edits this batch could not apply itself, one at a time.
   //
-  // There is deliberately no ordering machinery around this. An edit whose
-  // original is still being written by the consumer is answered 404, and
-  // `awaitResponse` puts the delivery back through the retry loop — the
-  // ordering is already in the protocol, and four rounds of hand-built
-  // barriers, chains and delivery slots only added ways to lose a message that
-  // the retry never had. After decryption this IS a plaintext edit, so it is
-  // delivered as one and inherits exactly the guarantees the provider already
-  // gives every other edit.
+  // Nothing here waits on the upserts: an edit whose original the consumer has
+  // not written yet is answered 404 and `awaitResponse` puts the delivery back
+  // through the retry loop, so that ordering is already in the protocol. The
+  // barriers and delivery slots built to duplicate it only added ways to lose a
+  // message the retry never had, and are gone.
+  //
+  // What the protocol does NOT give is order between two edits of the SAME
+  // message: once the target exists both are answered 200, so a first edit
+  // working through a retry can land after a second and the older text wins.
+  // Hence the queue — and only the queue. It orders edits against each other,
+  // touches nothing else on the connection, and holds the in-flight
+  // reservation for the span, which is the piece a graceful shutdown needs.
   private emitUnresolvedEdits(
     unresolved: Array<{ message: WAMessage; edit: SecretMessageEdit }>,
   ) {
-    for (const { message, edit } of unresolved) {
-      // Reserved synchronously, for the reason `stallReportChain` reserves its
-      // own: recalling the secret and decrypting both suspend before
-      // sendToWebhook increments anything, and a SIGTERM landing in that gap
-      // would read nothing pending and exit on top of the edit.
-      this._inFlightWebhooks += 1;
-      void this.emitSecretMessageEdit(message, edit).finally(() => {
+    if (unresolved.length === 0) {
+      return;
+    }
+
+    // Reserved synchronously, for the reason `stallReportChain` reserves its
+    // own: the queue does not reach sendToWebhook until a microtask, and a
+    // SIGTERM landing in that gap would read nothing pending and exit on top of
+    // these edits.
+    this._inFlightWebhooks += 1;
+    this.editDeliveryQueue = this.editDeliveryQueue
+      .catch(() => {})
+      .then(async () => {
+        for (const { message, edit } of unresolved) {
+          await this.emitSecretMessageEdit(message, edit);
+        }
+      })
+      .catch(() => {})
+      .finally(() => {
         this._inFlightWebhooks -= 1;
       });
-    }
   }
 
-  private repairSecretMessageEdits(messages: WAMessage[]): {
+  private repairSecretMessageEdits(
+    messages: WAMessage[],
+    { onlyRecent = false }: { onlyRecent?: boolean } = {},
+  ): {
     kept: WAMessage[];
     unresolved: Array<{ message: WAMessage; edit: SecretMessageEdit }>;
+    secrets: MessageSecretEntry[];
   } {
     const { kept, edits } = this.splitSecretMessageEdits(messages);
+
+    // Read BEFORE any repair below, and filed from here rather than from the
+    // messages afterwards: applying an edit in place replaces the content that
+    // holds the secret, so re-reading a repaired message finds nothing and the
+    // NEXT edit to it would arrive undecryptable.
+    const secrets = this.collectMessageSecrets(kept, { onlyRecent });
+
     if (edits.length === 0) {
-      return { kept, unresolved: [] };
+      return { kept, unresolved: [], secrets };
     }
 
     const unresolved: Array<{ message: WAMessage; edit: SecretMessageEdit }> =
       [];
 
-    // Indexed from the dump itself, not from Redis: an edit replayed alongside
-    // its original needs that original's secret, and one round trip per edit
-    // would ask the network for something already in hand.
-    const secrets = new Map<string, Uint8Array>();
+    // Indexed from this batch, not from Redis: an edit arriving alongside its
+    // original needs that original's secret, and a round trip per edit would
+    // ask the network for something already in hand.
     const byId = new Map<string, WAMessage>();
+    const secretById = new Map<string, Uint8Array>();
+    for (const entry of secrets) {
+      secretById.set(entry.messageId, entry.secret);
+    }
     for (const message of kept) {
       const id = message.key?.id;
-      if (!id) {
-        continue;
-      }
-      byId.set(id, message);
-      const secret = ownMessageSecret(message);
-      if (secret) {
-        secrets.set(id, secret);
+      if (id) {
+        byId.set(id, message);
       }
     }
 
     for (const { message, edit } of edits) {
       const targetId = edit.targetKey.id as string;
       const target = byId.get(targetId);
-      const secret = secrets.get(targetId);
+      const secret = secretById.get(targetId);
       if (!target || !secret) {
         unresolved.push({ message, edit });
         continue;
@@ -2543,7 +2568,7 @@ export class BaileysConnection {
       }
     }
 
-    return { kept, unresolved };
+    return { kept, unresolved, secrets };
   }
 
   // Files only the messages a future edit could still target. WhatsApp closes
@@ -2552,10 +2577,15 @@ export class BaileysConnection {
   // decrypt anything: filing an archive's worth of them would spend a round
   // trip per message, hold the dump behind all of them, and leave a keyspace
   // nothing will ever read.
-  private async rememberMessageSecretsFor(
+  // The secrets on these messages, as store entries. Split from the write so
+  // the read can happen before an in-place repair overwrites what it reads.
+  private collectMessageSecrets(
     messages: WAMessage[],
     { onlyRecent = false }: { onlyRecent?: boolean } = {},
-  ) {
+  ): MessageSecretEntry[] {
+    // Only a dump is filtered by age: a live message is current by definition,
+    // and dropping one whose timestamp reads oddly would silently cost the edit
+    // that follows it.
     const oldest = Date.now() / 1000 - MESSAGE_SECRET_TTL_SECONDS;
     const entries: MessageSecretEntry[] = [];
 
@@ -2575,6 +2605,10 @@ export class BaileysConnection {
       });
     }
 
+    return entries;
+  }
+
+  private async fileMessageSecrets(entries: MessageSecretEntry[]) {
     if (entries.length === 0) {
       return;
     }
@@ -2586,8 +2620,10 @@ export class BaileysConnection {
         () => rememberMessageSecrets(this.phoneNumber, entries),
       );
     } catch (error) {
+      // A secret we cannot file is a future edit we cannot decrypt, never a
+      // reason to withhold the messages themselves.
       logger.warn(
-        "[%s] [rememberMessageSecretsFor] failed for %d message(s)\n%s",
+        "[%s] [fileMessageSecrets] failed for %d message(s)\n%s",
         this.phoneNumber,
         entries.length,
         errorToString(error),
@@ -2916,12 +2952,12 @@ export class BaileysConnection {
       data.lidPnMappings,
       data.chats ?? [],
     );
-    const { kept: messages, unresolved: unresolvedEdits } =
-      this.repairSecretMessageEdits(addressed);
-    // Only the dump is filtered by age: a live message is current by
-    // definition, and dropping one whose timestamp reads oddly would silently
-    // cost the edit that follows it.
-    await this.rememberMessageSecretsFor(messages, { onlyRecent: true });
+    const {
+      kept: messages,
+      unresolved: unresolvedEdits,
+      secrets,
+    } = this.repairSecretMessageEdits(addressed, { onlyRecent: true });
+    await this.fileMessageSecrets(secrets);
 
     // The one thing worth keeping from the chat records: which chats have
     // nothing older left. An answer that still has history behind it carries no

--- a/src/baileys/connection.ts
+++ b/src/baileys/connection.ts
@@ -54,7 +54,9 @@ import { preprocessAudio } from "@/baileys/helpers/preprocessAudio";
 import {
   decodeEditedMessage,
   messageTimestampSeconds,
+  orderEditsOldestFirst,
   ownMessageSecret,
+  replaceInnerContent,
   type SecretMessageEdit,
   secretMessageEdit,
 } from "@/baileys/helpers/secretEncryptedMessageEdit";
@@ -2425,26 +2427,37 @@ export class BaileysConnection {
     const { kept, unresolved, secrets } = this.repairSecretMessageEdits(
       messagesData.messages,
     );
-    await this.fileMessageSecrets(secrets);
 
-    if (kept.length > 0) {
-      if (kept.length !== messagesData.messages.length) {
-        messagesData = { ...messagesData, messages: kept };
+    // Reserved here, synchronously, and held until the batch is out. Between
+    // this line and the send sit a Redis write and a media download, and both
+    // can stall: a handoff or SIGTERM landing on either reads inFlightWebhooks
+    // as zero, leaves this connection out of drainingWebhooks and exits on top
+    // of messages that were never delivered.
+    this._inFlightWebhooks += 1;
+    try {
+      await this.fileMessageSecrets(secrets);
+
+      if (kept.length > 0) {
+        if (kept.length !== messagesData.messages.length) {
+          messagesData = { ...messagesData, messages: kept };
+        }
+
+        const payload: BaileysConnectionWebhookPayload = {
+          event: "messages.upsert",
+          data: messagesData,
+        };
+
+        const media = await downloadMediaFromMessages(messagesData.messages, {
+          includeMedia: this.includeMedia,
+        });
+        if (media) {
+          payload.extra = { media };
+        }
+
+        await this.sendToWebhook(payload);
       }
-
-      const payload: BaileysConnectionWebhookPayload = {
-        event: "messages.upsert",
-        data: messagesData,
-      };
-
-      const media = await downloadMediaFromMessages(messagesData.messages, {
-        includeMedia: this.includeMedia,
-      });
-      if (media) {
-        payload.extra = { media };
-      }
-
-      await this.sendToWebhook(payload);
+    } finally {
+      this._inFlightWebhooks -= 1;
     }
 
     this.emitUnresolvedEdits(unresolved);
@@ -2491,7 +2504,7 @@ export class BaileysConnection {
 
   private repairSecretMessageEdits(
     messages: WAMessage[],
-    { onlyRecent = false }: { onlyRecent?: boolean } = {},
+    { history = false }: { history?: boolean } = {},
   ): {
     kept: WAMessage[];
     unresolved: Array<{ message: WAMessage; edit: SecretMessageEdit }>;
@@ -2503,7 +2516,7 @@ export class BaileysConnection {
     // messages afterwards: applying an edit in place replaces the content that
     // holds the secret, so re-reading a repaired message finds nothing and the
     // NEXT edit to it would arrive undecryptable.
-    const secrets = this.collectMessageSecrets(kept, { onlyRecent });
+    const secrets = this.collectMessageSecrets(kept, { history });
 
     if (edits.length === 0) {
       return { kept, unresolved: [], secrets };
@@ -2527,7 +2540,9 @@ export class BaileysConnection {
       }
     }
 
-    for (const { message, edit } of edits) {
+    for (const { message, edit } of orderEditsOldestFirst(edits, {
+      newestFirst: history,
+    })) {
       const targetId = edit.targetKey.id as string;
       const target = byId.get(targetId);
       const secret = secretById.get(targetId);
@@ -2557,7 +2572,10 @@ export class BaileysConnection {
           );
           continue;
         }
-        target.message = decodeEditedMessage(decrypted.plaintext);
+        target.message = replaceInnerContent(
+          target.message,
+          decodeEditedMessage(decrypted.plaintext),
+        );
       } catch (error) {
         logger.warn(
           "[%s] [repairSecretMessageEdits] failed targetId=%s\n%s",
@@ -2581,11 +2599,12 @@ export class BaileysConnection {
   // the read can happen before an in-place repair overwrites what it reads.
   private collectMessageSecrets(
     messages: WAMessage[],
-    { onlyRecent = false }: { onlyRecent?: boolean } = {},
+    { history = false }: { history?: boolean } = {},
   ): MessageSecretEntry[] {
     // Only a dump is filtered by age: a live message is current by definition,
     // and dropping one whose timestamp reads oddly would silently cost the edit
-    // that follows it.
+    // that follows it. This is the age half of `history`; the other half is the
+    // array order, which orderEditsOldestFirst reads.
     const oldest = Date.now() / 1000 - MESSAGE_SECRET_TTL_SECONDS;
     const entries: MessageSecretEntry[] = [];
 
@@ -2595,7 +2614,7 @@ export class BaileysConnection {
       if (!messageId || !secret) {
         continue;
       }
-      if (onlyRecent && messageTimestampSeconds(message) < oldest) {
+      if (history && messageTimestampSeconds(message) < oldest) {
         continue;
       }
       entries.push({
@@ -2956,16 +2975,35 @@ export class BaileysConnection {
       kept: messages,
       unresolved: unresolvedEdits,
       secrets,
-    } = this.repairSecretMessageEdits(addressed, { onlyRecent: true });
-    await this.fileMessageSecrets(secrets);
+    } = this.repairSecretMessageEdits(addressed, { history: true });
 
+    // Same reservation, same reason as the live path: the Redis write below is
+    // a stall this connection has to survive being drained through, and until
+    // the first frame reaches sendToWebhook nothing else is holding it.
+    this._inFlightWebhooks += 1;
+    try {
+      await this.fileMessageSecrets(secrets);
+      await this.deliverHistoryFrames(data, messages);
+    } finally {
+      this._inFlightWebhooks -= 1;
+    }
+
+    // After the frames: the dump is what carries the originals these could not
+    // be applied to, and a consumer that has not seen them yet answers 404.
+    // That answer is retried, which is the whole reason this needs no queue.
+    this.emitUnresolvedEdits(unresolvedEdits);
+  }
+
+  private async deliverHistoryFrames(
+    data: BaileysEventMap["messaging-history.set"],
+    messages: WAMessage[],
+  ) {
     // The one thing worth keeping from the chat records: which chats have
     // nothing older left. An answer that still has history behind it carries no
     // chat record at all, so an empty list here means "no news", never "there
     // is more".
     const exhausted = exhaustedChats(data.chats ?? []);
     if (messages.length === 0 && exhausted.length === 0) {
-      this.emitUnresolvedEdits(unresolvedEdits);
       return;
     }
 
@@ -3016,11 +3054,6 @@ export class BaileysConnection {
         },
       });
     }
-
-    // After the frames: the dump is what carries the originals these could not
-    // be applied to, and a consumer that has not seen them yet answers 404.
-    // That answer is retried, which is the whole reason this needs no queue.
-    this.emitUnresolvedEdits(unresolvedEdits);
   }
 
   // Restores the addressing a dump strips (see historySync.ts), from the two

--- a/src/baileys/connection.ts
+++ b/src/baileys/connection.ts
@@ -3050,35 +3050,72 @@ export class BaileysConnection {
     data: BaileysEventMap["messages.update"],
   ): Promise<unknown> {
     const seq = ++this.eventSeq;
-    const wanted = data.filter((entry, rank) => {
+    const edits: {
+      entry: BaileysEventMap["messages.update"][number];
+      targetId: string;
+      position: EditPosition;
+    }[] = [];
+    const rest: BaileysEventMap["messages.update"] = [];
+
+    data.forEach((entry, rank) => {
       const targetId = entry.key?.id;
       if (!entry.update?.message?.editedMessage || !targetId) {
-        return true;
+        rest.push(entry);
+        return;
       }
-      const claimed = this.claimEditPosition(targetId, {
-        at: messageTimestampSeconds(entry.update),
-        seq,
-        rank,
-      });
-      if (!claimed) {
+      const position = { at: messageTimestampSeconds(entry.update), seq, rank };
+      if (!this.claimEditPosition(targetId, position)) {
+        // Relaying it would put the older text back over the newer one, which
+        // is the whole point of the claim.
         logger.debug(
           "[%s] [onMessagesUpdate] superseded plaintext edit targetId=%s",
           this.phoneNumber,
           targetId,
         );
+        return;
       }
-      return claimed;
+      edits.push({ entry, targetId, position });
     });
 
-    if (!wanted.length) {
-      // Every entry was an edit something newer had already answered. Dropping
-      // them is the point — relaying one puts the older text back — but they
-      // were still inbound activity, and the rebalancer reads silence as idle.
+    if (edits.length) {
+      // One delivery per edit, on the target's own chain, exactly as the
+      // encrypted path does — and for the same three reasons. A batch relayed
+      // whole could only carry one `stillWanted` for all of it, so one aged
+      // edit would drop the others; the chain keeps two edits of one message in
+      // order without holding up any other chat; and being IN `editDeliveries`
+      // is what stops a history sync from evicting this position out from under
+      // its own retry.
+      //
+      // Reserved synchronously, for the reason `emitUnresolvedEdits` reserves
+      // its own: nothing reaches sendToWebhook until a microtask, and a SIGTERM
+      // landing in that gap would read nothing pending and exit on top of it.
+      this._inFlightWebhooks += 1;
+      const deliveries = edits.map(({ entry, targetId, position }) =>
+        this.enqueueEditDelivery(targetId, () =>
+          this.handleMessagesUpdate([entry], {
+            // Re-read between retries, not only before the first attempt: a
+            // 404 parks this in the retry ladder for a minute, and an
+            // encrypted edit applied meanwhile has already sent newer text.
+            stillWanted: () => !this.editSuperseded(targetId, position),
+          }).then(() => {}),
+        ),
+      );
+      Promise.all(deliveries)
+        .catch(() => {})
+        .finally(() => {
+          this._inFlightWebhooks -= 1;
+        });
+    }
+
+    if (!rest.length) {
+      // Nothing left to relay inline, but this was still inbound activity and
+      // the rebalancer reads silence as idle. The deliveries above mark it too,
+      // a tick later, which is a tick too late.
       this.markTraffic();
       return Promise.resolve();
     }
 
-    return this.handleMessagesUpdate(wanted);
+    return this.handleMessagesUpdate(rest);
   }
 
   private handleMessagesUpdate(

--- a/src/baileys/connection.ts
+++ b/src/baileys/connection.ts
@@ -176,11 +176,21 @@ export class BaileysSendStalledError extends Error {
   }
 }
 
-/** An edit's place in its target's history: when it was made, then which event
- * brought it. The second term only ever separates a tie in the first. */
+/**
+ * An edit's place in its target's history: when it was made, then which event
+ * brought it, then where it sat inside that event. Each term only ever
+ * separates a tie in the one before it.
+ *
+ * The third exists because one batch can carry two edits of the same message
+ * stamped in the same second, and they do not necessarily take the same route
+ * out: the newer can decrypt in place while the older falls back to the stored
+ * sender forms and leaves as an update. Without a rank the older one would not
+ * look superseded, and would revert the message.
+ */
 interface EditPosition {
   at: number;
   seq: number;
+  rank: number;
 }
 
 interface UnresolvedEdit {
@@ -2660,7 +2670,10 @@ export class BaileysConnection {
     if (position.at !== applied.at) {
       return position.at < applied.at;
     }
-    return position.seq < applied.seq;
+    if (position.seq !== applied.seq) {
+      return position.seq < applied.seq;
+    }
+    return position.rank < applied.rank;
   }
 
   private repairSecretMessageEdits(
@@ -2707,13 +2720,14 @@ export class BaileysConnection {
       }
     }
 
-    for (const { message, edit } of orderEditsOldestFirst(edits, {
-      newestFirst: history,
-    })) {
+    // Ranked by the order they were just sorted into, which is the order they
+    // are applied in.
+    const ordered = orderEditsOldestFirst(edits, { newestFirst: history });
+    for (const [rank, { message, edit }] of ordered.entries()) {
       const targetId = edit.targetKey.id as string;
       const target = byId.get(targetId);
       const secret = secretById.get(targetId);
-      const position = { at: messageTimestampSeconds(message), seq };
+      const position = { at: messageTimestampSeconds(message), seq, rank };
       if (!target || !secret) {
         unresolved.push({ message, edit, position });
         continue;

--- a/src/baileys/connection.ts
+++ b/src/baileys/connection.ts
@@ -309,6 +309,9 @@ export class BaileysConnection {
   // Serializes encrypted-edit deliveries against each other. See
   // emitUnresolvedEdits.
   private editDeliveryQueue: Promise<void> = Promise.resolve();
+  // Secrets this connection has taken in but not yet filed. See
+  // beginSecretIntake.
+  private secretIntake: Promise<unknown> = Promise.resolve();
   private stallStrikeRollback:
     | { previous: SendStallState | null; ttlMs: number | null; wrote: string }
     | undefined;
@@ -2424,6 +2427,9 @@ export class BaileysConnection {
     // Same two steps as a history dump, and deliberately the same code: repair
     // what this batch can repair itself, file the secrets a later edit will
     // need, and let anything left over go out as an ordinary update.
+    // Opened before the secrets are read and closed once they are filed, so an
+    // edit arriving on another callback waits for them instead of missing.
+    const releaseIntake = this.beginSecretIntake();
     const { kept, unresolved, secrets } = this.repairSecretMessageEdits(
       messagesData.messages,
     );
@@ -2445,7 +2451,11 @@ export class BaileysConnection {
     // of messages that were never delivered.
     this._inFlightWebhooks += 1;
     try {
-      await this.fileMessageSecrets(secrets);
+      try {
+        await this.fileMessageSecrets(secrets);
+      } finally {
+        releaseIntake();
+      }
 
       if (kept.length > 0) {
         if (kept.length !== messagesData.messages.length) {
@@ -2508,6 +2518,27 @@ export class BaileysConnection {
       .finally(() => {
         this._inFlightWebhooks -= 1;
       });
+  }
+
+  /**
+   * Opens a window that stays open until this batch's secrets are filed, and
+   * returns the handle that closes it. Registered synchronously, so it is
+   * already open before anything else on this connection gets to run.
+   *
+   * An edit's key lookup waits for whatever windows were open when it ran. A
+   * miss there is final in a way nothing else in this path is: an edit
+   * delivered out of order is answered 404 and the retry loop recovers it, but
+   * an edit that found no key emits nothing, so there is nothing to retry. The
+   * dump that carries the key can easily still be inside `addressHistory` when
+   * the live edit arrives, because Baileys does not await our handlers.
+   */
+  private beginSecretIntake(): () => void {
+    let close: () => void = () => {};
+    const open = new Promise<void>((resolve) => {
+      close = resolve;
+    });
+    this.secretIntake = Promise.all([this.secretIntake, open]);
+    return close;
   }
 
   private repairSecretMessageEdits(
@@ -2710,6 +2741,26 @@ export class BaileysConnection {
     { targetKey, encPayload, encIv }: SecretMessageEdit,
   ) {
     const targetId = targetKey.id as string;
+
+    // The dump or upsert carrying this message's secret may still be filing it.
+    // Bounded, because `addressHistory` waits on the keystore and a wedged one
+    // must not park every edit behind it: on a timeout the lookup goes ahead
+    // and, at worst, misses the way it would have anyway.
+    try {
+      await withTimeout(
+        "secretIntake",
+        config.baileys.messageSecretStoreTimeoutMs,
+        () => this.secretIntake,
+      );
+    } catch (error) {
+      logger.warn(
+        "[%s] [emitSecretMessageEdit] secret intake did not settle targetId=%s\n%s",
+        this.phoneNumber,
+        targetId,
+        errorToString(error),
+      );
+    }
+
     const stored = await withTimeout(
       "recallMessageSecret",
       config.baileys.messageSecretStoreTimeoutMs,
@@ -2977,34 +3028,45 @@ export class BaileysConnection {
   private async handleMessagingHistorySet(
     data: BaileysEventMap["messaging-history.set"],
   ) {
-    // Addressing first, secrets second, and the order is load-bearing: a dump's
-    // keys arrive without their `remoteJidAlt`/`participantAlt`, and those are
-    // the second JID form every stored author candidate needs. Filing before
-    // the restore would record half the candidates, and a later edit derived
-    // from the form we dropped would never verify.
-    const addressed = await this.addressHistory(
-      data.messages ?? [],
-      data.lidPnMappings,
-      data.chats ?? [],
-    );
-    const {
-      kept: messages,
-      unresolved: unresolvedEdits,
-      secrets,
-    } = this.repairSecretMessageEdits(addressed, { history: true });
-    // Same reason as the live path: enqueued before the awaits below, so the
-    // queue's order is the order the dumps were handled in rather than whichever
-    // one finished writing first. The one await this cannot get in front of is
-    // `addressHistory` above, which has to run before anything can be decrypted;
-    // two dumps carrying edits of the SAME message can still cross there.
-    this.emitUnresolvedEdits(unresolvedEdits);
+    // Opened before the addressing round trip below, which is the window the
+    // whole gate exists for: a live edit arriving while this dump is still
+    // resolving LIDs would look its key up, find the dump had not filed it yet
+    // and drop the edit with nothing to retry.
+    const releaseIntake = this.beginSecretIntake();
 
     // Same reservation, same reason as the live path: the Redis write below is
     // a stall this connection has to survive being drained through, and until
     // the first frame reaches sendToWebhook nothing else is holding it.
     this._inFlightWebhooks += 1;
     try {
-      await this.fileMessageSecrets(secrets);
+      let messages: WAMessage[] = [];
+      try {
+        // Addressing first, secrets second, and the order is load-bearing: a
+        // dump's keys arrive without their `remoteJidAlt`/`participantAlt`, and
+        // those are the second JID form every stored author candidate needs.
+        // Filing before the restore would record half the candidates, and a
+        // later edit derived from the form we dropped would never verify.
+        const addressed = await this.addressHistory(
+          data.messages ?? [],
+          data.lidPnMappings,
+          data.chats ?? [],
+        );
+        const { kept, unresolved, secrets } = this.repairSecretMessageEdits(
+          addressed,
+          { history: true },
+        );
+        messages = kept;
+        // Same reason as the live path: enqueued before the write below, so the
+        // queue's order is the order the dumps were handled in rather than
+        // whichever one finished writing first.
+        this.emitUnresolvedEdits(unresolved);
+        await this.fileMessageSecrets(secrets);
+      } finally {
+        // Closed as soon as the secrets are down, not after the frames: an edit
+        // has no reason to wait behind the delivery of a whole archive.
+        releaseIntake();
+      }
+
       await this.deliverHistoryFrames(data, messages);
     } finally {
       this._inFlightWebhooks -= 1;

--- a/src/baileys/connection.ts
+++ b/src/baileys/connection.ts
@@ -176,6 +176,19 @@ export class BaileysSendStalledError extends Error {
   }
 }
 
+/** An edit's place in its target's history: when it was made, then which event
+ * brought it. The second term only ever separates a tie in the first. */
+interface EditPosition {
+  at: number;
+  seq: number;
+}
+
+interface UnresolvedEdit {
+  message: WAMessage;
+  edit: SecretMessageEdit;
+  position: EditPosition;
+}
+
 export class BaileysConnection {
   private LOGGER_OMIT_KEYS: ReadonlyArray<string> = [
     "qr",
@@ -314,7 +327,13 @@ export class BaileysConnection {
   private secretIntake: Promise<unknown> = Promise.resolve();
   // When each edited message was last edited, as far as this connection has
   // delivered. See claimEditPosition.
-  private editedAt = new Map<string, number>();
+  private editedAt = new Map<string, EditPosition>();
+  // Increments once per event this connection takes in, read synchronously at
+  // the top of each handler. It is the tie-break for edits stamped in the same
+  // second: the timestamp cannot separate them, but the order WhatsApp handed
+  // them to us can, and that order is only knowable before the handler starts
+  // awaiting things.
+  private eventSeq = 0;
   private stallStrikeRollback:
     | { previous: SendStallState | null; ttlMs: number | null; wrote: string }
     | undefined;
@@ -2395,6 +2414,9 @@ export class BaileysConnection {
   }
 
   private async handleMessagesUpsert(data: BaileysEventMap["messages.upsert"]) {
+    // Taken before anything can suspend, so it records the order WhatsApp
+    // handed us the events rather than the order they finished being processed.
+    const seq = ++this.eventSeq;
     this.markTraffic();
     if (data.type === "notify") {
       for (const msg of data.messages) {
@@ -2438,6 +2460,7 @@ export class BaileysConnection {
     const releaseIntake = this.beginSecretIntake();
     const { kept, unresolved, secrets } = this.repairSecretMessageEdits(
       messagesData.messages,
+      { seq },
     );
     // Enqueued here, before the first await: the queue orders edits by the
     // moment they are put on it, and everything below can suspend. Two upsert
@@ -2501,9 +2524,7 @@ export class BaileysConnection {
   // Hence the queue — and only the queue. It orders edits against each other,
   // touches nothing else on the connection, and holds the in-flight
   // reservation for the span, which is the piece a graceful shutdown needs.
-  private emitUnresolvedEdits(
-    unresolved: Array<{ message: WAMessage; edit: SecretMessageEdit }>,
-  ) {
+  private emitUnresolvedEdits(unresolved: UnresolvedEdit[]) {
     if (unresolved.length === 0) {
       return;
     }
@@ -2523,8 +2544,8 @@ export class BaileysConnection {
     this.editDeliveryQueue = this.editDeliveryQueue
       .catch(() => {})
       .then(async () => {
-        for (const { message, edit } of unresolved) {
-          await this.emitSecretMessageEdit(message, edit);
+        for (const { message, edit, position } of unresolved) {
+          await this.emitSecretMessageEdit(message, edit, position);
         }
       })
       .catch(() => {})
@@ -2573,20 +2594,21 @@ export class BaileysConnection {
    * cost more than it bought, so the guard is on the outcome instead: an edit
    * older than one already applied changes nothing, whichever way it got here.
    *
-   * Strictly older, not older-or-equal: two edits stamped in the same second
-   * carry no order of their own, and `editDeliveryQueue` is what keeps those in
-   * the order they arrived.
+   * Ordered by the edit's timestamp and then by the event it arrived on, which
+   * is what separates two edits stamped in the same second. Without the second
+   * term the guard would have to let both through and trust the delivery order,
+   * and the delivery order is precisely what a dump's addressing lookup
+   * reshuffles.
    */
-  private claimEditPosition(targetId: string, editedAt: number): boolean {
-    const applied = this.editedAt.get(targetId);
-    if (applied !== undefined && editedAt < applied) {
+  private claimEditPosition(targetId: string, position: EditPosition): boolean {
+    if (this.editSuperseded(targetId, position)) {
       return false;
     }
 
     // Re-inserted rather than updated in place, so the map's own order stays
     // least-recently-claimed first and the eviction below takes the right one.
     this.editedAt.delete(targetId);
-    this.editedAt.set(targetId, Math.max(editedAt, applied ?? editedAt));
+    this.editedAt.set(targetId, position);
     if (this.editedAt.size > BaileysConnection.EDIT_POSITION_MEMORY) {
       const oldest = this.editedAt.keys().next();
       if (!oldest.done) {
@@ -2596,12 +2618,31 @@ export class BaileysConnection {
     return true;
   }
 
+  /**
+   * Whether something newer than this edit has already been applied.
+   *
+   * Read again between a delivery's retries, not only before it starts: an edit
+   * answered 404 sits in the retry ladder for a minute, and a batch that
+   * repaired the same message in the meantime has already sent the newer text.
+   * The retry would then land last and put the older text back.
+   */
+  private editSuperseded(targetId: string, position: EditPosition): boolean {
+    const applied = this.editedAt.get(targetId);
+    if (!applied) {
+      return false;
+    }
+    if (position.at !== applied.at) {
+      return position.at < applied.at;
+    }
+    return position.seq < applied.seq;
+  }
+
   private repairSecretMessageEdits(
     messages: WAMessage[],
-    { history = false }: { history?: boolean } = {},
+    { history = false, seq }: { history?: boolean; seq: number },
   ): {
     kept: WAMessage[];
-    unresolved: Array<{ message: WAMessage; edit: SecretMessageEdit }>;
+    unresolved: Array<UnresolvedEdit>;
     secrets: MessageSecretEntry[];
   } {
     const { kept, edits } = this.splitSecretMessageEdits(messages);
@@ -2623,8 +2664,7 @@ export class BaileysConnection {
       return { kept, unresolved: [], secrets };
     }
 
-    const unresolved: Array<{ message: WAMessage; edit: SecretMessageEdit }> =
-      [];
+    const unresolved: UnresolvedEdit[] = [];
 
     // Indexed from this batch, not from Redis: an edit arriving alongside its
     // original needs that original's secret, and a round trip per edit would
@@ -2647,8 +2687,9 @@ export class BaileysConnection {
       const targetId = edit.targetKey.id as string;
       const target = byId.get(targetId);
       const secret = secretById.get(targetId);
+      const position = { at: messageTimestampSeconds(message), seq };
       if (!target || !secret) {
-        unresolved.push({ message, edit });
+        unresolved.push({ message, edit, position });
         continue;
       }
 
@@ -2675,12 +2716,10 @@ export class BaileysConnection {
             this.phoneNumber,
             targetId,
           );
-          unresolved.push({ message, edit });
+          unresolved.push({ message, edit, position });
           continue;
         }
-        if (
-          !this.claimEditPosition(targetId, messageTimestampSeconds(message))
-        ) {
+        if (!this.claimEditPosition(targetId, position)) {
           continue;
         }
         target.message = replaceInnerContent(
@@ -2784,9 +2823,10 @@ export class BaileysConnection {
   private async emitSecretMessageEdit(
     message: WAMessage,
     edit: SecretMessageEdit,
+    position: EditPosition,
   ) {
     try {
-      await this.decryptAndEmitMessageEdit(message, edit);
+      await this.decryptAndEmitMessageEdit(message, edit, position);
     } catch (error) {
       // Contained per edit. Redis can refuse the lookup and a decrypted payload
       // can still fail to parse, and neither is a reason to lose the other
@@ -2804,6 +2844,7 @@ export class BaileysConnection {
   private async decryptAndEmitMessageEdit(
     message: WAMessage,
     { targetKey, encPayload, encIv }: SecretMessageEdit,
+    position: EditPosition,
   ) {
     const targetId = targetKey.id as string;
 
@@ -2875,7 +2916,7 @@ export class BaileysConnection {
     // decrypting: an edit that cannot be read changes nothing, and letting it
     // take the position would reject a later, older edit that CAN be read as
     // superseded by an update nobody ever received.
-    if (!this.claimEditPosition(targetId, messageTimestampSeconds(message))) {
+    if (!this.claimEditPosition(targetId, position)) {
       logger.debug(
         "[%s] [emitSecretMessageEdit] superseded targetId=%s",
         this.phoneNumber,
@@ -2887,19 +2928,27 @@ export class BaileysConnection {
     // Same shape Baileys emits for a plaintext MESSAGE_EDIT: the edit's own key
     // with the id swapped for the original's, so the consumer updates the
     // message that was edited rather than creating a new one.
-    await this.handleMessagesUpdate([
-      {
-        key: { ...message.key, id: targetId },
-        update: {
-          message: {
-            editedMessage: {
-              message: decodeEditedMessage(decrypted.plaintext),
+    await this.handleMessagesUpdate(
+      [
+        {
+          key: { ...message.key, id: targetId },
+          update: {
+            message: {
+              editedMessage: {
+                message: decodeEditedMessage(decrypted.plaintext),
+              },
             },
+            messageTimestamp: message.messageTimestamp,
           },
-          messageTimestamp: message.messageTimestamp,
         },
-      },
-    ]);
+      ],
+      // Re-checked between retries: a 404 puts this delivery in the retry ladder
+      // for a minute, and a batch that repaired the same message meanwhile has
+      // already sent the newer text. Without this, the retry lands last and puts
+      // the older text back. It cannot cover a request already on the wire; that
+      // last sliver is the consumer's to settle, and is what #393 is about.
+      { stillWanted: () => !this.editSuperseded(targetId, position) },
+    );
   }
 
   // Remembered rather than read fresh every time, because a handoff clears the
@@ -2925,6 +2974,7 @@ export class BaileysConnection {
 
   private handleMessagesUpdate(
     data: BaileysEventMap["messages.update"],
+    options?: { stillWanted?: () => boolean },
   ): Promise<unknown> {
     // Edits, deletions and reactions are conversation activity too — a
     // connection seeing them must not look idle to the rebalancer.
@@ -2952,6 +3002,7 @@ export class BaileysConnection {
       },
       {
         awaitResponse: true,
+        stillWanted: options?.stillWanted,
       },
     );
   }
@@ -3122,6 +3173,11 @@ export class BaileysConnection {
   private async handleMessagingHistorySet(
     data: BaileysEventMap["messaging-history.set"],
   ) {
+    // Read here, before the addressing round trip below: two dumps whose edits
+    // are stamped in the same second are separated only by the order they
+    // arrived in, and after the await that order is gone.
+    const seq = ++this.eventSeq;
+
     // Opened before the addressing round trip below, which is the window the
     // whole gate exists for: a live edit arriving while this dump is still
     // resolving LIDs would look its key up, find the dump had not filed it yet
@@ -3147,7 +3203,7 @@ export class BaileysConnection {
         );
         const { kept, unresolved, secrets } = this.repairSecretMessageEdits(
           addressed,
-          { history: true },
+          { history: true, seq },
         );
         messages = kept;
         // Same reason as the live path: enqueued before the write below, so the
@@ -3467,6 +3523,7 @@ export class BaileysConnection {
     payload: BaileysConnectionWebhookPayload,
     options?: {
       awaitResponse?: boolean;
+      stillWanted?: () => boolean;
     },
   ) {
     // connection.update events carry the lease epoch so the client can
@@ -3495,6 +3552,12 @@ export class BaileysConnection {
     payload: BaileysConnectionWebhookPayload,
     options?: {
       awaitResponse?: boolean;
+      /**
+       * Asked again before every attempt. Answering false abandons the delivery,
+       * for a payload that has been made obsolete while it was being retried.
+       * Absent means "always wanted", which is every other caller.
+       */
+      stillWanted?: () => boolean;
     },
   ) {
     let sanitizedPayload: Record<string, unknown> | null = null;
@@ -3529,6 +3592,16 @@ export class BaileysConnection {
     let delay = retryInterval;
 
     while (attempt <= maxRetries) {
+      if (options?.stillWanted && !options.stillWanted()) {
+        logger.info(
+          "[%s] [sendToWebhook] [ABANDONED] event=%s attempt=%d",
+          this.phoneNumber,
+          payload.event,
+          attempt,
+        );
+        return;
+      }
+
       const { response, error } = await this.sendPayloadToWebhook(
         webhookUrl,
         serializedBody,

--- a/src/baileys/connection.ts
+++ b/src/baileys/connection.ts
@@ -22,6 +22,7 @@ import makeWASocket, {
   type WAPresence,
 } from "@whiskeysockets/baileys";
 import { toDataURL } from "qrcode";
+import { decryptMessageEdit } from "@/baileys/helpers/decryptMessageEdit";
 import { downloadMediaFromMessages } from "@/baileys/helpers/downloadMediaFromMessages";
 import { fetchBaileysClientVersion } from "@/baileys/helpers/fetchBaileysClientVersion";
 import {
@@ -37,8 +38,23 @@ import {
   isTxMutexTimeout,
   txMutexTimeoutKey,
 } from "@/baileys/helpers/isTxMutexTimeout";
+import {
+  messageAuthorJids,
+  messageEditSenderCandidates,
+  type OwnJids,
+} from "@/baileys/helpers/messageEditSenders";
+import {
+  recallMessageSecret,
+  rememberMessageSecret,
+} from "@/baileys/helpers/messageSecretStore";
 import { normalizeBrazilPhoneNumber } from "@/baileys/helpers/normalizeBrazilPhoneNumber";
 import { preprocessAudio } from "@/baileys/helpers/preprocessAudio";
+import {
+  decodeEditedMessage,
+  ownMessageSecret,
+  type SecretMessageEdit,
+  secretMessageEdit,
+} from "@/baileys/helpers/secretEncryptedMessageEdit";
 import { shouldIgnoreJid } from "@/baileys/helpers/shouldIgnoreJid";
 import {
   advanceImportCandidate,
@@ -2397,6 +2413,16 @@ export class BaileysConnection {
       messagesData = { ...data, messages: individualMessages };
     }
 
+    const remaining = await this.absorbSecretMessageEdits(
+      messagesData.messages,
+    );
+    if (remaining.length !== messagesData.messages.length) {
+      if (remaining.length === 0) {
+        return;
+      }
+      messagesData = { ...messagesData, messages: remaining };
+    }
+
     const payload: BaileysConnectionWebhookPayload = {
       event: "messages.upsert",
       data: messagesData,
@@ -2410,6 +2436,127 @@ export class BaileysConnection {
     }
 
     this.sendToWebhook(payload);
+  }
+
+  // Turns encrypted message edits back into the `messages.update` the rest of
+  // the world already understands, and files every message secret that arrives
+  // so the NEXT edit has something to decrypt with.
+  //
+  // Returns the messages that are still messages. An edit is not one: forwarded
+  // as an upsert it becomes a second bubble the consumer can only render as
+  // unsupported content, which is precisely the bug this exists to remove.
+  private async absorbSecretMessageEdits(
+    messages: WAMessage[],
+  ): Promise<WAMessage[]> {
+    const kept: WAMessage[] = [];
+
+    for (const message of messages) {
+      const edit = secretMessageEdit(message);
+      if (edit) {
+        await this.emitSecretMessageEdit(message, edit);
+        continue;
+      }
+
+      kept.push(message);
+      await this.rememberOwnMessageSecret(message);
+    }
+
+    return kept;
+  }
+
+  private async rememberOwnMessageSecret(message: WAMessage) {
+    const secret = ownMessageSecret(message);
+    const messageId = message.key?.id;
+    if (!secret || !messageId) {
+      return;
+    }
+
+    try {
+      await rememberMessageSecret(
+        this.phoneNumber,
+        messageId,
+        secret,
+        messageAuthorJids(message.key, this.ownJids()),
+      );
+    } catch (error) {
+      // A message we cannot file is a future edit we cannot decrypt, never a
+      // reason to drop the message itself.
+      logger.warn(
+        "[%s] [rememberOwnMessageSecret] failed messageId=%s\n%s",
+        this.phoneNumber,
+        messageId,
+        errorToString(error),
+      );
+    }
+  }
+
+  private async emitSecretMessageEdit(
+    message: WAMessage,
+    { targetKey, encPayload, encIv }: SecretMessageEdit,
+  ) {
+    const targetId = targetKey.id as string;
+    const stored = await recallMessageSecret(this.phoneNumber, targetId);
+    if (!stored) {
+      // The original never passed through this instance, or it did so more than
+      // MESSAGE_SECRET_TTL_SECONDS ago. Nothing to derive the key from.
+      logger.warn(
+        "[%s] [emitSecretMessageEdit] no stored secret for targetId=%s",
+        this.phoneNumber,
+        targetId,
+      );
+      return;
+    }
+
+    const decrypted = decryptMessageEdit({
+      encPayload,
+      encIv,
+      origMsgId: targetId,
+      messageSecret: stored.secret,
+      senderCandidates: messageEditSenderCandidates({
+        editKey: message.key,
+        targetKey,
+        me: this.ownJids(),
+        storedSenders: stored.senders,
+      }),
+    });
+
+    if (!decrypted) {
+      logger.warn(
+        "[%s] [emitSecretMessageEdit] no sender candidate decrypted targetId=%s",
+        this.phoneNumber,
+        targetId,
+      );
+      return;
+    }
+
+    logger.debug(
+      "[%s] [emitSecretMessageEdit] decrypted targetId=%s senders=%o",
+      this.phoneNumber,
+      targetId,
+      decrypted.senders,
+    );
+
+    // Same shape Baileys emits for a plaintext MESSAGE_EDIT: the edit's own key
+    // with the id swapped for the original's, so the consumer updates the
+    // message that was edited rather than creating a new one.
+    this.handleMessagesUpdate([
+      {
+        key: { ...message.key, id: targetId },
+        update: {
+          message: {
+            editedMessage: {
+              message: decodeEditedMessage(decrypted.plaintext),
+            },
+          },
+          messageTimestamp: message.messageTimestamp,
+        },
+      },
+    ]);
+  }
+
+  private ownJids(): OwnJids {
+    const user = this.socket?.user;
+    return { id: user?.id, lid: user?.lid };
   }
 
   private handleMessagesUpdate(data: BaileysEventMap["messages.update"]) {

--- a/src/baileys/connection.ts
+++ b/src/baileys/connection.ts
@@ -305,10 +305,10 @@ export class BaileysConnection {
   private sessionEnded = false;
   // Serializes the send-stall verdicts against each other. See reportSendStall.
   private stallReportChain: Promise<unknown> = Promise.resolve();
-  // Orders the encrypted message edits against each other and against the
-  // upserts carrying the messages they edit. See queueSecretMessageEdit.
+  // Orders the encrypted message edits against each other and against every
+  // delivery that carries the messages they edit. See queueSecretMessageEdit.
   private editDeliveryChain: Promise<void> = Promise.resolve();
-  private inFlightUpsertDeliveries = new Set<Promise<unknown>>();
+  private inFlightMessageDeliveries = new Set<Promise<void>>();
   private stallStrikeRollback:
     | { previous: SendStallState | null; ttlMs: number | null; wrote: string }
     | undefined;
@@ -2421,66 +2421,81 @@ export class BaileysConnection {
       messagesData = { ...data, messages: individualMessages };
     }
 
-    const { kept, edits } = await this.absorbSecretMessageEdits(
-      messagesData.messages,
-    );
-
-    if (kept.length > 0) {
-      if (kept.length !== messagesData.messages.length) {
-        messagesData = { ...messagesData, messages: kept };
-      }
-
-      const payload: BaileysConnectionWebhookPayload = {
-        event: "messages.upsert",
-        data: messagesData,
-      };
-
-      const media = await downloadMediaFromMessages(messagesData.messages, {
-        includeMedia: this.includeMedia,
-      });
-      if (media) {
-        payload.extra = { media };
-      }
-
-      await this.deliverUpsert(payload);
-    }
-
-    for (const { message, edit } of edits) {
-      this.queueSecretMessageEdit(message, edit);
-    }
-  }
-
-  // Tracked, not just sent. An encrypted edit is an update to a message that
-  // arrived on an upsert, and the original need not be in the same batch — nor
-  // even in the same callback, since Baileys does not await its listeners and
-  // two upserts can be in flight at once. Awaiting inside one callback
-  // therefore orders nothing against the others, which is why the edits wait on
-  // this set rather than on their own batch alone.
-  private async deliverUpsert(payload: BaileysConnectionWebhookPayload) {
-    const delivery = this.sendToWebhook(payload);
-    this.inFlightUpsertDeliveries.add(delivery);
+    // Registered before the first await, not at send time. Filing secrets and
+    // downloading media both suspend, and an edit arriving in a callback that
+    // runs during either would find nothing in flight and overtake the very
+    // message it edits.
+    const settled = this.beginMessageDelivery();
     try {
-      await delivery;
+      const { kept, edits } = await this.absorbSecretMessageEdits(
+        messagesData.messages,
+      );
+
+      if (kept.length > 0) {
+        if (kept.length !== messagesData.messages.length) {
+          messagesData = { ...messagesData, messages: kept };
+        }
+
+        const payload: BaileysConnectionWebhookPayload = {
+          event: "messages.upsert",
+          data: messagesData,
+        };
+
+        const media = await downloadMediaFromMessages(messagesData.messages, {
+          includeMedia: this.includeMedia,
+        });
+        if (media) {
+          payload.extra = { media };
+        }
+
+        await this.sendToWebhook(payload);
+      }
+
+      for (const { message, edit } of edits) {
+        this.queueSecretMessageEdit(message, edit);
+      }
     } finally {
-      this.inFlightUpsertDeliveries.delete(delivery);
+      settled();
     }
   }
 
-  // Queues one edit behind every upsert delivery that had already started, and
+  // Opens a slot for one delivery of messages to the consumer, and answers with
+  // the function that closes it.
+  //
+  // The slot spans the whole callback rather than the webhook call, because an
+  // edit has to wait for the message it edits to be DELIVERED, and everything
+  // between the event and the send — decryption, secret filing, media download
+  // — is time in which a competing callback can run. Both routes a message
+  // reaches the consumer by open one: live upserts and history frames.
+  private beginMessageDelivery(): () => void {
+    let close!: () => void;
+    const slot = new Promise<void>((resolve) => {
+      close = resolve;
+    });
+    this.inFlightMessageDeliveries.add(slot);
+    return () => {
+      this.inFlightMessageDeliveries.delete(slot);
+      close();
+    };
+  }
+
+  // Queues one edit behind every message delivery that had already started, and
   // behind the edits queued before it.
   //
-  // Both halves are load-bearing. Without the barrier an update can reach the
-  // consumer before the message it edits and be rejected as targeting an
-  // unknown id, leaving the original unedited — this feature's own bug, by
-  // another door. Without the chain two edits to the same message can land out
-  // of order and the older text wins.
+  // Both halves are load-bearing, and each covers a failure the other does not.
+  // Without the barrier an update reaches the consumer before the message it
+  // edits and is rejected as targeting an unknown id, leaving the original
+  // unedited — this feature's own bug, by another door. Without the chain two
+  // edits to one message race, and since the chain only advances once a
+  // delivery has actually finished, a first edit that needed a webhook retry
+  // cannot be overtaken by a second that went out on the first attempt.
   //
   // The reservation is taken HERE, synchronously, for the reason
   // `stallReportChain` takes its own: the chain does not enter sendToWebhook
   // until a microtask, and a graceful shutdown reading inFlightWebhooks in
   // between would see nothing pending and exit on top of a queued edit.
   private queueSecretMessageEdit(message: WAMessage, edit: SecretMessageEdit) {
-    const barrier = [...this.inFlightUpsertDeliveries];
+    const barrier = [...this.inFlightMessageDeliveries];
     this._inFlightWebhooks += 1;
     this.editDeliveryChain = this.editDeliveryChain
       .catch(() => {})
@@ -2526,16 +2541,25 @@ export class BaileysConnection {
   // decrypted replacement lands the same content — an update event, by
   // contrast, would flag an already-current message as edited over itself.
   //
-  // An edit whose target is not in the dump is dropped: there is nothing here to
-  // repair, and the message it belongs to was imported long ago.
-  private async repairHistoryEdits(
-    messages: WAMessage[],
-  ): Promise<WAMessage[]> {
+  // An edit whose target is NOT in this dump gets handed back instead. A sync
+  // split across notifications can put the original in an earlier one, and by
+  // then there is nothing left here to repair — but its secret was filed, so
+  // the edit is still readable and the caller sends it as a live update once
+  // the frames are out. That path races the importer's own write, which is
+  // exactly why it is the fallback and not the rule: an edit that may not land
+  // still beats one that certainly will not.
+  private async repairHistoryEdits(messages: WAMessage[]): Promise<{
+    kept: WAMessage[];
+    unresolved: Array<{ message: WAMessage; edit: SecretMessageEdit }>;
+  }> {
     const { kept, edits } = this.splitSecretMessageEdits(messages);
     if (edits.length === 0 && kept.length === messages.length) {
       await this.rememberHistorySecrets(kept);
-      return kept;
+      return { kept, unresolved: [] };
     }
+
+    const unresolved: Array<{ message: WAMessage; edit: SecretMessageEdit }> =
+      [];
 
     // Indexed from the dump itself, not from Redis: an edit replayed alongside
     // its original needs that original's secret, and one round trip per edit
@@ -2559,11 +2583,7 @@ export class BaileysConnection {
       const target = byId.get(targetId);
       const secret = secrets.get(targetId);
       if (!target || !secret) {
-        logger.warn(
-          "[%s] [repairHistoryEdits] no target in this dump for targetId=%s",
-          this.phoneNumber,
-          targetId,
-        );
+        unresolved.push({ message, edit });
         continue;
       }
 
@@ -2600,7 +2620,7 @@ export class BaileysConnection {
     }
 
     await this.rememberHistorySecrets(kept);
-    return kept;
+    return { kept, unresolved };
   }
 
   // Files only the messages a future edit could still target. WhatsApp closes
@@ -2759,7 +2779,7 @@ export class BaileysConnection {
     // Same shape Baileys emits for a plaintext MESSAGE_EDIT: the edit's own key
     // with the id swapped for the original's, so the consumer updates the
     // message that was edited rather than creating a new one.
-    this.handleMessagesUpdate([
+    await this.handleMessagesUpdate([
       {
         key: { ...message.key, id: targetId },
         update: {
@@ -2779,7 +2799,9 @@ export class BaileysConnection {
     return { id: user?.id, lid: user?.lid };
   }
 
-  private handleMessagesUpdate(data: BaileysEventMap["messages.update"]) {
+  private handleMessagesUpdate(
+    data: BaileysEventMap["messages.update"],
+  ): Promise<unknown> {
     // Edits, deletions and reactions are conversation activity too — a
     // connection seeing them must not look idle to the rebalancer.
     this.markTraffic();
@@ -2795,7 +2817,11 @@ export class BaileysConnection {
 
     this.trackOutgoingAck(data);
 
-    this.sendToWebhook(
+    // Returned, not fired and forgotten: the encrypted-edit chain advances on
+    // this promise, and a chain that advanced on the CALL would let a second
+    // edit start while the first was still working through its retries — the
+    // older text then landing last and winning.
+    return this.sendToWebhook(
       {
         event: "messages.update",
         data,
@@ -2977,12 +3003,25 @@ export class BaileysConnection {
     // the second JID form every stored author candidate needs. Filing before
     // the restore would record half the candidates, and a later edit derived
     // from the form we dropped would never verify.
+    // Opened before the first await for the same reason the upsert path opens
+    // one: a live edit arriving while this dump is being decoded must wait for
+    // the messages it may target to actually go out.
+    const settled = this.beginMessageDelivery();
+    try {
+      await this.deliverHistory(data);
+    } finally {
+      settled();
+    }
+  }
+
+  private async deliverHistory(data: BaileysEventMap["messaging-history.set"]) {
     const addressed = await this.addressHistory(
       data.messages ?? [],
       data.lidPnMappings,
       data.chats ?? [],
     );
-    const messages = await this.repairHistoryEdits(addressed);
+    const { kept: messages, unresolved } =
+      await this.repairHistoryEdits(addressed);
 
     // The one thing worth keeping from the chat records: which chats have
     // nothing older left. An answer that still has history behind it carries no
@@ -2990,6 +3029,7 @@ export class BaileysConnection {
     // is more".
     const exhausted = exhaustedChats(data.chats ?? []);
     if (messages.length === 0 && exhausted.length === 0) {
+      this.queueUnresolvedHistoryEdits(unresolved);
       return;
     }
 
@@ -3039,6 +3079,20 @@ export class BaileysConnection {
           exhausted,
         },
       });
+    }
+
+    this.queueUnresolvedHistoryEdits(unresolved);
+  }
+
+  // Sends, as live updates, the dump edits whose targets were not in the dump.
+  // They go through the same chain as a live edit, so they queue behind this
+  // dump's own frames — which are still counted as in flight by the delivery
+  // slot the caller opened.
+  private queueUnresolvedHistoryEdits(
+    unresolved: Array<{ message: WAMessage; edit: SecretMessageEdit }>,
+  ) {
+    for (const { message, edit } of unresolved) {
+      this.queueSecretMessageEdit(message, edit);
     }
   }
 

--- a/src/baileys/connection.ts
+++ b/src/baileys/connection.ts
@@ -843,8 +843,8 @@ export class BaileysConnection {
         this.handleMessagesUpsert,
       ),
       "messages.update": this.withErrorHandling(
-        "handleMessagesUpdate",
-        this.handleMessagesUpdate,
+        "onMessagesUpdate",
+        this.onMessagesUpdate,
       ),
       "message-receipt.update": this.withErrorHandling(
         "handleMessageReceiptUpdate",
@@ -2645,19 +2645,29 @@ export class BaileysConnection {
     // least-recently-claimed first and the eviction below takes the right one.
     this.editedAt.delete(targetId);
     this.editedAt.set(targetId, position);
-    if (this.editedAt.size > BaileysConnection.EDIT_POSITION_MEMORY) {
-      for (const candidate of this.editedAt.keys()) {
-        // A message still being delivered keeps its position no matter how old
-        // the claim is: the retry consults it before every attempt, and a
-        // position that was evicted reads as "nothing applied yet", which is
-        // precisely the answer that lets a stale retry through. A history sync
-        // touching thousands of messages would otherwise do this routinely.
-        if (this.editDeliveries.has(candidate)) {
-          continue;
-        }
-        this.editedAt.delete(candidate);
+    // Trimmed back to the cap rather than by one entry per claim: a protected
+    // candidate is skipped, not evicted, so "evict one" can evict none, and the
+    // map would then stay above the cap for as long as the connection lives —
+    // every later claim adding one and removing one. The loop runs at most once
+    // over the map, and only while it is over the cap.
+    for (const candidate of this.editedAt.keys()) {
+      if (this.editedAt.size <= BaileysConnection.EDIT_POSITION_MEMORY) {
         break;
       }
+      // A message still being delivered keeps its position no matter how old
+      // the claim is: the retry consults it before every attempt, and a
+      // position that was evicted reads as "nothing applied yet", which is
+      // precisely the answer that lets a stale retry through. A history sync
+      // touching thousands of messages would otherwise do this routinely.
+      //
+      // With more deliveries in flight than the cap there is nothing to take,
+      // and the map grows until they settle. That is the honest outcome: the
+      // alternative is dropping a position something is still consulting. The
+      // next claim after they settle brings it back down.
+      if (this.editDeliveries.has(candidate)) {
+        continue;
+      }
+      this.editedAt.delete(candidate);
     }
     return true;
   }
@@ -3018,6 +3028,57 @@ export class BaileysConnection {
       this.ownJidsSeen.lid = user.lid;
     }
     return { ...this.ownJidsSeen };
+  }
+
+  /**
+   * The event listener, as opposed to the relay the encrypted path calls.
+   *
+   * Baileys still turns a plaintext MESSAGE_EDIT into exactly the shape the
+   * encrypted path synthesises: the original message's id, an `editedMessage`
+   * body, and the edit's own timestamp. Both edit the same message, so both
+   * have to answer to the same guard. Without this, an encrypted edit sitting
+   * in the retry ladder would never learn that a newer plaintext edit had
+   * already landed, and would put its older text back — and a plaintext edit
+   * older than an encrypted one already applied would do the same in reverse.
+   *
+   * Only the listener claims. The encrypted path claims before it calls the
+   * relay, and hands `stillWanted` that very position to compare against;
+   * claiming again on the way through would supersede it and make the delivery
+   * abandon itself one attempt later.
+   */
+  private onMessagesUpdate(
+    data: BaileysEventMap["messages.update"],
+  ): Promise<unknown> {
+    const seq = ++this.eventSeq;
+    const wanted = data.filter((entry, rank) => {
+      const targetId = entry.key?.id;
+      if (!entry.update?.message?.editedMessage || !targetId) {
+        return true;
+      }
+      const claimed = this.claimEditPosition(targetId, {
+        at: messageTimestampSeconds(entry.update),
+        seq,
+        rank,
+      });
+      if (!claimed) {
+        logger.debug(
+          "[%s] [onMessagesUpdate] superseded plaintext edit targetId=%s",
+          this.phoneNumber,
+          targetId,
+        );
+      }
+      return claimed;
+    });
+
+    if (!wanted.length) {
+      // Every entry was an edit something newer had already answered. Dropping
+      // them is the point — relaying one puts the older text back — but they
+      // were still inbound activity, and the rebalancer reads silence as idle.
+      this.markTraffic();
+      return Promise.resolve();
+    }
+
+    return this.handleMessagesUpdate(wanted);
   }
 
   private handleMessagesUpdate(

--- a/src/baileys/connection.ts
+++ b/src/baileys/connection.ts
@@ -47,7 +47,6 @@ import {
   MESSAGE_SECRET_TTL_SECONDS,
   type MessageSecretEntry,
   recallMessageSecret,
-  rememberMessageSecret,
   rememberMessageSecrets,
 } from "@/baileys/helpers/messageSecretStore";
 import { normalizeBrazilPhoneNumber } from "@/baileys/helpers/normalizeBrazilPhoneNumber";
@@ -305,10 +304,6 @@ export class BaileysConnection {
   private sessionEnded = false;
   // Serializes the send-stall verdicts against each other. See reportSendStall.
   private stallReportChain: Promise<unknown> = Promise.resolve();
-  // Orders the encrypted message edits against each other and against every
-  // delivery that carries the messages they edit. See queueSecretMessageEdit.
-  private editDeliveryChain: Promise<void> = Promise.resolve();
-  private inFlightMessageDeliveries = new Set<Promise<void>>();
   private stallStrikeRollback:
     | { previous: SendStallState | null; ttlMs: number | null; wrote: string }
     | undefined;
@@ -2421,127 +2416,64 @@ export class BaileysConnection {
       messagesData = { ...data, messages: individualMessages };
     }
 
-    // Registered before the first await, not at send time. Filing secrets and
-    // downloading media both suspend, and an edit arriving in a callback that
-    // runs during either would find nothing in flight and overtake the very
-    // message it edits.
-    const settled = this.beginMessageDelivery();
-    try {
-      const { kept, edits } = this.splitSecretMessageEdits(
-        messagesData.messages,
-      );
+    // Same two steps as a history dump, and deliberately the same code: repair
+    // what this batch can repair itself, file the secrets a later edit will
+    // need, and let anything left over go out as an ordinary update.
+    const { kept, unresolved } = this.repairSecretMessageEdits(
+      messagesData.messages,
+    );
+    await this.rememberMessageSecretsFor(kept);
 
-      // Queued before ANY await, so an edit's place in the chain is the order
-      // it arrived in. Queueing even one await later loses that: filing the
-      // batch's secrets suspends, and a callback carrying only an edit has no
-      // secrets to file, so it would overtake an edit seen earlier and its
-      // newer text would land first. The barrier is unaffected — it holds this
-      // callback's delivery slot, which stays open until the send below.
-      for (const { message, edit } of edits) {
-        this.queueSecretMessageEdit(message, edit);
+    if (kept.length > 0) {
+      if (kept.length !== messagesData.messages.length) {
+        messagesData = { ...messagesData, messages: kept };
       }
 
-      await this.rememberOwnMessageSecrets(kept);
+      const payload: BaileysConnectionWebhookPayload = {
+        event: "messages.upsert",
+        data: messagesData,
+      };
 
-      if (kept.length > 0) {
-        if (kept.length !== messagesData.messages.length) {
-          messagesData = { ...messagesData, messages: kept };
-        }
-
-        const payload: BaileysConnectionWebhookPayload = {
-          event: "messages.upsert",
-          data: messagesData,
-        };
-
-        const media = await downloadMediaFromMessages(messagesData.messages, {
-          includeMedia: this.includeMedia,
-        });
-        if (media) {
-          payload.extra = { media };
-        }
-
-        await this.sendToWebhook(payload);
+      const media = await downloadMediaFromMessages(messagesData.messages, {
+        includeMedia: this.includeMedia,
+      });
+      if (media) {
+        payload.extra = { media };
       }
-    } finally {
-      settled();
+
+      await this.sendToWebhook(payload);
     }
+
+    this.emitUnresolvedEdits(unresolved);
   }
 
-  // Opens a slot for one delivery of messages to the consumer, and answers with
-  // the function that closes it.
+  // Sends the edits this batch could not apply itself, exactly the way Baileys
+  // sends a plaintext one: fire and forget, in arrival order, no queue.
   //
-  // The slot spans the whole callback rather than the webhook call, because an
-  // edit has to wait for the message it edits to be DELIVERED, and everything
-  // between the event and the send — decryption, secret filing, media download
-  // — is time in which a competing callback can run. Both routes a message
-  // reaches the consumer by open one: live upserts and history frames.
-  private beginMessageDelivery(): () => void {
-    let close!: () => void;
-    const slot = new Promise<void>((resolve) => {
-      close = resolve;
-    });
-    this.inFlightMessageDeliveries.add(slot);
-    return () => {
-      this.inFlightMessageDeliveries.delete(slot);
-      close();
-    };
-  }
-
-  // Queues one edit behind every message delivery that had already started, and
-  // behind the edits queued before it.
-  //
-  // Both halves are load-bearing, and each covers a failure the other does not.
-  // Without the barrier an update reaches the consumer before the message it
-  // edits and is rejected as targeting an unknown id, leaving the original
-  // unedited — this feature's own bug, by another door. Without the chain two
-  // edits to one message race, and since the chain only advances once a
-  // delivery has actually finished, a first edit that needed a webhook retry
-  // cannot be overtaken by a second that went out on the first attempt.
-  //
-  // The reservation is taken HERE, synchronously, for the reason
-  // `stallReportChain` takes its own: the chain does not enter sendToWebhook
-  // until a microtask, and a graceful shutdown reading inFlightWebhooks in
-  // between would see nothing pending and exit on top of a queued edit.
-  private queueSecretMessageEdit(message: WAMessage, edit: SecretMessageEdit) {
-    const barrier = [...this.inFlightMessageDeliveries];
-    this._inFlightWebhooks += 1;
-    this.editDeliveryChain = this.editDeliveryChain
-      .catch(() => {})
-      .then(async () => {
-        await Promise.allSettled(barrier);
-        await this.emitSecretMessageEdit(message, edit);
-      })
-      .catch(() => {})
-      .finally(() => {
+  // There is deliberately no ordering machinery around this. An edit whose
+  // original is still being written by the consumer is answered 404, and
+  // `awaitResponse` puts the delivery back through the retry loop — the
+  // ordering is already in the protocol, and four rounds of hand-built
+  // barriers, chains and delivery slots only added ways to lose a message that
+  // the retry never had. After decryption this IS a plaintext edit, so it is
+  // delivered as one and inherits exactly the guarantees the provider already
+  // gives every other edit.
+  private emitUnresolvedEdits(
+    unresolved: Array<{ message: WAMessage; edit: SecretMessageEdit }>,
+  ) {
+    for (const { message, edit } of unresolved) {
+      // Reserved synchronously, for the reason `stallReportChain` reserves its
+      // own: recalling the secret and decrypting both suspend before
+      // sendToWebhook increments anything, and a SIGTERM landing in that gap
+      // would read nothing pending and exit on top of the edit.
+      this._inFlightWebhooks += 1;
+      void this.emitSecretMessageEdit(message, edit).finally(() => {
         this._inFlightWebhooks -= 1;
       });
-  }
-
-  private async rememberOwnMessageSecrets(messages: WAMessage[]) {
-    for (const message of messages) {
-      await this.rememberOwnMessageSecret(message);
     }
   }
 
-  // Applies a dump's encrypted edits to the messages inside that same dump, and
-  // files the secrets that can still matter later.
-  //
-  // Repaired in place rather than re-narrated as `messages.update`. A dump is a
-  // replay of stored state read by an importer that decides its own ordering,
-  // so an update would race the very write it targets. It is also the only
-  // choice that is right either way: whether the dump's row holds the message's
-  // original text or the text it was edited to, overwriting it with the
-  // decrypted replacement lands the same content — an update event, by
-  // contrast, would flag an already-current message as edited over itself.
-  //
-  // An edit whose target is NOT in this dump gets handed back instead. A sync
-  // split across notifications can put the original in an earlier one, and by
-  // then there is nothing left here to repair — but its secret was filed, so
-  // the edit is still readable and the caller sends it as a live update once
-  // the frames are out. That path races the importer's own write, which is
-  // exactly why it is the fallback and not the rule: an edit that may not land
-  // still beats one that certainly will not.
-  private repairHistoryEdits(messages: WAMessage[]): {
+  private repairSecretMessageEdits(messages: WAMessage[]): {
     kept: WAMessage[];
     unresolved: Array<{ message: WAMessage; edit: SecretMessageEdit }>;
   } {
@@ -2594,7 +2526,7 @@ export class BaileysConnection {
         });
         if (!decrypted) {
           logger.warn(
-            "[%s] [repairHistoryEdits] no sender candidate decrypted targetId=%s",
+            "[%s] [repairSecretMessageEdits] no sender candidate decrypted targetId=%s",
             this.phoneNumber,
             targetId,
           );
@@ -2603,7 +2535,7 @@ export class BaileysConnection {
         target.message = decodeEditedMessage(decrypted.plaintext);
       } catch (error) {
         logger.warn(
-          "[%s] [repairHistoryEdits] failed targetId=%s\n%s",
+          "[%s] [repairSecretMessageEdits] failed targetId=%s\n%s",
           this.phoneNumber,
           targetId,
           errorToString(error),
@@ -2620,7 +2552,10 @@ export class BaileysConnection {
   // decrypt anything: filing an archive's worth of them would spend a round
   // trip per message, hold the dump behind all of them, and leave a keyspace
   // nothing will ever read.
-  private async rememberHistorySecrets(messages: WAMessage[]) {
+  private async rememberMessageSecretsFor(
+    messages: WAMessage[],
+    { onlyRecent = false }: { onlyRecent?: boolean } = {},
+  ) {
     const oldest = Date.now() / 1000 - MESSAGE_SECRET_TTL_SECONDS;
     const entries: MessageSecretEntry[] = [];
 
@@ -2630,7 +2565,7 @@ export class BaileysConnection {
       if (!messageId || !secret) {
         continue;
       }
-      if (messageTimestampSeconds(message) < oldest) {
+      if (onlyRecent && messageTimestampSeconds(message) < oldest) {
         continue;
       }
       entries.push({
@@ -2652,7 +2587,7 @@ export class BaileysConnection {
       );
     } catch (error) {
       logger.warn(
-        "[%s] [rememberHistorySecrets] failed for %d message(s)\n%s",
+        "[%s] [rememberMessageSecretsFor] failed for %d message(s)\n%s",
         this.phoneNumber,
         entries.length,
         errorToString(error),
@@ -2677,37 +2612,6 @@ export class BaileysConnection {
     }
 
     return { kept, edits };
-  }
-
-  private async rememberOwnMessageSecret(message: WAMessage) {
-    const secret = ownMessageSecret(message);
-    const messageId = message.key?.id;
-    if (!secret || !messageId) {
-      return;
-    }
-
-    try {
-      await withTimeout(
-        "rememberMessageSecret",
-        config.baileys.messageSecretStoreTimeoutMs,
-        () =>
-          rememberMessageSecret(
-            this.phoneNumber,
-            messageId,
-            secret,
-            messageAuthorJids(message.key, this.ownJids()),
-          ),
-      );
-    } catch (error) {
-      // A message we cannot file is a future edit we cannot decrypt, never a
-      // reason to drop the message itself.
-      logger.warn(
-        "[%s] [rememberOwnMessageSecret] failed messageId=%s\n%s",
-        this.phoneNumber,
-        messageId,
-        errorToString(error),
-      );
-    }
   }
 
   private async emitSecretMessageEdit(
@@ -3007,32 +2911,17 @@ export class BaileysConnection {
     // the second JID form every stored author candidate needs. Filing before
     // the restore would record half the candidates, and a later edit derived
     // from the form we dropped would never verify.
-    // Opened before the first await for the same reason the upsert path opens
-    // one: a live edit arriving while this dump is being decoded must wait for
-    // the messages it may target to actually go out.
-    const settled = this.beginMessageDelivery();
-    try {
-      await this.deliverHistory(data);
-    } finally {
-      settled();
-    }
-  }
-
-  private async deliverHistory(data: BaileysEventMap["messaging-history.set"]) {
     const addressed = await this.addressHistory(
       data.messages ?? [],
       data.lidPnMappings,
       data.chats ?? [],
     );
-    const { kept: messages, unresolved } = this.repairHistoryEdits(addressed);
-
-    // Same rule as the live path, for the same reason: the queue position is
-    // taken before the filing below suspends. The barrier still holds these
-    // behind this dump's frames, since the delivery slot the caller opened
-    // stays open until they are all out.
-    this.queueUnresolvedHistoryEdits(unresolved);
-
-    await this.rememberHistorySecrets(messages);
+    const { kept: messages, unresolved: unresolvedEdits } =
+      this.repairSecretMessageEdits(addressed);
+    // Only the dump is filtered by age: a live message is current by
+    // definition, and dropping one whose timestamp reads oddly would silently
+    // cost the edit that follows it.
+    await this.rememberMessageSecretsFor(messages, { onlyRecent: true });
 
     // The one thing worth keeping from the chat records: which chats have
     // nothing older left. An answer that still has history behind it carries no
@@ -3040,6 +2929,7 @@ export class BaileysConnection {
     // is more".
     const exhausted = exhaustedChats(data.chats ?? []);
     if (messages.length === 0 && exhausted.length === 0) {
+      this.emitUnresolvedEdits(unresolvedEdits);
       return;
     }
 
@@ -3090,18 +2980,11 @@ export class BaileysConnection {
         },
       });
     }
-  }
 
-  // Sends, as live updates, the dump edits whose targets were not in the dump.
-  // They go through the same chain as a live edit, so they queue behind this
-  // dump's own frames — which are still counted as in flight by the delivery
-  // slot the caller opened.
-  private queueUnresolvedHistoryEdits(
-    unresolved: Array<{ message: WAMessage; edit: SecretMessageEdit }>,
-  ) {
-    for (const { message, edit } of unresolved) {
-      this.queueSecretMessageEdit(message, edit);
-    }
+    // After the frames: the dump is what carries the originals these could not
+    // be applied to, and a consumer that has not seen them yet answers 404.
+    // That answer is retried, which is the whole reason this needs no queue.
+    this.emitUnresolvedEdits(unresolvedEdits);
   }
 
   // Restores the addressing a dump strips (see historySync.ts), from the two

--- a/src/baileys/connection.ts
+++ b/src/baileys/connection.ts
@@ -731,6 +731,9 @@ export class BaileysConnection {
 
     try {
       this.socket = makeWASocket(socketOptions);
+      // An existing session hands back its account JIDs immediately. Read them
+      // now so they outlive the socket; see ownJidsSeen.
+      this.ownJids();
       this.currentTxToken = txToken;
       // The new socket carries a new keystore and a new mutex map. Bumping here
       // (and only here) is what makes every stamped watchdog reading below
@@ -2505,6 +2508,13 @@ export class BaileysConnection {
       return;
     }
 
+    // Read while the socket is certainly still there: the loop below runs on a
+    // later tick, and a handoff clears the socket in between. A connection whose
+    // first edit targets a message an EARLIER connection filed has never called
+    // ownJids yet, so without this the cache would be empty exactly when the
+    // socket is gone, and a fromMe edit would derive no candidate at all.
+    this.ownJids();
+
     // Reserved synchronously, for the reason `stallReportChain` reserves its
     // own: the queue does not reach sendToWebhook until a microtask, and a
     // SIGTERM landing in that gap would read nothing pending and exit on top of
@@ -2540,7 +2550,11 @@ export class BaileysConnection {
     const open = new Promise<void>((resolve) => {
       close = resolve;
     });
-    this.secretIntake = Promise.all([this.secretIntake, open]);
+    // Flattened to void, not left as the Promise.all result: the aggregate
+    // resolves to an array holding the PREVIOUS aggregate's value, so a
+    // long-lived connection would nest one array per event handled and keep
+    // every one of them alive. Nothing ever reads the value.
+    this.secretIntake = Promise.all([this.secretIntake, open]).then(() => {});
     return close;
   }
 

--- a/src/baileys/connection.ts
+++ b/src/baileys/connection.ts
@@ -44,13 +44,17 @@ import {
   type OwnJids,
 } from "@/baileys/helpers/messageEditSenders";
 import {
+  MESSAGE_SECRET_TTL_SECONDS,
+  type MessageSecretEntry,
   recallMessageSecret,
   rememberMessageSecret,
+  rememberMessageSecrets,
 } from "@/baileys/helpers/messageSecretStore";
 import { normalizeBrazilPhoneNumber } from "@/baileys/helpers/normalizeBrazilPhoneNumber";
 import { preprocessAudio } from "@/baileys/helpers/preprocessAudio";
 import {
   decodeEditedMessage,
+  messageTimestampSeconds,
   ownMessageSecret,
   type SecretMessageEdit,
   secretMessageEdit,
@@ -301,6 +305,10 @@ export class BaileysConnection {
   private sessionEnded = false;
   // Serializes the send-stall verdicts against each other. See reportSendStall.
   private stallReportChain: Promise<unknown> = Promise.resolve();
+  // Orders the encrypted message edits against each other and against the
+  // upserts carrying the messages they edit. See queueSecretMessageEdit.
+  private editDeliveryChain: Promise<void> = Promise.resolve();
+  private inFlightUpsertDeliveries = new Set<Promise<unknown>>();
   private stallStrikeRollback:
     | { previous: SendStallState | null; ttlMs: number | null; wrote: string }
     | undefined;
@@ -2434,19 +2442,56 @@ export class BaileysConnection {
         payload.extra = { media };
       }
 
-      // Awaited, unlike before, because the edits below are updates to messages
-      // the consumer has to have seen: an offline burst can consolidate an
-      // original and its edit into ONE upsert, and each webhook delivery runs
-      // its own retry loop with no ordering between them. An update that
-      // overtakes the message it edits is rejected as targeting an unknown id,
-      // and the original then lands unedited — the bug this feature exists to
-      // fix, arriving by a different door.
-      await this.sendToWebhook(payload);
+      await this.deliverUpsert(payload);
     }
 
     for (const { message, edit } of edits) {
-      await this.emitSecretMessageEdit(message, edit);
+      this.queueSecretMessageEdit(message, edit);
     }
+  }
+
+  // Tracked, not just sent. An encrypted edit is an update to a message that
+  // arrived on an upsert, and the original need not be in the same batch — nor
+  // even in the same callback, since Baileys does not await its listeners and
+  // two upserts can be in flight at once. Awaiting inside one callback
+  // therefore orders nothing against the others, which is why the edits wait on
+  // this set rather than on their own batch alone.
+  private async deliverUpsert(payload: BaileysConnectionWebhookPayload) {
+    const delivery = this.sendToWebhook(payload);
+    this.inFlightUpsertDeliveries.add(delivery);
+    try {
+      await delivery;
+    } finally {
+      this.inFlightUpsertDeliveries.delete(delivery);
+    }
+  }
+
+  // Queues one edit behind every upsert delivery that had already started, and
+  // behind the edits queued before it.
+  //
+  // Both halves are load-bearing. Without the barrier an update can reach the
+  // consumer before the message it edits and be rejected as targeting an
+  // unknown id, leaving the original unedited — this feature's own bug, by
+  // another door. Without the chain two edits to the same message can land out
+  // of order and the older text wins.
+  //
+  // The reservation is taken HERE, synchronously, for the reason
+  // `stallReportChain` takes its own: the chain does not enter sendToWebhook
+  // until a microtask, and a graceful shutdown reading inFlightWebhooks in
+  // between would see nothing pending and exit on top of a queued edit.
+  private queueSecretMessageEdit(message: WAMessage, edit: SecretMessageEdit) {
+    const barrier = [...this.inFlightUpsertDeliveries];
+    this._inFlightWebhooks += 1;
+    this.editDeliveryChain = this.editDeliveryChain
+      .catch(() => {})
+      .then(async () => {
+        await Promise.allSettled(barrier);
+        await this.emitSecretMessageEdit(message, edit);
+      })
+      .catch(() => {})
+      .finally(() => {
+        this._inFlightWebhooks -= 1;
+      });
   }
 
   // Separates the encrypted edits out of a batch and files every message secret
@@ -2461,6 +2506,149 @@ export class BaileysConnection {
     kept: WAMessage[];
     edits: Array<{ message: WAMessage; edit: SecretMessageEdit }>;
   }> {
+    const { kept, edits } = this.splitSecretMessageEdits(messages);
+
+    for (const message of kept) {
+      await this.rememberOwnMessageSecret(message);
+    }
+
+    return { kept, edits };
+  }
+
+  // Applies a dump's encrypted edits to the messages inside that same dump, and
+  // files the secrets that can still matter later.
+  //
+  // Repaired in place rather than re-narrated as `messages.update`. A dump is a
+  // replay of stored state read by an importer that decides its own ordering,
+  // so an update would race the very write it targets. It is also the only
+  // choice that is right either way: whether the dump's row holds the message's
+  // original text or the text it was edited to, overwriting it with the
+  // decrypted replacement lands the same content — an update event, by
+  // contrast, would flag an already-current message as edited over itself.
+  //
+  // An edit whose target is not in the dump is dropped: there is nothing here to
+  // repair, and the message it belongs to was imported long ago.
+  private async repairHistoryEdits(
+    messages: WAMessage[],
+  ): Promise<WAMessage[]> {
+    const { kept, edits } = this.splitSecretMessageEdits(messages);
+    if (edits.length === 0 && kept.length === messages.length) {
+      await this.rememberHistorySecrets(kept);
+      return kept;
+    }
+
+    // Indexed from the dump itself, not from Redis: an edit replayed alongside
+    // its original needs that original's secret, and one round trip per edit
+    // would ask the network for something already in hand.
+    const secrets = new Map<string, Uint8Array>();
+    const byId = new Map<string, WAMessage>();
+    for (const message of kept) {
+      const id = message.key?.id;
+      if (!id) {
+        continue;
+      }
+      byId.set(id, message);
+      const secret = ownMessageSecret(message);
+      if (secret) {
+        secrets.set(id, secret);
+      }
+    }
+
+    for (const { message, edit } of edits) {
+      const targetId = edit.targetKey.id as string;
+      const target = byId.get(targetId);
+      const secret = secrets.get(targetId);
+      if (!target || !secret) {
+        logger.warn(
+          "[%s] [repairHistoryEdits] no target in this dump for targetId=%s",
+          this.phoneNumber,
+          targetId,
+        );
+        continue;
+      }
+
+      try {
+        const decrypted = decryptMessageEdit({
+          encPayload: edit.encPayload,
+          encIv: edit.encIv,
+          origMsgId: targetId,
+          messageSecret: secret,
+          senderCandidates: messageEditSenderCandidates({
+            editKey: message.key,
+            targetKey: edit.targetKey,
+            me: this.ownJids(),
+            storedSenders: messageAuthorJids(target.key, this.ownJids()),
+          }),
+        });
+        if (!decrypted) {
+          logger.warn(
+            "[%s] [repairHistoryEdits] no sender candidate decrypted targetId=%s",
+            this.phoneNumber,
+            targetId,
+          );
+          continue;
+        }
+        target.message = decodeEditedMessage(decrypted.plaintext);
+      } catch (error) {
+        logger.warn(
+          "[%s] [repairHistoryEdits] failed targetId=%s\n%s",
+          this.phoneNumber,
+          targetId,
+          errorToString(error),
+        );
+      }
+    }
+
+    await this.rememberHistorySecrets(kept);
+    return kept;
+  }
+
+  // Files only the messages a future edit could still target. WhatsApp closes
+  // the edit window minutes after sending, and a secret outlives its usefulness
+  // by MESSAGE_SECRET_TTL_SECONDS, so anything older than that can never
+  // decrypt anything: filing an archive's worth of them would spend a round
+  // trip per message, hold the dump behind all of them, and leave a keyspace
+  // nothing will ever read.
+  private async rememberHistorySecrets(messages: WAMessage[]) {
+    const oldest = Date.now() / 1000 - MESSAGE_SECRET_TTL_SECONDS;
+    const entries: MessageSecretEntry[] = [];
+
+    for (const message of messages) {
+      const messageId = message.key?.id;
+      const secret = messageId ? ownMessageSecret(message) : null;
+      if (!messageId || !secret) {
+        continue;
+      }
+      if (messageTimestampSeconds(message) < oldest) {
+        continue;
+      }
+      entries.push({
+        messageId,
+        secret,
+        senders: messageAuthorJids(message.key, this.ownJids()),
+      });
+    }
+
+    if (entries.length === 0) {
+      return;
+    }
+
+    try {
+      await rememberMessageSecrets(this.phoneNumber, entries);
+    } catch (error) {
+      logger.warn(
+        "[%s] [rememberHistorySecrets] failed for %d message(s)\n%s",
+        this.phoneNumber,
+        entries.length,
+        errorToString(error),
+      );
+    }
+  }
+
+  private splitSecretMessageEdits(messages: WAMessage[]): {
+    kept: WAMessage[];
+    edits: Array<{ message: WAMessage; edit: SecretMessageEdit }>;
+  } {
     const kept: WAMessage[] = [];
     const edits: Array<{ message: WAMessage; edit: SecretMessageEdit }> = [];
 
@@ -2468,11 +2656,9 @@ export class BaileysConnection {
       const edit = secretMessageEdit(message);
       if (edit) {
         edits.push({ message, edit });
-        continue;
+      } else {
+        kept.push(message);
       }
-
-      kept.push(message);
-      await this.rememberOwnMessageSecret(message);
     }
 
     return { kept, edits };
@@ -2786,18 +2972,18 @@ export class BaileysConnection {
   private async handleMessagingHistorySet(
     data: BaileysEventMap["messaging-history.set"],
   ) {
-    // A dump is the other route a message arrives by, so it is the other place
-    // its secret has to be filed: a reconnect can replay an original whose
-    // fifteen-minute edit window is still open, and the live edit that follows
-    // has nothing to decrypt with unless the dump was read for secrets too.
-    //
-    // The edits the dump itself carries are dropped rather than emitted. A dump
-    // is a replay of stored state, read by an importer that decides its own
-    // ordering, and injecting live-shaped updates into it would target messages
-    // the import has not written yet.
-    const { kept: messages } = await this.absorbSecretMessageEdits(
+    // Addressing first, secrets second, and the order is load-bearing: a dump's
+    // keys arrive without their `remoteJidAlt`/`participantAlt`, and those are
+    // the second JID form every stored author candidate needs. Filing before
+    // the restore would record half the candidates, and a later edit derived
+    // from the form we dropped would never verify.
+    const addressed = await this.addressHistory(
       data.messages ?? [],
+      data.lidPnMappings,
+      data.chats ?? [],
     );
+    const messages = await this.repairHistoryEdits(addressed);
+
     // The one thing worth keeping from the chat records: which chats have
     // nothing older left. An answer that still has history behind it carries no
     // chat record at all, so an empty list here means "no news", never "there
@@ -2819,7 +3005,7 @@ export class BaileysConnection {
 
     let chunkIndex = 0;
     for (const frame of historyFrames(
-      await this.addressHistory(messages, data.lidPnMappings, data.chats ?? []),
+      messages,
       config.webhook.historyFrameMaxBytes,
     )) {
       const payload: BaileysHistoryFramePayload = {

--- a/src/baileys/connection.ts
+++ b/src/baileys/connection.ts
@@ -2427,6 +2427,16 @@ export class BaileysConnection {
     const { kept, unresolved, secrets } = this.repairSecretMessageEdits(
       messagesData.messages,
     );
+    // Enqueued here, before the first await: the queue orders edits by the
+    // moment they are put on it, and everything below can suspend. Two upsert
+    // callbacks run concurrently -- Baileys does not await ours -- so an older
+    // edit sitting behind a slow secret write would otherwise reach the queue
+    // after a newer one that arrived later, and the older text would win.
+    //
+    // Nothing is lost by going first: these are the edits whose original is NOT
+    // in this batch, so this batch is not what the consumer is missing, and an
+    // original it has not written yet answers 404 and is retried.
+    this.emitUnresolvedEdits(unresolved);
 
     // Reserved here, synchronously, and held until the batch is out. Between
     // this line and the send sit a Redis write and a media download, and both
@@ -2459,8 +2469,6 @@ export class BaileysConnection {
     } finally {
       this._inFlightWebhooks -= 1;
     }
-
-    this.emitUnresolvedEdits(unresolved);
   }
 
   // Sends the edits this batch could not apply itself, one at a time.
@@ -2516,7 +2524,14 @@ export class BaileysConnection {
     // messages afterwards: applying an edit in place replaces the content that
     // holds the secret, so re-reading a repaired message finds nothing and the
     // NEXT edit to it would arrive undecryptable.
-    const secrets = this.collectMessageSecrets(kept, { history });
+    //
+    // `all` and `fresh` differ only for an archive. Filing a secret whose
+    // message can no longer be edited is waste, but an archive can carry an
+    // original AND its edit in the same batch, and that edit is decryptable
+    // right here from a secret nothing would ever store. Age decides what is
+    // worth keeping, never what this batch can read.
+    const { all, fresh } = this.collectMessageSecrets(kept);
+    const secrets = history ? fresh : all;
 
     if (edits.length === 0) {
       return { kept, unresolved: [], secrets };
@@ -2530,7 +2545,7 @@ export class BaileysConnection {
     // ask the network for something already in hand.
     const byId = new Map<string, WAMessage>();
     const secretById = new Map<string, Uint8Array>();
-    for (const entry of secrets) {
+    for (const entry of all) {
       secretById.set(entry.messageId, entry.secret);
     }
     for (const message of kept) {
@@ -2597,16 +2612,13 @@ export class BaileysConnection {
   // nothing will ever read.
   // The secrets on these messages, as store entries. Split from the write so
   // the read can happen before an in-place repair overwrites what it reads.
-  private collectMessageSecrets(
-    messages: WAMessage[],
-    { history = false }: { history?: boolean } = {},
-  ): MessageSecretEntry[] {
-    // Only a dump is filtered by age: a live message is current by definition,
-    // and dropping one whose timestamp reads oddly would silently cost the edit
-    // that follows it. This is the age half of `history`; the other half is the
-    // array order, which orderEditsOldestFirst reads.
+  private collectMessageSecrets(messages: WAMessage[]): {
+    all: MessageSecretEntry[];
+    fresh: MessageSecretEntry[];
+  } {
     const oldest = Date.now() / 1000 - MESSAGE_SECRET_TTL_SECONDS;
-    const entries: MessageSecretEntry[] = [];
+    const all: MessageSecretEntry[] = [];
+    const fresh: MessageSecretEntry[] = [];
 
     for (const message of messages) {
       const messageId = message.key?.id;
@@ -2614,17 +2626,21 @@ export class BaileysConnection {
       if (!messageId || !secret) {
         continue;
       }
-      if (history && messageTimestampSeconds(message) < oldest) {
-        continue;
-      }
-      entries.push({
+      const entry: MessageSecretEntry = {
         messageId,
         secret,
         senders: messageAuthorJids(message.key, this.ownJids()),
-      });
+      };
+      all.push(entry);
+      // A live message is current by definition, so only a dump ever splits
+      // here: an archive reaches back past any replay window, and filing those
+      // secrets leaves a keyspace nothing will read.
+      if (messageTimestampSeconds(message) >= oldest) {
+        fresh.push(entry);
+      }
     }
 
-    return entries;
+    return { all, fresh };
   }
 
   private async fileMessageSecrets(entries: MessageSecretEntry[]) {
@@ -2976,6 +2992,12 @@ export class BaileysConnection {
       unresolved: unresolvedEdits,
       secrets,
     } = this.repairSecretMessageEdits(addressed, { history: true });
+    // Same reason as the live path: enqueued before the awaits below, so the
+    // queue's order is the order the dumps were handled in rather than whichever
+    // one finished writing first. The one await this cannot get in front of is
+    // `addressHistory` above, which has to run before anything can be decrypted;
+    // two dumps carrying edits of the SAME message can still cross there.
+    this.emitUnresolvedEdits(unresolvedEdits);
 
     // Same reservation, same reason as the live path: the Redis write below is
     // a stall this connection has to survive being drained through, and until
@@ -2987,11 +3009,6 @@ export class BaileysConnection {
     } finally {
       this._inFlightWebhooks -= 1;
     }
-
-    // After the frames: the dump is what carries the originals these could not
-    // be applied to, and a consumer that has not seen them yet answers 404.
-    // That answer is retried, which is the whole reason this needs no queue.
-    this.emitUnresolvedEdits(unresolvedEdits);
   }
 
   private async deliverHistoryFrames(

--- a/src/baileys/connection.ts
+++ b/src/baileys/connection.ts
@@ -2646,9 +2646,17 @@ export class BaileysConnection {
     this.editedAt.delete(targetId);
     this.editedAt.set(targetId, position);
     if (this.editedAt.size > BaileysConnection.EDIT_POSITION_MEMORY) {
-      const oldest = this.editedAt.keys().next();
-      if (!oldest.done) {
-        this.editedAt.delete(oldest.value);
+      for (const candidate of this.editedAt.keys()) {
+        // A message still being delivered keeps its position no matter how old
+        // the claim is: the retry consults it before every attempt, and a
+        // position that was evicted reads as "nothing applied yet", which is
+        // precisely the answer that lets a stale retry through. A history sync
+        // touching thousands of messages would otherwise do this routinely.
+        if (this.editDeliveries.has(candidate)) {
+          continue;
+        }
+        this.editedAt.delete(candidate);
+        break;
       }
     }
     return true;

--- a/src/baileys/connection.ts
+++ b/src/baileys/connection.ts
@@ -319,9 +319,8 @@ export class BaileysConnection {
   private sessionEnded = false;
   // Serializes the send-stall verdicts against each other. See reportSendStall.
   private stallReportChain: Promise<unknown> = Promise.resolve();
-  // Serializes encrypted-edit deliveries against each other. See
-  // emitUnresolvedEdits.
-  private editDeliveryQueue: Promise<void> = Promise.resolve();
+  // One delivery chain per edited message. See enqueueEditDelivery.
+  private editDeliveries = new Map<string, Promise<void>>();
   // Secrets this connection has taken in but not yet filed. See
   // beginSecretIntake.
   private secretIntake: Promise<unknown> = Promise.resolve();
@@ -2510,7 +2509,7 @@ export class BaileysConnection {
     }
   }
 
-  // Sends the edits this batch could not apply itself, one at a time.
+  // Sends the edits this batch could not apply itself.
   //
   // Nothing here waits on the upserts: an edit whose original the consumer has
   // not written yet is answered 404 and `awaitResponse` puts the delivery back
@@ -2521,37 +2520,64 @@ export class BaileysConnection {
   // What the protocol does NOT give is order between two edits of the SAME
   // message: once the target exists both are answered 200, so a first edit
   // working through a retry can land after a second and the older text wins.
-  // Hence the queue — and only the queue. It orders edits against each other,
-  // touches nothing else on the connection, and holds the in-flight
-  // reservation for the span, which is the piece a graceful shutdown needs.
+  // Hence the chains — one per message, and only per message. A single chain
+  // for the connection would have one edit's retry ladder, minutes long,
+  // holding back every other chat's edits for an ordering none of them need.
   private emitUnresolvedEdits(unresolved: UnresolvedEdit[]) {
     if (unresolved.length === 0) {
       return;
     }
 
-    // Read while the socket is certainly still there: the loop below runs on a
-    // later tick, and a handoff clears the socket in between. A connection whose
-    // first edit targets a message an EARLIER connection filed has never called
-    // ownJids yet, so without this the cache would be empty exactly when the
-    // socket is gone, and a fromMe edit would derive no candidate at all.
+    // Read while the socket is certainly still there: the deliveries below run
+    // on a later tick, and a handoff clears the socket in between. A connection
+    // whose first edit targets a message an EARLIER connection filed has never
+    // called ownJids yet, so without this the cache would be empty exactly when
+    // the socket is gone, and a fromMe edit would derive no candidate at all.
     this.ownJids();
 
     // Reserved synchronously, for the reason `stallReportChain` reserves its
-    // own: the queue does not reach sendToWebhook until a microtask, and a
-    // SIGTERM landing in that gap would read nothing pending and exit on top of
-    // these edits.
+    // own: nothing reaches sendToWebhook until a microtask, and a SIGTERM
+    // landing in that gap would read nothing pending and exit on top of these
+    // edits.
     this._inFlightWebhooks += 1;
-    this.editDeliveryQueue = this.editDeliveryQueue
-      .catch(() => {})
-      .then(async () => {
-        for (const { message, edit, position } of unresolved) {
-          await this.emitSecretMessageEdit(message, edit, position);
-        }
-      })
+    const deliveries = unresolved.map(({ message, edit, position }) =>
+      this.enqueueEditDelivery(edit.targetKey.id as string, () =>
+        this.emitSecretMessageEdit(message, edit, position),
+      ),
+    );
+    Promise.all(deliveries)
       .catch(() => {})
       .finally(() => {
         this._inFlightWebhooks -= 1;
       });
+  }
+
+  /**
+   * Runs `work` after whatever is already queued for the same message.
+   *
+   * Two edits of one message have to be delivered in order; two edits of
+   * different messages have nothing to do with each other. The chains are
+   * therefore per target, and each removes itself once it drains, so nothing
+   * has to cap or evict them.
+   */
+  private enqueueEditDelivery(
+    targetId: string,
+    work: () => Promise<void>,
+  ): Promise<void> {
+    const previous = this.editDeliveries.get(targetId) ?? Promise.resolve();
+    const next = previous
+      .catch(() => {})
+      .then(work)
+      .catch(() => {});
+    this.editDeliveries.set(targetId, next);
+    next.finally(() => {
+      // Only if nothing queued behind us in the meantime; that chain is now the
+      // one to wait on.
+      if (this.editDeliveries.get(targetId) === next) {
+        this.editDeliveries.delete(targetId);
+      }
+    });
+    return next;
   }
 
   /**

--- a/src/baileys/connection.ts
+++ b/src/baileys/connection.ts
@@ -2666,11 +2666,16 @@ export class BaileysConnection {
           }),
         });
         if (!decrypted) {
+          // Not a dead end: the batch knows only how this copy addressed the
+          // author, and the store may hold a form an earlier copy carried (see
+          // the merge in rememberMessageSecret). Hand it to the unresolved path,
+          // which asks the store and tries those too.
           logger.warn(
-            "[%s] [repairSecretMessageEdits] no sender candidate decrypted targetId=%s",
+            "[%s] [repairSecretMessageEdits] no in-batch candidate decrypted, deferring targetId=%s",
             this.phoneNumber,
             targetId,
           );
+          unresolved.push({ message, edit });
           continue;
         }
         if (
@@ -2837,17 +2842,6 @@ export class BaileysConnection {
       return;
     }
 
-    if (!this.claimEditPosition(targetId, messageTimestampSeconds(message))) {
-      // A newer edit of this message has already been applied. Delivering this
-      // one would put the older text back.
-      logger.debug(
-        "[%s] [emitSecretMessageEdit] superseded targetId=%s",
-        this.phoneNumber,
-        targetId,
-      );
-      return;
-    }
-
     const decrypted = decryptMessageEdit({
       encPayload,
       encIv,
@@ -2876,6 +2870,19 @@ export class BaileysConnection {
       targetId,
       decrypted.senders,
     );
+
+    // Claimed only now, for the same reason the in-batch path claims after
+    // decrypting: an edit that cannot be read changes nothing, and letting it
+    // take the position would reject a later, older edit that CAN be read as
+    // superseded by an update nobody ever received.
+    if (!this.claimEditPosition(targetId, messageTimestampSeconds(message))) {
+      logger.debug(
+        "[%s] [emitSecretMessageEdit] superseded targetId=%s",
+        this.phoneNumber,
+        targetId,
+      );
+      return;
+    }
 
     // Same shape Baileys emits for a plaintext MESSAGE_EDIT: the edit's own key
     // with the id swapped for the original's, so the consumer updates the

--- a/src/baileys/connection.ts
+++ b/src/baileys/connection.ts
@@ -312,6 +312,9 @@ export class BaileysConnection {
   // Secrets this connection has taken in but not yet filed. See
   // beginSecretIntake.
   private secretIntake: Promise<unknown> = Promise.resolve();
+  // When each edited message was last edited, as far as this connection has
+  // delivered. See claimEditPosition.
+  private editedAt = new Map<string, number>();
   private stallStrikeRollback:
     | { previous: SendStallState | null; ttlMs: number | null; wrote: string }
     | undefined;
@@ -2541,6 +2544,44 @@ export class BaileysConnection {
     return close;
   }
 
+  // How many edited messages the ordering guard remembers. An entry is one id
+  // and one number, and it only has to outlive the window in which two edits of
+  // the same message can still be in flight against each other.
+  private static readonly EDIT_POSITION_MEMORY = 1_000;
+
+  /**
+   * Whether this edit is the newest one seen for its target, recording it if so.
+   *
+   * Order of arrival is not something this connection can guarantee. Baileys
+   * runs the callbacks concurrently, a dump spends a keystore round trip on
+   * addressing before it knows what it holds, and a delivery that had to be
+   * retried lands after one that did not. Every attempt to force the order has
+   * cost more than it bought, so the guard is on the outcome instead: an edit
+   * older than one already applied changes nothing, whichever way it got here.
+   *
+   * Strictly older, not older-or-equal: two edits stamped in the same second
+   * carry no order of their own, and `editDeliveryQueue` is what keeps those in
+   * the order they arrived.
+   */
+  private claimEditPosition(targetId: string, editedAt: number): boolean {
+    const applied = this.editedAt.get(targetId);
+    if (applied !== undefined && editedAt < applied) {
+      return false;
+    }
+
+    // Re-inserted rather than updated in place, so the map's own order stays
+    // least-recently-claimed first and the eviction below takes the right one.
+    this.editedAt.delete(targetId);
+    this.editedAt.set(targetId, Math.max(editedAt, applied ?? editedAt));
+    if (this.editedAt.size > BaileysConnection.EDIT_POSITION_MEMORY) {
+      const oldest = this.editedAt.keys().next();
+      if (!oldest.done) {
+        this.editedAt.delete(oldest.value);
+      }
+    }
+    return true;
+  }
+
   private repairSecretMessageEdits(
     messages: WAMessage[],
     { history = false }: { history?: boolean } = {},
@@ -2616,6 +2657,11 @@ export class BaileysConnection {
             this.phoneNumber,
             targetId,
           );
+          continue;
+        }
+        if (
+          !this.claimEditPosition(targetId, messageTimestampSeconds(message))
+        ) {
           continue;
         }
         target.message = replaceInnerContent(
@@ -2777,6 +2823,17 @@ export class BaileysConnection {
       return;
     }
 
+    if (!this.claimEditPosition(targetId, messageTimestampSeconds(message))) {
+      // A newer edit of this message has already been applied. Delivering this
+      // one would put the older text back.
+      logger.debug(
+        "[%s] [emitSecretMessageEdit] superseded targetId=%s",
+        this.phoneNumber,
+        targetId,
+      );
+      return;
+    }
+
     const decrypted = decryptMessageEdit({
       encPayload,
       encIv,
@@ -2824,9 +2881,25 @@ export class BaileysConnection {
     ]);
   }
 
+  // Remembered rather than read fresh every time, because a handoff clears the
+  // socket while its webhooks are deliberately left draining. An edit still in
+  // that queue with `fromMe` derives its key from the account's own JIDs, and
+  // reading them off a socket that is already gone yields no candidate at all
+  // and drops the edit without a word.
+  private ownJidsSeen: OwnJids = {};
+
   private ownJids(): OwnJids {
     const user = this.socket?.user;
-    return { id: user?.id, lid: user?.lid };
+    // Merged one field at a time: `lid` can be absent from a user record that
+    // still has `id`, and overwriting wholesale would throw away the form the
+    // derivation actually used.
+    if (user?.id) {
+      this.ownJidsSeen.id = user.id;
+    }
+    if (user?.lid) {
+      this.ownJidsSeen.lid = user.lid;
+    }
+    return { ...this.ownJidsSeen };
   }
 
   private handleMessagesUpdate(

--- a/src/baileys/connection.ts
+++ b/src/baileys/connection.ts
@@ -2413,47 +2413,61 @@ export class BaileysConnection {
       messagesData = { ...data, messages: individualMessages };
     }
 
-    const remaining = await this.absorbSecretMessageEdits(
+    const { kept, edits } = await this.absorbSecretMessageEdits(
       messagesData.messages,
     );
-    if (remaining.length !== messagesData.messages.length) {
-      if (remaining.length === 0) {
-        return;
+
+    if (kept.length > 0) {
+      if (kept.length !== messagesData.messages.length) {
+        messagesData = { ...messagesData, messages: kept };
       }
-      messagesData = { ...messagesData, messages: remaining };
+
+      const payload: BaileysConnectionWebhookPayload = {
+        event: "messages.upsert",
+        data: messagesData,
+      };
+
+      const media = await downloadMediaFromMessages(messagesData.messages, {
+        includeMedia: this.includeMedia,
+      });
+      if (media) {
+        payload.extra = { media };
+      }
+
+      // Awaited, unlike before, because the edits below are updates to messages
+      // the consumer has to have seen: an offline burst can consolidate an
+      // original and its edit into ONE upsert, and each webhook delivery runs
+      // its own retry loop with no ordering between them. An update that
+      // overtakes the message it edits is rejected as targeting an unknown id,
+      // and the original then lands unedited — the bug this feature exists to
+      // fix, arriving by a different door.
+      await this.sendToWebhook(payload);
     }
 
-    const payload: BaileysConnectionWebhookPayload = {
-      event: "messages.upsert",
-      data: messagesData,
-    };
-
-    const media = await downloadMediaFromMessages(messagesData.messages, {
-      includeMedia: this.includeMedia,
-    });
-    if (media) {
-      payload.extra = { media };
+    for (const { message, edit } of edits) {
+      await this.emitSecretMessageEdit(message, edit);
     }
-
-    this.sendToWebhook(payload);
   }
 
-  // Turns encrypted message edits back into the `messages.update` the rest of
-  // the world already understands, and files every message secret that arrives
-  // so the NEXT edit has something to decrypt with.
+  // Separates the encrypted edits out of a batch and files every message secret
+  // that arrives, so the NEXT edit has something to decrypt with.
   //
-  // Returns the messages that are still messages. An edit is not one: forwarded
-  // as an upsert it becomes a second bubble the consumer can only render as
-  // unsupported content, which is precisely the bug this exists to remove.
-  private async absorbSecretMessageEdits(
-    messages: WAMessage[],
-  ): Promise<WAMessage[]> {
+  // `kept` is the messages that are still messages. An edit is not one:
+  // forwarded as an upsert it becomes a second bubble the consumer can only
+  // render as unsupported content, which is precisely the bug this exists to
+  // remove. The edits are handed back rather than emitted here, because they
+  // may only go out after the batch that carries their originals.
+  private async absorbSecretMessageEdits(messages: WAMessage[]): Promise<{
+    kept: WAMessage[];
+    edits: Array<{ message: WAMessage; edit: SecretMessageEdit }>;
+  }> {
     const kept: WAMessage[] = [];
+    const edits: Array<{ message: WAMessage; edit: SecretMessageEdit }> = [];
 
     for (const message of messages) {
       const edit = secretMessageEdit(message);
       if (edit) {
-        await this.emitSecretMessageEdit(message, edit);
+        edits.push({ message, edit });
         continue;
       }
 
@@ -2461,7 +2475,7 @@ export class BaileysConnection {
       await this.rememberOwnMessageSecret(message);
     }
 
-    return kept;
+    return { kept, edits };
   }
 
   private async rememberOwnMessageSecret(message: WAMessage) {
@@ -2491,6 +2505,26 @@ export class BaileysConnection {
   }
 
   private async emitSecretMessageEdit(
+    message: WAMessage,
+    edit: SecretMessageEdit,
+  ) {
+    try {
+      await this.decryptAndEmitMessageEdit(message, edit);
+    } catch (error) {
+      // Contained per edit. Redis can refuse the lookup and a decrypted payload
+      // can still fail to parse, and neither is a reason to lose the other
+      // edits in the batch — nor, before this was awaited after the upsert, the
+      // ordinary messages that rode in with them.
+      logger.warn(
+        "[%s] [emitSecretMessageEdit] failed targetId=%s\n%s",
+        this.phoneNumber,
+        edit.targetKey.id,
+        errorToString(error),
+      );
+    }
+  }
+
+  private async decryptAndEmitMessageEdit(
     message: WAMessage,
     { targetKey, encPayload, encIv }: SecretMessageEdit,
   ) {
@@ -2752,7 +2786,18 @@ export class BaileysConnection {
   private async handleMessagingHistorySet(
     data: BaileysEventMap["messaging-history.set"],
   ) {
-    const messages = data.messages ?? [];
+    // A dump is the other route a message arrives by, so it is the other place
+    // its secret has to be filed: a reconnect can replay an original whose
+    // fifteen-minute edit window is still open, and the live edit that follows
+    // has nothing to decrypt with unless the dump was read for secrets too.
+    //
+    // The edits the dump itself carries are dropped rather than emitted. A dump
+    // is a replay of stored state, read by an importer that decides its own
+    // ordering, and injecting live-shaped updates into it would target messages
+    // the import has not written yet.
+    const { kept: messages } = await this.absorbSecretMessageEdits(
+      data.messages ?? [],
+    );
     // The one thing worth keeping from the chat records: which chats have
     // nothing older left. An answer that still has history behind it carries no
     // chat record at all, so an empty list here means "no news", never "there

--- a/src/baileys/connection.ts
+++ b/src/baileys/connection.ts
@@ -2427,9 +2427,21 @@ export class BaileysConnection {
     // message it edits.
     const settled = this.beginMessageDelivery();
     try {
-      const { kept, edits } = await this.absorbSecretMessageEdits(
+      const { kept, edits } = this.splitSecretMessageEdits(
         messagesData.messages,
       );
+
+      // Queued before ANY await, so an edit's place in the chain is the order
+      // it arrived in. Queueing even one await later loses that: filing the
+      // batch's secrets suspends, and a callback carrying only an edit has no
+      // secrets to file, so it would overtake an edit seen earlier and its
+      // newer text would land first. The barrier is unaffected — it holds this
+      // callback's delivery slot, which stays open until the send below.
+      for (const { message, edit } of edits) {
+        this.queueSecretMessageEdit(message, edit);
+      }
+
+      await this.rememberOwnMessageSecrets(kept);
 
       if (kept.length > 0) {
         if (kept.length !== messagesData.messages.length) {
@@ -2449,10 +2461,6 @@ export class BaileysConnection {
         }
 
         await this.sendToWebhook(payload);
-      }
-
-      for (const { message, edit } of edits) {
-        this.queueSecretMessageEdit(message, edit);
       }
     } finally {
       settled();
@@ -2509,25 +2517,10 @@ export class BaileysConnection {
       });
   }
 
-  // Separates the encrypted edits out of a batch and files every message secret
-  // that arrives, so the NEXT edit has something to decrypt with.
-  //
-  // `kept` is the messages that are still messages. An edit is not one:
-  // forwarded as an upsert it becomes a second bubble the consumer can only
-  // render as unsupported content, which is precisely the bug this exists to
-  // remove. The edits are handed back rather than emitted here, because they
-  // may only go out after the batch that carries their originals.
-  private async absorbSecretMessageEdits(messages: WAMessage[]): Promise<{
-    kept: WAMessage[];
-    edits: Array<{ message: WAMessage; edit: SecretMessageEdit }>;
-  }> {
-    const { kept, edits } = this.splitSecretMessageEdits(messages);
-
-    for (const message of kept) {
+  private async rememberOwnMessageSecrets(messages: WAMessage[]) {
+    for (const message of messages) {
       await this.rememberOwnMessageSecret(message);
     }
-
-    return { kept, edits };
   }
 
   // Applies a dump's encrypted edits to the messages inside that same dump, and
@@ -2548,13 +2541,12 @@ export class BaileysConnection {
   // the frames are out. That path races the importer's own write, which is
   // exactly why it is the fallback and not the rule: an edit that may not land
   // still beats one that certainly will not.
-  private async repairHistoryEdits(messages: WAMessage[]): Promise<{
+  private repairHistoryEdits(messages: WAMessage[]): {
     kept: WAMessage[];
     unresolved: Array<{ message: WAMessage; edit: SecretMessageEdit }>;
-  }> {
+  } {
     const { kept, edits } = this.splitSecretMessageEdits(messages);
-    if (edits.length === 0 && kept.length === messages.length) {
-      await this.rememberHistorySecrets(kept);
+    if (edits.length === 0) {
       return { kept, unresolved: [] };
     }
 
@@ -2619,7 +2611,6 @@ export class BaileysConnection {
       }
     }
 
-    await this.rememberHistorySecrets(kept);
     return { kept, unresolved };
   }
 
@@ -2654,7 +2645,11 @@ export class BaileysConnection {
     }
 
     try {
-      await rememberMessageSecrets(this.phoneNumber, entries);
+      await withTimeout(
+        "rememberMessageSecrets",
+        config.baileys.messageSecretStoreTimeoutMs,
+        () => rememberMessageSecrets(this.phoneNumber, entries),
+      );
     } catch (error) {
       logger.warn(
         "[%s] [rememberHistorySecrets] failed for %d message(s)\n%s",
@@ -2692,11 +2687,16 @@ export class BaileysConnection {
     }
 
     try {
-      await rememberMessageSecret(
-        this.phoneNumber,
-        messageId,
-        secret,
-        messageAuthorJids(message.key, this.ownJids()),
+      await withTimeout(
+        "rememberMessageSecret",
+        config.baileys.messageSecretStoreTimeoutMs,
+        () =>
+          rememberMessageSecret(
+            this.phoneNumber,
+            messageId,
+            secret,
+            messageAuthorJids(message.key, this.ownJids()),
+          ),
       );
     } catch (error) {
       // A message we cannot file is a future edit we cannot decrypt, never a
@@ -2735,7 +2735,11 @@ export class BaileysConnection {
     { targetKey, encPayload, encIv }: SecretMessageEdit,
   ) {
     const targetId = targetKey.id as string;
-    const stored = await recallMessageSecret(this.phoneNumber, targetId);
+    const stored = await withTimeout(
+      "recallMessageSecret",
+      config.baileys.messageSecretStoreTimeoutMs,
+      () => recallMessageSecret(this.phoneNumber, targetId),
+    );
     if (!stored) {
       // The original never passed through this instance, or it did so more than
       // MESSAGE_SECRET_TTL_SECONDS ago. Nothing to derive the key from.
@@ -3020,8 +3024,15 @@ export class BaileysConnection {
       data.lidPnMappings,
       data.chats ?? [],
     );
-    const { kept: messages, unresolved } =
-      await this.repairHistoryEdits(addressed);
+    const { kept: messages, unresolved } = this.repairHistoryEdits(addressed);
+
+    // Same rule as the live path, for the same reason: the queue position is
+    // taken before the filing below suspends. The barrier still holds these
+    // behind this dump's frames, since the delivery slot the caller opened
+    // stays open until they are all out.
+    this.queueUnresolvedHistoryEdits(unresolved);
+
+    await this.rememberHistorySecrets(messages);
 
     // The one thing worth keeping from the chat records: which chats have
     // nothing older left. An answer that still has history behind it carries no
@@ -3029,7 +3040,6 @@ export class BaileysConnection {
     // is more".
     const exhausted = exhaustedChats(data.chats ?? []);
     if (messages.length === 0 && exhausted.length === 0) {
-      this.queueUnresolvedHistoryEdits(unresolved);
       return;
     }
 
@@ -3080,8 +3090,6 @@ export class BaileysConnection {
         },
       });
     }
-
-    this.queueUnresolvedHistoryEdits(unresolved);
   }
 
   // Sends, as live updates, the dump edits whose targets were not in the dump.

--- a/src/baileys/helpers/decryptMessageEdit.spec.ts
+++ b/src/baileys/helpers/decryptMessageEdit.spec.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from "bun:test";
+import { createCipheriv, randomBytes } from "node:crypto";
+import {
+  decryptMessageEdit,
+  type MessageEditSenders,
+  messageEditKey,
+} from "./decryptMessageEdit";
+
+const ORIG_MSG_ID = "3EB078E05D8F792B76A79F";
+const SENDERS: MessageEditSenders = {
+  origMsgSender: "167392323834034@lid",
+  editSender: "167392323834034@lid",
+};
+
+// Mirrors what WhatsApp does on the sending side, so a round trip exercises the
+// real GCM framing (tag appended to the ciphertext) rather than a stand-in.
+// It shares messageEditKey with the code under test on purpose: the derivation
+// itself has no published test vector, and is proven against a real edit from a
+// real phone, not here. What these tests own is the framing and the candidate
+// search around it.
+function seal(
+  plaintext: Buffer,
+  messageSecret: Uint8Array,
+  senders: MessageEditSenders,
+) {
+  const encIv = randomBytes(12);
+  const key = messageEditKey({
+    ...senders,
+    origMsgId: ORIG_MSG_ID,
+    messageSecret,
+  });
+  const cipher = createCipheriv("aes-256-gcm", key, encIv);
+  cipher.setAAD(Buffer.alloc(0));
+  const body = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+  return { encIv, encPayload: Buffer.concat([body, cipher.getAuthTag()]) };
+}
+
+describe("messageEditKey", () => {
+  const messageSecret = Buffer.alloc(32, 7);
+
+  it("derives 32 bytes", () => {
+    expect(
+      messageEditKey({ ...SENDERS, origMsgId: ORIG_MSG_ID, messageSecret }),
+    ).toHaveLength(32);
+  });
+
+  it("is deterministic for the same inputs", () => {
+    const args = { ...SENDERS, origMsgId: ORIG_MSG_ID, messageSecret };
+    expect(messageEditKey(args)).toEqual(messageEditKey(args));
+  });
+
+  // The two parties enter the derivation in a fixed order, so swapping them has
+  // to change the key — otherwise a candidate pair that is merely reversed
+  // would decrypt and we would trust the wrong attribution.
+  it("binds the two parties in order", () => {
+    const forward = messageEditKey({
+      origMsgSender: "a@lid",
+      editSender: "b@lid",
+      origMsgId: ORIG_MSG_ID,
+      messageSecret,
+    });
+    const reversed = messageEditKey({
+      origMsgSender: "b@lid",
+      editSender: "a@lid",
+      origMsgId: ORIG_MSG_ID,
+      messageSecret,
+    });
+    expect(forward).not.toEqual(reversed);
+  });
+
+  it("binds the original message id", () => {
+    const args = { ...SENDERS, messageSecret };
+    expect(messageEditKey({ ...args, origMsgId: "AAA" })).not.toEqual(
+      messageEditKey({ ...args, origMsgId: "BBB" }),
+    );
+  });
+});
+
+describe("decryptMessageEdit", () => {
+  const messageSecret = randomBytes(32);
+  const plaintext = Buffer.from("the edited body", "utf8");
+
+  it("recovers the plaintext for the matching candidate", () => {
+    const { encPayload, encIv } = seal(plaintext, messageSecret, SENDERS);
+
+    const result = decryptMessageEdit({
+      encPayload,
+      encIv,
+      origMsgId: ORIG_MSG_ID,
+      messageSecret,
+      senderCandidates: [SENDERS],
+    });
+
+    expect(result?.plaintext).toEqual(plaintext);
+    expect(result?.senders).toEqual(SENDERS);
+  });
+
+  // The whole reason candidates exist: a chat mid-LID-migration reports the
+  // same person under two JIDs and only one of them went into the key.
+  it("keeps trying until a candidate verifies, and reports which one", () => {
+    const { encPayload, encIv } = seal(plaintext, messageSecret, SENDERS);
+    const wrong: MessageEditSenders = {
+      origMsgSender: "553499503261@s.whatsapp.net",
+      editSender: "553499503261@s.whatsapp.net",
+    };
+
+    const result = decryptMessageEdit({
+      encPayload,
+      encIv,
+      origMsgId: ORIG_MSG_ID,
+      messageSecret,
+      senderCandidates: [wrong, SENDERS],
+    });
+
+    expect(result?.plaintext).toEqual(plaintext);
+    expect(result?.senders).toEqual(SENDERS);
+  });
+
+  // A wrong guess must be a clean miss. The tag check is what makes brute
+  // forcing the JID form safe: it can never yield a wrong plaintext.
+  it("returns null when no candidate verifies", () => {
+    const { encPayload, encIv } = seal(plaintext, messageSecret, SENDERS);
+
+    expect(
+      decryptMessageEdit({
+        encPayload,
+        encIv,
+        origMsgId: ORIG_MSG_ID,
+        messageSecret,
+        senderCandidates: [
+          { origMsgSender: "x@lid", editSender: "y@lid" },
+          { origMsgSender: "y@lid", editSender: "x@lid" },
+        ],
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null when the wrong message secret is stored", () => {
+    const { encPayload, encIv } = seal(plaintext, messageSecret, SENDERS);
+
+    expect(
+      decryptMessageEdit({
+        encPayload,
+        encIv,
+        origMsgId: ORIG_MSG_ID,
+        messageSecret: randomBytes(32),
+        senderCandidates: [SENDERS],
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null with no candidates at all", () => {
+    const { encPayload, encIv } = seal(plaintext, messageSecret, SENDERS);
+
+    expect(
+      decryptMessageEdit({
+        encPayload,
+        encIv,
+        origMsgId: ORIG_MSG_ID,
+        messageSecret,
+        senderCandidates: [],
+      }),
+    ).toBeNull();
+  });
+
+  // A payload too short to hold a tag would make the subarray split produce
+  // nonsense; refuse it instead of letting createDecipheriv decide.
+  it("refuses a payload shorter than the GCM tag", () => {
+    expect(
+      decryptMessageEdit({
+        encPayload: Buffer.alloc(16),
+        encIv: randomBytes(12),
+        origMsgId: ORIG_MSG_ID,
+        messageSecret,
+        senderCandidates: [SENDERS],
+      }),
+    ).toBeNull();
+  });
+});

--- a/src/baileys/helpers/decryptMessageEdit.ts
+++ b/src/baileys/helpers/decryptMessageEdit.ts
@@ -1,0 +1,98 @@
+import { createDecipheriv, hkdfSync } from "node:crypto";
+
+// AES-GCM appends its authentication tag to the ciphertext.
+const GCM_TAG_LENGTH = 16;
+
+// Part of the key derivation input, so this string is protocol rather than a
+// label: it is the `MsgSecretType` WhatsApp uses for a message edit. See
+// whatsmeow's msgsecret.go (`EncSecretMessageEdit`) and, on the Baileys side,
+// the identical construction in Utils/reporting-utils.js.
+const MESSAGE_EDIT_USE_CASE = "Message Edit";
+
+export interface MessageEditSenders {
+  /** JID of whoever wrote the message being edited. */
+  origMsgSender: string;
+  /** JID of whoever sent the edit. */
+  editSender: string;
+}
+
+/**
+ * HKDF-SHA256 over the original message's secret, bound to the message id and
+ * to both parties, exactly as WhatsApp derives it. A wrong JID string yields a
+ * wrong key and the GCM tag check fails — which is why callers try candidates.
+ */
+export function messageEditKey({
+  origMsgId,
+  origMsgSender,
+  editSender,
+  messageSecret,
+}: MessageEditSenders & {
+  origMsgId: string;
+  messageSecret: Uint8Array;
+}): Buffer {
+  const info = Buffer.concat([
+    Buffer.from(origMsgId, "utf8"),
+    Buffer.from(origMsgSender, "utf8"),
+    Buffer.from(editSender, "utf8"),
+    Buffer.from(MESSAGE_EDIT_USE_CASE, "utf8"),
+  ]);
+
+  // Salt omitted, matching whatsmeow's hkdfutil.SHA256(secret, nil, info, 32).
+  return Buffer.from(
+    hkdfSync("sha256", messageSecret, Buffer.alloc(0), info, 32),
+  );
+}
+
+/**
+ * Decrypts a `secretEncryptedMessage` of type MESSAGE_EDIT into the serialized
+ * `proto.Message` the author replaced the original with.
+ *
+ * `senderCandidates` is tried in order and the first pair whose GCM tag
+ * verifies wins. Candidates exist because WhatsApp is mid-migration from phone
+ * JIDs to LIDs and the derivation is over the JID *string*: which of the two
+ * forms went into the key is not something the payload tells us. The tag check
+ * makes a wrong guess a clean miss, never a wrong plaintext.
+ *
+ * Returns the plaintext and the pair that produced it, or null when no
+ * candidate verifies.
+ */
+export function decryptMessageEdit({
+  encPayload,
+  encIv,
+  origMsgId,
+  messageSecret,
+  senderCandidates,
+}: {
+  encPayload: Uint8Array;
+  encIv: Uint8Array;
+  origMsgId: string;
+  messageSecret: Uint8Array;
+  senderCandidates: MessageEditSenders[];
+}): { plaintext: Buffer; senders: MessageEditSenders } | null {
+  if (encPayload.length <= GCM_TAG_LENGTH) {
+    return null;
+  }
+
+  const ciphertext = encPayload.subarray(0, encPayload.length - GCM_TAG_LENGTH);
+  const tag = encPayload.subarray(encPayload.length - GCM_TAG_LENGTH);
+
+  for (const senders of senderCandidates) {
+    const key = messageEditKey({ ...senders, origMsgId, messageSecret });
+    try {
+      const decipher = createDecipheriv("aes-256-gcm", key, encIv);
+      // No additional data for a message edit: WhatsApp only binds AAD on the
+      // poll-vote and event-response use cases.
+      decipher.setAAD(Buffer.alloc(0));
+      decipher.setAuthTag(tag);
+      const plaintext = Buffer.concat([
+        decipher.update(ciphertext),
+        decipher.final(),
+      ]);
+      return { plaintext, senders };
+    } catch {
+      // Wrong candidate: the tag did not verify. Try the next one.
+    }
+  }
+
+  return null;
+}

--- a/src/baileys/helpers/messageEditSenders.spec.ts
+++ b/src/baileys/helpers/messageEditSenders.spec.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from "bun:test";
+import {
+  messageAuthorJids,
+  messageEditSenderCandidates,
+} from "./messageEditSenders";
+
+const ME = { id: "5511936199421:12@s.whatsapp.net", lid: "89572297961476@lid" };
+
+describe("messageAuthorJids", () => {
+  it("gives both addressing forms of an incoming author, LID first", () => {
+    expect(
+      messageAuthorJids(
+        {
+          remoteJid: "167392323834034@lid",
+          remoteJidAlt: "553499503261@s.whatsapp.net",
+          fromMe: false,
+          id: "x",
+        },
+        ME,
+      ),
+    ).toEqual(["167392323834034@lid", "553499503261@s.whatsapp.net"]);
+  });
+
+  it("prefers the participant in a group", () => {
+    expect(
+      messageAuthorJids(
+        {
+          remoteJid: "120363000000000000@g.us",
+          participant: "167392323834034@lid",
+          participantAlt: "553499503261@s.whatsapp.net",
+          fromMe: false,
+          id: "x",
+        },
+        ME,
+      ),
+    ).toEqual(["167392323834034@lid", "553499503261@s.whatsapp.net"]);
+  });
+
+  it("answers with our own JIDs for our own message", () => {
+    expect(
+      messageAuthorJids(
+        { remoteJid: "167392323834034@lid", fromMe: true, id: "x" },
+        ME,
+      ),
+    ).toEqual(["89572297961476@lid", "5511936199421@s.whatsapp.net"]);
+  });
+
+  // The device suffix is per-session and never part of the derivation.
+  it("strips the device suffix", () => {
+    expect(
+      messageAuthorJids(
+        { remoteJid: "167392323834034:58@lid", fromMe: false, id: "x" },
+        ME,
+      ),
+    ).toEqual(["167392323834034@lid"]);
+  });
+
+  it("drops duplicates and blanks", () => {
+    expect(
+      messageAuthorJids(
+        {
+          remoteJid: "167392323834034@lid",
+          remoteJidAlt: "167392323834034@lid",
+          participant: "",
+          fromMe: false,
+          id: "x",
+        },
+        ME,
+      ),
+    ).toEqual(["167392323834034@lid"]);
+  });
+});
+
+describe("messageEditSenderCandidates", () => {
+  const editKey = {
+    remoteJid: "167392323834034@lid",
+    remoteJidAlt: "553499503261@s.whatsapp.net",
+    fromMe: false,
+    id: "edit-1",
+  };
+
+  // The observed shape: the contact edits their own message, so
+  // targetMessageKey.fromMe is true from THEIR point of view and the original
+  // author is the editor.
+  it("makes the editor the original author when the target is theirs", () => {
+    expect(
+      messageEditSenderCandidates({
+        editKey,
+        targetKey: {
+          remoteJid: "89572297961476@lid",
+          fromMe: true,
+          id: "orig-1",
+        },
+        me: ME,
+      }),
+    ).toEqual([
+      {
+        origMsgSender: "167392323834034@lid",
+        editSender: "167392323834034@lid",
+      },
+      {
+        origMsgSender: "167392323834034@lid",
+        editSender: "553499503261@s.whatsapp.net",
+      },
+      {
+        origMsgSender: "553499503261@s.whatsapp.net",
+        editSender: "167392323834034@lid",
+      },
+      {
+        origMsgSender: "553499503261@s.whatsapp.net",
+        editSender: "553499503261@s.whatsapp.net",
+      },
+    ]);
+  });
+
+  // fromMe false means they are editing OUR message, and the key's remoteJid is
+  // then how they address us — which is not a JID we would otherwise guess.
+  it("takes the original author from the target key when it is not theirs", () => {
+    const candidates = messageEditSenderCandidates({
+      editKey,
+      targetKey: { remoteJid: "89572297961476@lid", fromMe: false, id: "o" },
+      me: ME,
+    });
+
+    expect(candidates.map((c) => c.origMsgSender)).toEqual([
+      "89572297961476@lid",
+      "89572297961476@lid",
+    ]);
+  });
+
+  // The fallback for a JID form the reasoning above did not predict: whoever we
+  // actually filed the original under.
+  it("appends the stored authors after the derived one", () => {
+    const candidates = messageEditSenderCandidates({
+      editKey,
+      targetKey: { remoteJid: "89572297961476@lid", fromMe: false, id: "o" },
+      me: ME,
+      storedSenders: ["167392323834034@lid"],
+    });
+
+    expect(candidates.map((c) => c.origMsgSender)).toEqual([
+      "89572297961476@lid",
+      "89572297961476@lid",
+      "167392323834034@lid",
+      "167392323834034@lid",
+    ]);
+  });
+
+  it("does not repeat a stored author already derived", () => {
+    const candidates = messageEditSenderCandidates({
+      editKey,
+      targetKey: { remoteJid: "89572297961476@lid", fromMe: false, id: "o" },
+      me: ME,
+      storedSenders: ["89572297961476@lid"],
+    });
+
+    expect(candidates).toHaveLength(2);
+  });
+});

--- a/src/baileys/helpers/messageEditSenders.ts
+++ b/src/baileys/helpers/messageEditSenders.ts
@@ -1,0 +1,89 @@
+import { jidNormalizedUser, type WAMessageKey } from "@whiskeysockets/baileys";
+import type { MessageEditSenders } from "@/baileys/helpers/decryptMessageEdit";
+
+export interface OwnJids {
+  /** socket.user.id — phone-number form for a paired account. */
+  id?: string | null;
+  /** socket.user.lid — the same account addressed by its LID. */
+  lid?: string | null;
+}
+
+function normalize(jid: string | null | undefined): string | null {
+  if (!jid) {
+    return null;
+  }
+  try {
+    // Strips the device suffix ("…:58@lid"), which is never part of the
+    // derivation — whatsmeow calls the same normalization ToNonAD().
+    return jidNormalizedUser(jid) || null;
+  } catch {
+    return null;
+  }
+}
+
+function unique(jids: Array<string | null | undefined>): string[] {
+  const out: string[] = [];
+  for (const jid of jids) {
+    const normalized = normalize(jid);
+    if (normalized && !out.includes(normalized)) {
+      out.push(normalized);
+    }
+  }
+  return out;
+}
+
+/**
+ * The JIDs a message's author may be addressed by, most likely first.
+ *
+ * Two of them, not one, because a chat mid-LID-migration reports the same
+ * person both as `<lid>@lid` and as `<phone>@s.whatsapp.net`, and the key
+ * derivation is over whichever string WhatsApp itself used.
+ */
+export function messageAuthorJids(key: WAMessageKey, me: OwnJids): string[] {
+  if (key.fromMe) {
+    return unique([me.lid, me.id]);
+  }
+  return unique([
+    key.participant || key.remoteJid,
+    key.participantAlt || key.remoteJidAlt,
+  ]);
+}
+
+/**
+ * Candidate (original author, editor) pairs for a message edit, in the order
+ * they are worth trying.
+ *
+ * `targetMessageKey.fromMe` is written from the EDITOR's point of view: true
+ * means they are editing their own message, so the original author is the
+ * editor. False means they are editing ours, and the key's remoteJid is then
+ * how they address us. `storedSenders` are the JIDs we filed the original
+ * under and act as the fallback for when that reasoning meets a JID form we
+ * did not predict.
+ */
+export function messageEditSenderCandidates({
+  editKey,
+  targetKey,
+  me,
+  storedSenders = [],
+}: {
+  editKey: WAMessageKey;
+  targetKey: WAMessageKey;
+  me: OwnJids;
+  storedSenders?: string[];
+}): MessageEditSenders[] {
+  const editSenders = messageAuthorJids(editKey, me);
+  const origSenders = unique([
+    ...(targetKey.fromMe
+      ? editSenders
+      : [targetKey.participant || targetKey.remoteJid]),
+    ...storedSenders,
+  ]);
+
+  const candidates: MessageEditSenders[] = [];
+  for (const origMsgSender of origSenders) {
+    for (const editSender of editSenders) {
+      candidates.push({ origMsgSender, editSender });
+    }
+  }
+  return candidates;
+}

--- a/src/baileys/helpers/messageSecretStore.spec.ts
+++ b/src/baileys/helpers/messageSecretStore.spec.ts
@@ -23,6 +23,7 @@ describe("messageSecretStore", () => {
     stringData.clear();
     hashData.clear();
     expirations.clear();
+    (redis as any).__multiCommands.length = 0;
   });
 
   it("round-trips the secret and its authors", async () => {
@@ -35,6 +36,20 @@ describe("messageSecretStore", () => {
       secret: SECRET,
       senders: ["167392323834034@lid", "553499503261@s.whatsapp.net"],
     });
+  });
+
+  // A hash created by a write whose EXPIRE never landed is a key nothing will
+  // ever delete, which is the whole failure the TTL exists to prevent. One
+  // transaction, so the entry and its lifetime stand or fall together.
+  it("writes the entry and its expiry in one transaction", async () => {
+    const before = (redis as any).multi.mock.calls.length;
+
+    await rememberMessageSecret(PHONE, MESSAGE_ID, SECRET, []);
+
+    expect((redis as any).multi.mock.calls.length).toBe(before + 1);
+    const ops = (redis as any).__multiCommands.map((c: any) => c.op);
+    expect(ops).toContain("hSet");
+    expect(ops).toContain("expire");
   });
 
   // Per-message keys with no expiry would grow the keyspace by every message

--- a/src/baileys/helpers/messageSecretStore.spec.ts
+++ b/src/baileys/helpers/messageSecretStore.spec.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from "bun:test";
 import redis from "@/lib/redis";
 import {
   MESSAGE_SECRET_TTL_SECONDS,
+  MESSAGE_SECRET_WRITE_SCRIPT,
   messageSecretKey,
   recallMessageSecret,
   rememberMessageSecret,
@@ -40,16 +41,18 @@ describe("messageSecretStore", () => {
 
   // A hash created by a write whose EXPIRE never landed is a key nothing will
   // ever delete, which is the whole failure the TTL exists to prevent. One
-  // transaction, so the entry and its lifetime stand or fall together.
-  it("writes the entry and its expiry in one transaction", async () => {
-    const before = (redis as any).multi.mock.calls.length;
+  // command, so the entry and its lifetime stand or fall together -- and a
+  // script rather than a transaction, because node-redis queues a MULTI's
+  // commands without the abort signal and an unbounded write is the other
+  // failure this store guards against.
+  it("writes the entry and its expiry as one abortable command", async () => {
+    const before = (redis as any).eval.mock.calls.length;
 
     await rememberMessageSecret(PHONE, MESSAGE_ID, SECRET, []);
 
-    expect((redis as any).multi.mock.calls.length).toBe(before + 1);
-    const ops = (redis as any).__multiCommands.map((c: any) => c.op);
-    expect(ops).toContain("hSet");
-    expect(ops).toContain("expire");
+    expect((redis as any).eval.mock.calls.length).toBe(before + 1);
+    expect(MESSAGE_SECRET_WRITE_SCRIPT).toContain("HSET");
+    expect(MESSAGE_SECRET_WRITE_SCRIPT).toContain("EXPIRE");
   });
 
   // Per-message keys with no expiry would grow the keyspace by every message

--- a/src/baileys/helpers/messageSecretStore.spec.ts
+++ b/src/baileys/helpers/messageSecretStore.spec.ts
@@ -69,4 +69,51 @@ describe("messageSecretStore", () => {
 
     expect(await recallMessageSecret(PHONE, MESSAGE_ID)).toBeNull();
   });
+
+  // The same message arrives by more than one route and they do not address its
+  // author equally well: a dump whose LID mapping was unknown carries one JID
+  // form where the live copy carried two. Letting the poorer copy overwrite the
+  // richer one leaves an edit encrypted under the dropped form undecryptable.
+  it("keeps a sender form a later, poorer copy of the message dropped", async () => {
+    const lid = "167392323834034@lid";
+    const pn = "553499503261@s.whatsapp.net";
+    await rememberMessageSecret(PHONE, MESSAGE_ID, SECRET, [lid, pn]);
+
+    await rememberMessageSecret(PHONE, MESSAGE_ID, SECRET, [lid]);
+
+    const stored = await recallMessageSecret(PHONE, MESSAGE_ID);
+    expect(stored?.senders).toEqual([lid, pn]);
+  });
+
+  // A timeout only stops us awaiting; the command stays on node-redis's queue
+  // with its payload until the connection returns. Aborting is what removes it,
+  // so every command here has to carry the signal.
+  it("sends its commands under an abort signal", async () => {
+    const seen: AbortSignal[] = [];
+    const real = (redis as any).withAbortSignal;
+    (redis as any).withAbortSignal = (signal: AbortSignal) => {
+      seen.push(signal);
+      return redis;
+    };
+
+    try {
+      await rememberMessageSecret(PHONE, MESSAGE_ID, SECRET, []);
+      await recallMessageSecret(PHONE, MESSAGE_ID);
+    } finally {
+      (redis as any).withAbortSignal = real;
+    }
+
+    expect(seen).toHaveLength(2);
+    expect(seen.every((signal) => signal instanceof AbortSignal)).toBe(true);
+  });
+
+  it("does not rewrite when the new copy already covers the old", async () => {
+    const lid = "167392323834034@lid";
+    await rememberMessageSecret(PHONE, MESSAGE_ID, SECRET, [lid]);
+    const writes = (redis as any).set.mock.calls.length;
+
+    await rememberMessageSecret(PHONE, MESSAGE_ID, SECRET, [lid]);
+
+    expect((redis as any).set.mock.calls.length).toBe(writes + 1);
+  });
 });

--- a/src/baileys/helpers/messageSecretStore.spec.ts
+++ b/src/baileys/helpers/messageSecretStore.spec.ts
@@ -8,6 +8,7 @@ import {
 } from "./messageSecretStore";
 
 const stringData = (redis as any).__stringData as Map<string, string>;
+const hashData = (redis as any).__hashData as Map<string, Map<string, string>>;
 const expirations = (redis as any).__expirations as Map<
   string,
   { type: string; value: number }
@@ -20,6 +21,7 @@ const SECRET = Buffer.alloc(32, 3);
 describe("messageSecretStore", () => {
   afterEach(() => {
     stringData.clear();
+    hashData.clear();
     expirations.clear();
   });
 
@@ -58,14 +60,29 @@ describe("messageSecretStore", () => {
     expect(await recallMessageSecret(PHONE, "unknown")).toBeNull();
   });
 
-  it("answers null instead of throwing on a corrupt entry", async () => {
-    stringData.set(messageSecretKey(PHONE, MESSAGE_ID), "not json");
+  // An older build of this feature stored a JSON string under the same key, and
+  // those entries outlive a rollback by up to the TTL. Reading one answers
+  // WRONGTYPE, which is unreadable, which is the same as absent.
+  it("answers null instead of throwing on an entry it cannot read", async () => {
+    const real = (redis as any).hGetAll;
+    (redis as any).hGetAll = async () => {
+      throw new Error(
+        "WRONGTYPE Operation against a key holding the wrong kind of value",
+      );
+    };
 
-    expect(await recallMessageSecret(PHONE, MESSAGE_ID)).toBeNull();
+    try {
+      expect(await recallMessageSecret(PHONE, MESSAGE_ID)).toBeNull();
+    } finally {
+      (redis as any).hGetAll = real;
+    }
   });
 
   it("answers null on an entry with no secret", async () => {
-    stringData.set(messageSecretKey(PHONE, MESSAGE_ID), JSON.stringify({}));
+    hashData.set(
+      messageSecretKey(PHONE, MESSAGE_ID),
+      new Map([["jid:167392323834034@lid", "1"]]),
+    );
 
     expect(await recallMessageSecret(PHONE, MESSAGE_ID)).toBeNull();
   });
@@ -82,7 +99,20 @@ describe("messageSecretStore", () => {
     await rememberMessageSecret(PHONE, MESSAGE_ID, SECRET, [lid]);
 
     const stored = await recallMessageSecret(PHONE, MESSAGE_ID);
-    expect(stored?.senders).toEqual([lid, pn]);
+    expect(stored?.senders.sort()).toEqual([lid, pn].sort());
+  });
+
+  // The merge is Redis's own, not a read-modify-write: setting fields only adds,
+  // so a poorer copy can neither publish itself first nor lose the richer form
+  // if the connection drops between two writes.
+  it("never reads the entry back to merge it", async () => {
+    const reads = (redis as any).hGetAll.mock.calls.length;
+
+    await rememberMessageSecret(PHONE, MESSAGE_ID, SECRET, [
+      "167392323834034@lid",
+    ]);
+
+    expect((redis as any).hGetAll.mock.calls.length).toBe(reads);
   });
 
   // A timeout only stops us awaiting; the command stays on node-redis's queue
@@ -105,15 +135,5 @@ describe("messageSecretStore", () => {
 
     expect(seen).toHaveLength(2);
     expect(seen.every((signal) => signal instanceof AbortSignal)).toBe(true);
-  });
-
-  it("does not rewrite when the new copy already covers the old", async () => {
-    const lid = "167392323834034@lid";
-    await rememberMessageSecret(PHONE, MESSAGE_ID, SECRET, [lid]);
-    const writes = (redis as any).set.mock.calls.length;
-
-    await rememberMessageSecret(PHONE, MESSAGE_ID, SECRET, [lid]);
-
-    expect((redis as any).set.mock.calls.length).toBe(writes + 1);
   });
 });

--- a/src/baileys/helpers/messageSecretStore.spec.ts
+++ b/src/baileys/helpers/messageSecretStore.spec.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import redis from "@/lib/redis";
+import {
+  MESSAGE_SECRET_TTL_SECONDS,
+  messageSecretKey,
+  recallMessageSecret,
+  rememberMessageSecret,
+} from "./messageSecretStore";
+
+const stringData = (redis as any).__stringData as Map<string, string>;
+const expirations = (redis as any).__expirations as Map<
+  string,
+  { type: string; value: number }
+>;
+
+const PHONE = "+5511936199421";
+const MESSAGE_ID = "3EB078E05D8F792B76A79F";
+const SECRET = Buffer.alloc(32, 3);
+
+describe("messageSecretStore", () => {
+  afterEach(() => {
+    stringData.clear();
+    expirations.clear();
+  });
+
+  it("round-trips the secret and its authors", async () => {
+    await rememberMessageSecret(PHONE, MESSAGE_ID, SECRET, [
+      "167392323834034@lid",
+      "553499503261@s.whatsapp.net",
+    ]);
+
+    expect(await recallMessageSecret(PHONE, MESSAGE_ID)).toEqual({
+      secret: SECRET,
+      senders: ["167392323834034@lid", "553499503261@s.whatsapp.net"],
+    });
+  });
+
+  // Per-message keys with no expiry would grow the keyspace by every message
+  // the fleet ever receives, to serve a 15-minute edit window.
+  it("expires the entry", async () => {
+    await rememberMessageSecret(PHONE, MESSAGE_ID, SECRET, []);
+
+    expect(expirations.get(messageSecretKey(PHONE, MESSAGE_ID))).toEqual({
+      type: "EX",
+      value: MESSAGE_SECRET_TTL_SECONDS,
+    });
+  });
+
+  // Ids are unique per message, but the key is scoped per connection anyway so
+  // two inboxes can never read each other's secrets.
+  it("scopes the key to the connection", async () => {
+    await rememberMessageSecret(PHONE, MESSAGE_ID, SECRET, []);
+
+    expect(await recallMessageSecret("+5511999999999", MESSAGE_ID)).toBeNull();
+  });
+
+  it("answers null for a message it never saw", async () => {
+    expect(await recallMessageSecret(PHONE, "unknown")).toBeNull();
+  });
+
+  it("answers null instead of throwing on a corrupt entry", async () => {
+    stringData.set(messageSecretKey(PHONE, MESSAGE_ID), "not json");
+
+    expect(await recallMessageSecret(PHONE, MESSAGE_ID)).toBeNull();
+  });
+
+  it("answers null on an entry with no secret", async () => {
+    stringData.set(messageSecretKey(PHONE, MESSAGE_ID), JSON.stringify({}));
+
+    expect(await recallMessageSecret(PHONE, MESSAGE_ID)).toBeNull();
+  });
+});

--- a/src/baileys/helpers/messageSecretStore.ts
+++ b/src/baileys/helpers/messageSecretStore.ts
@@ -1,3 +1,4 @@
+import config from "@/config";
 import redis from "@/lib/redis";
 
 const redisKeyPrefix = "@baileys-api:connections";
@@ -41,13 +42,26 @@ export interface MessageSecretEntry {
 }
 
 // node-redis parks a command on an offline queue while the connection is down
-// and replays it on reconnect. `withTimeout` stops us AWAITING the command; it
-// cannot cancel it, so every message that publishes a secret would leave one
-// more command, promise and encoded payload parked there, growing for as long
-// as the outage lasts. A secret we cannot file is a future edit we cannot read,
-// which is the degradation a failed write already accepts.
+// and replays it on reconnect, so every message that publishes a secret would
+// leave one more command, promise and encoded payload parked there, growing for
+// as long as the outage lasts. A secret we cannot file is a future edit we
+// cannot read, which is the degradation a failed write already accepts.
+//
+// Two guards, because neither is enough alone. The readiness check keeps the
+// command from being created at all during a known outage, but it is a snapshot:
+// the connection can drop between the check and the flush. The abort signal is
+// what covers that, and is the only thing that actually CANCELS -- a timeout
+// merely stops us awaiting, leaving the command exactly where it was.
 function storeUnavailable() {
   return !redis.isReady;
+}
+
+// Aborting removes the command from the client's pending queue and rejects it,
+// so nothing is retained past the deadline the caller was willing to wait.
+function bounded() {
+  return redis.withAbortSignal(
+    AbortSignal.timeout(config.baileys.messageSecretStoreTimeoutMs),
+  );
 }
 
 export async function rememberMessageSecret(
@@ -60,15 +74,59 @@ export async function rememberMessageSecret(
     return;
   }
 
+  const key = messageSecretKey(phoneNumber, messageId);
   const payload: StoredMessageSecret = {
     secret: Buffer.from(secret).toString("base64"),
     senders,
   };
-  await redis.set(
-    messageSecretKey(phoneNumber, messageId),
-    JSON.stringify(payload),
-    { expiration: { type: "EX", value: MESSAGE_SECRET_TTL_SECONDS } },
-  );
+  const client = bounded();
+
+  // GET on the write, so the round trip that stores also reports what it
+  // replaced. The same message arrives by more than one route and they do not
+  // address its author equally well: a dump whose LID mapping was unknown
+  // carries one JID form where the live copy carried two. Overwriting the
+  // richer record with the poorer one leaves a later edit, encrypted under the
+  // form that was dropped, with no candidate that verifies.
+  const previous = await client.set(key, JSON.stringify(payload), {
+    expiration: { type: "EX", value: MESSAGE_SECRET_TTL_SECONDS },
+    GET: true,
+  });
+
+  const merged = mergeSenders(previous, senders);
+  if (!merged) {
+    return;
+  }
+
+  await client.set(key, JSON.stringify({ ...payload, senders: merged }), {
+    expiration: { type: "EX", value: MESSAGE_SECRET_TTL_SECONDS },
+  });
+}
+
+/**
+ * The union of the stored author JIDs and the ones just written, or null when
+ * the write already covers everything that was there.
+ *
+ * Only the candidate list is merged, never the secret: the secret is the
+ * message's own and identical on every copy, so the fresh one always stands.
+ */
+function mergeSenders(
+  previous: string | null | undefined,
+  senders: string[],
+): string[] | null {
+  if (!previous) {
+    return null;
+  }
+
+  let stored: string[];
+  try {
+    const parsed = JSON.parse(previous) as StoredMessageSecret;
+    stored = Array.isArray(parsed?.senders) ? parsed.senders : [];
+  } catch {
+    return null;
+  }
+
+  const missing = stored.filter((jid) => jid && !senders.includes(jid));
+  return missing.length > 0 ? [...senders, ...missing] : null;
 }
 
 /**
@@ -100,7 +158,7 @@ export async function recallMessageSecret(
     return null;
   }
 
-  const raw = await redis.get(messageSecretKey(phoneNumber, messageId));
+  const raw = await bounded().get(messageSecretKey(phoneNumber, messageId));
   if (!raw) {
     return null;
   }

--- a/src/baileys/helpers/messageSecretStore.ts
+++ b/src/baileys/helpers/messageSecretStore.ts
@@ -2,11 +2,17 @@ import redis from "@/lib/redis";
 
 const redisKeyPrefix = "@baileys-api:connections";
 
-// WhatsApp gives the author 15 minutes to edit a message, so a secret older
-// than that can no longer decrypt anything. An hour of slack covers a webhook
-// retry or a reconnect around the edit; keeping it longer would only grow a
-// per-message keyspace nobody reads.
-export const MESSAGE_SECRET_TTL_SECONDS = 60 * 60;
+// How long a secret is kept, and the window it has to cover is NOT the fifteen
+// minutes WhatsApp gives an author to edit a message. An edit created well
+// inside that window is only replayed to us when the connection comes back, so
+// what matters is how long a disconnect may last before its history arrives —
+// hours, sometimes days. A secret that expired first turns a valid edit into
+// one nothing can read.
+//
+// Seven days is the same horizon the reconnect quarantine works on. Each entry
+// is a few dozen bytes for one message, and only for messages that publish a
+// secret at all.
+export const MESSAGE_SECRET_TTL_SECONDS = 7 * 24 * 60 * 60;
 
 export interface StoredMessageSecret {
   /** base64 of the original message's messageContextInfo.messageSecret */

--- a/src/baileys/helpers/messageSecretStore.ts
+++ b/src/baileys/helpers/messageSecretStore.ts
@@ -15,31 +15,10 @@ const redisKeyPrefix = "@baileys-api:connections";
 // secret at all.
 export const MESSAGE_SECRET_TTL_SECONDS = 7 * 24 * 60 * 60;
 
-export interface StoredMessageSecret {
-  /** base64 of the original message's messageContextInfo.messageSecret */
-  secret: string;
-  /**
-   * JIDs the original message's author was addressed by, most authoritative
-   * first. More than one because a chat mid-LID-migration reports the same
-   * person as `<lid>@lid` and `<phone>@s.whatsapp.net`, and only one of them
-   * is the string WhatsApp fed into the key derivation.
-   */
-  senders: string[];
-}
-
-// Keyed by message id alone, deliberately: the edit's targetMessageKey carries
-// the chat jid as the EDITOR sees it (our own lid), which never matches the jid
-// we filed the original under. Ids are random per message and the key is
-// already scoped to one connection, so the id is identity enough.
-export function messageSecretKey(phoneNumber: string, messageId: string) {
-  return `${redisKeyPrefix}:${phoneNumber}:message-secret:${messageId}`;
-}
-
-export interface MessageSecretEntry {
-  messageId: string;
-  secret: Uint8Array;
-  senders: string[];
-}
+/** Hash field holding the base64 of the message's own messageSecret. */
+const SECRET_FIELD = "secret";
+/** Prefix of the hash fields holding the author's JID forms, one per field. */
+const SENDER_FIELD_PREFIX = "jid:";
 
 // node-redis parks a command on an offline queue while the connection is down
 // and replays it on reconnect, so every message that publishes a secret would
@@ -64,6 +43,35 @@ function bounded() {
   );
 }
 
+// Keyed by message id alone, deliberately: the edit's targetMessageKey carries
+// the chat jid as the EDITOR sees it (our own lid), which never matches the jid
+// we filed the original under. Ids are random per message and the key is
+// already scoped to one connection, so the id is identity enough.
+export function messageSecretKey(phoneNumber: string, messageId: string) {
+  return `${redisKeyPrefix}:${phoneNumber}:message-secret:${messageId}`;
+}
+
+export interface MessageSecretEntry {
+  messageId: string;
+  secret: Uint8Array;
+  senders: string[];
+}
+
+/**
+ * Files a message's secret and the JID forms its author was addressed by.
+ *
+ * A hash whose sender JIDs are one field each, rather than a JSON value, and
+ * the shape is the whole point: the same message arrives by more than one route
+ * and they do not address its author equally well, so a dump whose LID mapping
+ * was unknown carries one form where the live copy carried two. Writing a value
+ * means read, merge, write, which is neither atomic against a concurrent writer
+ * nor safe to interrupt: the poorer list is published first and a disconnect
+ * between the two writes loses the richer one for good. Setting fields only ever
+ * adds, so the union is what Redis itself does and there is nothing to lose.
+ *
+ * The secret is not merged, it is simply written: it belongs to the message and
+ * is identical on every copy.
+ */
 export async function rememberMessageSecret(
   phoneNumber: string,
   messageId: string,
@@ -75,58 +83,18 @@ export async function rememberMessageSecret(
   }
 
   const key = messageSecretKey(phoneNumber, messageId);
-  const payload: StoredMessageSecret = {
-    secret: Buffer.from(secret).toString("base64"),
-    senders,
+  const fields: Record<string, string> = {
+    [SECRET_FIELD]: Buffer.from(secret).toString("base64"),
   };
+  for (const jid of senders) {
+    if (jid) {
+      fields[`${SENDER_FIELD_PREFIX}${jid}`] = "1";
+    }
+  }
+
   const client = bounded();
-
-  // GET on the write, so the round trip that stores also reports what it
-  // replaced. The same message arrives by more than one route and they do not
-  // address its author equally well: a dump whose LID mapping was unknown
-  // carries one JID form where the live copy carried two. Overwriting the
-  // richer record with the poorer one leaves a later edit, encrypted under the
-  // form that was dropped, with no candidate that verifies.
-  const previous = await client.set(key, JSON.stringify(payload), {
-    expiration: { type: "EX", value: MESSAGE_SECRET_TTL_SECONDS },
-    GET: true,
-  });
-
-  const merged = mergeSenders(previous, senders);
-  if (!merged) {
-    return;
-  }
-
-  await client.set(key, JSON.stringify({ ...payload, senders: merged }), {
-    expiration: { type: "EX", value: MESSAGE_SECRET_TTL_SECONDS },
-  });
-}
-
-/**
- * The union of the stored author JIDs and the ones just written, or null when
- * the write already covers everything that was there.
- *
- * Only the candidate list is merged, never the secret: the secret is the
- * message's own and identical on every copy, so the fresh one always stands.
- */
-function mergeSenders(
-  previous: string | null | undefined,
-  senders: string[],
-): string[] | null {
-  if (!previous) {
-    return null;
-  }
-
-  let stored: string[];
-  try {
-    const parsed = JSON.parse(previous) as StoredMessageSecret;
-    stored = Array.isArray(parsed?.senders) ? parsed.senders : [];
-  } catch {
-    return null;
-  }
-
-  const missing = stored.filter((jid) => jid && !senders.includes(jid));
-  return missing.length > 0 ? [...senders, ...missing] : null;
+  await client.hSet(key, fields);
+  await client.expire(key, MESSAGE_SECRET_TTL_SECONDS);
 }
 
 /**
@@ -158,21 +126,26 @@ export async function recallMessageSecret(
     return null;
   }
 
-  const raw = await bounded().get(messageSecretKey(phoneNumber, messageId));
-  if (!raw) {
+  let stored: Record<string, string> | undefined;
+  try {
+    stored = await bounded().hGetAll(messageSecretKey(phoneNumber, messageId));
+  } catch {
+    // Includes WRONGTYPE, which is what a key left by an older build of this
+    // feature answers. Unreadable is the same as absent here.
     return null;
   }
 
-  try {
-    const parsed = JSON.parse(raw) as StoredMessageSecret;
-    if (!parsed?.secret) {
-      return null;
-    }
-    return {
-      secret: Buffer.from(parsed.secret, "base64"),
-      senders: Array.isArray(parsed.senders) ? parsed.senders : [],
-    };
-  } catch {
+  const encoded = stored?.[SECRET_FIELD];
+  if (!encoded) {
     return null;
   }
+
+  // Unordered, unlike the list this used to store. The order was only ever a
+  // hint about which form to try first, and trying a wrong one costs a failed
+  // GCM tag check over a handful of candidates.
+  const senders = Object.keys(stored)
+    .filter((field) => field.startsWith(SENDER_FIELD_PREFIX))
+    .map((field) => field.slice(SENDER_FIELD_PREFIX.length));
+
+  return { secret: Buffer.from(encoded, "base64"), senders };
 }

--- a/src/baileys/helpers/messageSecretStore.ts
+++ b/src/baileys/helpers/messageSecretStore.ts
@@ -1,0 +1,69 @@
+import redis from "@/lib/redis";
+
+const redisKeyPrefix = "@baileys-api:connections";
+
+// WhatsApp gives the author 15 minutes to edit a message, so a secret older
+// than that can no longer decrypt anything. An hour of slack covers a webhook
+// retry or a reconnect around the edit; keeping it longer would only grow a
+// per-message keyspace nobody reads.
+export const MESSAGE_SECRET_TTL_SECONDS = 60 * 60;
+
+export interface StoredMessageSecret {
+  /** base64 of the original message's messageContextInfo.messageSecret */
+  secret: string;
+  /**
+   * JIDs the original message's author was addressed by, most authoritative
+   * first. More than one because a chat mid-LID-migration reports the same
+   * person as `<lid>@lid` and `<phone>@s.whatsapp.net`, and only one of them
+   * is the string WhatsApp fed into the key derivation.
+   */
+  senders: string[];
+}
+
+// Keyed by message id alone, deliberately: the edit's targetMessageKey carries
+// the chat jid as the EDITOR sees it (our own lid), which never matches the jid
+// we filed the original under. Ids are random per message and the key is
+// already scoped to one connection, so the id is identity enough.
+export function messageSecretKey(phoneNumber: string, messageId: string) {
+  return `${redisKeyPrefix}:${phoneNumber}:message-secret:${messageId}`;
+}
+
+export async function rememberMessageSecret(
+  phoneNumber: string,
+  messageId: string,
+  secret: Uint8Array,
+  senders: string[],
+): Promise<void> {
+  const payload: StoredMessageSecret = {
+    secret: Buffer.from(secret).toString("base64"),
+    senders,
+  };
+  await redis.set(
+    messageSecretKey(phoneNumber, messageId),
+    JSON.stringify(payload),
+    { expiration: { type: "EX", value: MESSAGE_SECRET_TTL_SECONDS } },
+  );
+}
+
+export async function recallMessageSecret(
+  phoneNumber: string,
+  messageId: string,
+): Promise<{ secret: Buffer; senders: string[] } | null> {
+  const raw = await redis.get(messageSecretKey(phoneNumber, messageId));
+  if (!raw) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as StoredMessageSecret;
+    if (!parsed?.secret) {
+      return null;
+    }
+    return {
+      secret: Buffer.from(parsed.secret, "base64"),
+      senders: Array.isArray(parsed.senders) ? parsed.senders : [],
+    };
+  } catch {
+    return null;
+  }
+}

--- a/src/baileys/helpers/messageSecretStore.ts
+++ b/src/baileys/helpers/messageSecretStore.ts
@@ -28,6 +28,12 @@ export function messageSecretKey(phoneNumber: string, messageId: string) {
   return `${redisKeyPrefix}:${phoneNumber}:message-secret:${messageId}`;
 }
 
+export interface MessageSecretEntry {
+  messageId: string;
+  secret: Uint8Array;
+  senders: string[];
+}
+
 export async function rememberMessageSecret(
   phoneNumber: string,
   messageId: string,
@@ -42,6 +48,23 @@ export async function rememberMessageSecret(
     messageSecretKey(phoneNumber, messageId),
     JSON.stringify(payload),
     { expiration: { type: "EX", value: MESSAGE_SECRET_TTL_SECONDS } },
+  );
+}
+
+/**
+ * Files a whole batch at once. Written for a history dump, which can carry
+ * thousands of messages: awaiting each write in turn would put a Redis round
+ * trip between every message and the next, and hold the dump's delivery behind
+ * all of them. Fired together, the client pipelines them into one flush.
+ */
+export async function rememberMessageSecrets(
+  phoneNumber: string,
+  entries: MessageSecretEntry[],
+): Promise<void> {
+  await Promise.all(
+    entries.map(({ messageId, secret, senders }) =>
+      rememberMessageSecret(phoneNumber, messageId, secret, senders),
+    ),
   );
 }
 

--- a/src/baileys/helpers/messageSecretStore.ts
+++ b/src/baileys/helpers/messageSecretStore.ts
@@ -40,12 +40,26 @@ export interface MessageSecretEntry {
   senders: string[];
 }
 
+// node-redis parks a command on an offline queue while the connection is down
+// and replays it on reconnect. `withTimeout` stops us AWAITING the command; it
+// cannot cancel it, so every message that publishes a secret would leave one
+// more command, promise and encoded payload parked there, growing for as long
+// as the outage lasts. A secret we cannot file is a future edit we cannot read,
+// which is the degradation a failed write already accepts.
+function storeUnavailable() {
+  return !redis.isReady;
+}
+
 export async function rememberMessageSecret(
   phoneNumber: string,
   messageId: string,
   secret: Uint8Array,
   senders: string[],
 ): Promise<void> {
+  if (storeUnavailable()) {
+    return;
+  }
+
   const payload: StoredMessageSecret = {
     secret: Buffer.from(secret).toString("base64"),
     senders,
@@ -67,6 +81,10 @@ export async function rememberMessageSecrets(
   phoneNumber: string,
   entries: MessageSecretEntry[],
 ): Promise<void> {
+  if (storeUnavailable()) {
+    return;
+  }
+
   await Promise.all(
     entries.map(({ messageId, secret, senders }) =>
       rememberMessageSecret(phoneNumber, messageId, secret, senders),
@@ -78,6 +96,10 @@ export async function recallMessageSecret(
   phoneNumber: string,
   messageId: string,
 ): Promise<{ secret: Buffer; senders: string[] } | null> {
+  if (storeUnavailable()) {
+    return null;
+  }
+
   const raw = await redis.get(messageSecretKey(phoneNumber, messageId));
   if (!raw) {
     return null;

--- a/src/baileys/helpers/messageSecretStore.ts
+++ b/src/baileys/helpers/messageSecretStore.ts
@@ -35,6 +35,25 @@ function storeUnavailable() {
   return !redis.isReady;
 }
 
+/**
+ * Writes the fields and the lifetime together.
+ *
+ * A script rather than a MULTI, and the reason is the abort signal rather than
+ * atomicity: node-redis 6 queues a transaction's commands through
+ * `_executeMulti`, which passes only `chainId` and `typeMapping`, so the signal
+ * never reaches them and an unbounded write is exactly what the guards above
+ * exist to prevent. EVAL is one ordinary command, so it carries the signal, and
+ * a script is atomic by definition.
+ *
+ * The alternative -- HSET then EXPIRE as two commands -- can leave a hash whose
+ * expiry never landed, which is a key nothing will ever delete.
+ */
+export const MESSAGE_SECRET_WRITE_SCRIPT = `
+redis.call('HSET', KEYS[1], unpack(ARGV, 2))
+redis.call('EXPIRE', KEYS[1], ARGV[1])
+return 1
+`.trim();
+
 // Aborting removes the command from the client's pending queue and rejects it,
 // so nothing is retained past the deadline the caller was willing to wait.
 function bounded() {
@@ -92,14 +111,15 @@ export async function rememberMessageSecret(
     }
   }
 
-  // One transaction, not two commands: a hash that was created and then failed
-  // to get its expiry is a key nothing will ever delete, and the whole point of
-  // filing these per message is that they age out on their own.
-  await bounded()
-    .multi()
-    .hSet(key, fields)
-    .expire(key, MESSAGE_SECRET_TTL_SECONDS)
-    .exec();
+  const args = [String(MESSAGE_SECRET_TTL_SECONDS)];
+  for (const [field, value] of Object.entries(fields)) {
+    args.push(field, value);
+  }
+
+  await bounded().eval(MESSAGE_SECRET_WRITE_SCRIPT, {
+    keys: [key],
+    arguments: args,
+  });
 }
 
 /**

--- a/src/baileys/helpers/messageSecretStore.ts
+++ b/src/baileys/helpers/messageSecretStore.ts
@@ -92,9 +92,14 @@ export async function rememberMessageSecret(
     }
   }
 
-  const client = bounded();
-  await client.hSet(key, fields);
-  await client.expire(key, MESSAGE_SECRET_TTL_SECONDS);
+  // One transaction, not two commands: a hash that was created and then failed
+  // to get its expiry is a key nothing will ever delete, and the whole point of
+  // filing these per message is that they age out on their own.
+  await bounded()
+    .multi()
+    .hSet(key, fields)
+    .expire(key, MESSAGE_SECRET_TTL_SECONDS)
+    .exec();
 }
 
 /**

--- a/src/baileys/helpers/secretEncryptedMessageEdit.spec.ts
+++ b/src/baileys/helpers/secretEncryptedMessageEdit.spec.ts
@@ -160,6 +160,40 @@ describe("ownMessageSecret", () => {
     expect(ownMessageSecret(upsert({ conversation: "oi" }))).toBeNull();
   });
 
+  // A wrapper's own context can exist for an expiration or a device list and
+  // carry no secret at all. Protobuf gives that field an empty Uint8Array,
+  // which is truthy, so the candidate has to be chosen by length.
+  it("skips an empty inner secret and takes the outer one", () => {
+    const secret = new Uint8Array(32).fill(9);
+
+    expect(
+      ownMessageSecret(
+        upsert({
+          messageContextInfo: { messageSecret: secret },
+          ephemeralMessage: {
+            message: {
+              conversation: "oi",
+              messageContextInfo: { messageSecret: new Uint8Array(0) },
+            },
+          },
+        }),
+      ),
+    ).toEqual(secret);
+  });
+
+  // The same hole one level further in: a dump strips the content's secret and
+  // carries it on the WebMessageInfo.
+  it("skips an empty content secret and takes the dump's", () => {
+    const secret = new Uint8Array(32).fill(9);
+    const message = upsert({
+      conversation: "oi",
+      messageContextInfo: { messageSecret: new Uint8Array(0) },
+    });
+    message.messageSecret = secret;
+
+    expect(ownMessageSecret(message)).toEqual(secret);
+  });
+
   it("treats an empty secret as none", () => {
     expect(
       ownMessageSecret(

--- a/src/baileys/helpers/secretEncryptedMessageEdit.spec.ts
+++ b/src/baileys/helpers/secretEncryptedMessageEdit.spec.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from "bun:test";
+import { proto as realProto } from "@whiskeysockets/baileys/WAProto/index.js";
+import {
+  decodeEditedMessage,
+  ownMessageSecret,
+  secretMessageEdit,
+} from "./secretEncryptedMessageEdit";
+
+const TARGET_KEY = {
+  remoteJid: "89572297961476@lid",
+  fromMe: true,
+  id: "3EB078E05D8F792B76A79F",
+};
+
+function upsert(message: any) {
+  return {
+    key: { remoteJid: "167392323834034@lid", fromMe: false, id: "edit-1" },
+    message,
+  } as any;
+}
+
+function encoded(message: any) {
+  return realProto.Message.encode(
+    realProto.Message.fromObject(message),
+  ).finish();
+}
+
+describe("secretMessageEdit", () => {
+  const encrypted = {
+    targetMessageKey: TARGET_KEY,
+    encPayload: new Uint8Array([1, 2, 3]),
+    encIv: new Uint8Array([4, 5, 6]),
+  };
+
+  it("recognizes the numeric enum", () => {
+    expect(
+      secretMessageEdit(
+        upsert({ secretEncryptedMessage: { ...encrypted, secretEncType: 2 } }),
+      ),
+    ).toEqual({
+      targetKey: TARGET_KEY,
+      encPayload: encrypted.encPayload,
+      encIv: encrypted.encIv,
+    });
+  });
+
+  // Which of the two a payload carries depends on how it was decoded upstream,
+  // and betting on one is how this kind of check silently stops matching.
+  it("recognizes the symbolic enum", () => {
+    expect(
+      secretMessageEdit(
+        upsert({
+          secretEncryptedMessage: {
+            ...encrypted,
+            secretEncType: "MESSAGE_EDIT",
+          },
+        }),
+      ),
+    ).not.toBeNull();
+  });
+
+  it("looks through a disappearing-message wrapper", () => {
+    expect(
+      secretMessageEdit(
+        upsert({
+          ephemeralMessage: {
+            message: {
+              secretEncryptedMessage: { ...encrypted, secretEncType: 2 },
+            },
+          },
+        }),
+      ),
+    ).not.toBeNull();
+  });
+
+  // EVENT_EDIT (1) rides the same node and is a different use case with a
+  // different key derivation; decrypting it as a message edit would fail the
+  // tag check anyway, but claiming it here would swallow the event.
+  it("ignores a secret message that is not a message edit", () => {
+    expect(
+      secretMessageEdit(
+        upsert({ secretEncryptedMessage: { ...encrypted, secretEncType: 1 } }),
+      ),
+    ).toBeNull();
+  });
+
+  it("ignores an ordinary message", () => {
+    expect(secretMessageEdit(upsert({ conversation: "oi" }))).toBeNull();
+  });
+
+  it("ignores an edit with no target to apply it to", () => {
+    expect(
+      secretMessageEdit(
+        upsert({
+          secretEncryptedMessage: {
+            ...encrypted,
+            targetMessageKey: { remoteJid: "x@lid", fromMe: true },
+            secretEncType: 2,
+          },
+        }),
+      ),
+    ).toBeNull();
+  });
+
+  it("ignores an edit with nothing encrypted in it", () => {
+    expect(
+      secretMessageEdit(
+        upsert({
+          secretEncryptedMessage: {
+            targetMessageKey: TARGET_KEY,
+            secretEncType: 2,
+          },
+        }),
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("ownMessageSecret", () => {
+  it("returns the secret a message publishes", () => {
+    const secret = new Uint8Array(32).fill(9);
+
+    expect(
+      ownMessageSecret(
+        upsert({
+          conversation: "oi",
+          messageContextInfo: { messageSecret: secret },
+        }),
+      ),
+    ).toEqual(secret);
+  });
+
+  it("returns null when there is none", () => {
+    expect(ownMessageSecret(upsert({ conversation: "oi" }))).toBeNull();
+  });
+
+  it("treats an empty secret as none", () => {
+    expect(
+      ownMessageSecret(
+        upsert({
+          conversation: "oi",
+          messageContextInfo: { messageSecret: new Uint8Array(0) },
+        }),
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("decodeEditedMessage", () => {
+  it("decodes a bare replacement body", () => {
+    const decoded = decodeEditedMessage(
+      encoded({ conversation: "oi editado" }),
+    );
+
+    expect(decoded.conversation).toBe("oi editado");
+  });
+
+  it("unwraps a replacement wrapped as an editedMessage", () => {
+    const decoded = decodeEditedMessage(
+      encoded({ editedMessage: { message: { conversation: "oi editado" } } }),
+    );
+
+    expect(decoded.conversation).toBe("oi editado");
+  });
+
+  it("unwraps a replacement wrapped in a protocolMessage", () => {
+    const decoded = decodeEditedMessage(
+      encoded({
+        protocolMessage: {
+          type: realProto.Message.ProtocolMessage.Type.MESSAGE_EDIT,
+          editedMessage: { conversation: "oi editado" },
+        },
+      }),
+    );
+
+    expect(decoded.conversation).toBe("oi editado");
+  });
+});

--- a/src/baileys/helpers/secretEncryptedMessageEdit.spec.ts
+++ b/src/baileys/helpers/secretEncryptedMessageEdit.spec.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from "bun:test";
 import { proto as realProto } from "@whiskeysockets/baileys/WAProto/index.js";
 import {
   decodeEditedMessage,
+  orderEditsOldestFirst,
   ownMessageSecret,
+  replaceInnerContent,
   secretMessageEdit,
 } from "./secretEncryptedMessageEdit";
 
@@ -198,5 +200,106 @@ describe("decodeEditedMessage", () => {
     );
 
     expect(decoded.conversation).toBe("oi editado");
+  });
+});
+
+describe("replaceInnerContent", () => {
+  it("replaces the content of a bare message", () => {
+    expect(
+      replaceInnerContent({ conversation: "oi" }, { conversation: "editado" }),
+    ).toEqual({ conversation: "editado" });
+  });
+
+  // The wrapper is what tells the consumer the message disappears, and the
+  // context next to it is where the secret for the NEXT edit lives.
+  it("keeps the wrapper and the outer context", () => {
+    const secret = new Uint8Array(32).fill(9);
+
+    expect(
+      replaceInnerContent(
+        {
+          messageContextInfo: { messageSecret: secret },
+          ephemeralMessage: { message: { conversation: "oi" } },
+        },
+        { conversation: "editado" },
+      ),
+    ).toEqual({
+      messageContextInfo: { messageSecret: secret },
+      ephemeralMessage: { message: { conversation: "editado" } },
+    });
+  });
+
+  it("replaces at the bottom of a nested wrapper", () => {
+    expect(
+      replaceInnerContent(
+        {
+          ephemeralMessage: {
+            message: { viewOnceMessageV2: { message: { conversation: "oi" } } },
+          },
+        },
+        { conversation: "editado" },
+      ),
+    ).toEqual({
+      ephemeralMessage: {
+        message: {
+          viewOnceMessageV2: { message: { conversation: "editado" } },
+        },
+      },
+    });
+  });
+
+  it("fills a wrapper that carries no content", () => {
+    expect(
+      replaceInnerContent(
+        { ephemeralMessage: {} },
+        { conversation: "editado" },
+      ),
+    ).toEqual({ ephemeralMessage: { message: { conversation: "editado" } } });
+  });
+
+  it("returns the replacement when there is nothing to keep", () => {
+    expect(replaceInnerContent(null, { conversation: "editado" })).toEqual({
+      conversation: "editado",
+    });
+  });
+});
+
+describe("orderEditsOldestFirst", () => {
+  const at = (seconds: number, label: string) => ({
+    label,
+    message: { messageTimestamp: seconds } as any,
+  });
+
+  it("sorts by the time the edit was made", () => {
+    expect(
+      orderEditsOldestFirst([at(30, "b"), at(10, "a"), at(50, "c")]).map(
+        (e) => e.label,
+      ),
+    ).toEqual(["a", "b", "c"]);
+  });
+
+  it("keeps arrival order for edits stamped in the same second", () => {
+    expect(
+      orderEditsOldestFirst([at(10, "a"), at(10, "b")]).map((e) => e.label),
+    ).toEqual(["a", "b"]);
+  });
+
+  // A history array is built newest-first, so equal stamps there mean the
+  // opposite of what they mean live.
+  it("reverses ties when the array was built newest-first", () => {
+    expect(
+      orderEditsOldestFirst([at(10, "b"), at(10, "a")], {
+        newestFirst: true,
+      }).map((e) => e.label),
+    ).toEqual(["a", "b"]);
+  });
+
+  it("reads a Long timestamp", () => {
+    expect(
+      orderEditsOldestFirst([
+        { label: "b", message: { messageTimestamp: { low: 30, high: 0 } } },
+        { label: "a", message: { messageTimestamp: { low: 10, high: 0 } } },
+      ] as any).map((e: any) => e.label),
+    ).toEqual(["a", "b"]);
   });
 });

--- a/src/baileys/helpers/secretEncryptedMessageEdit.spec.ts
+++ b/src/baileys/helpers/secretEncryptedMessageEdit.spec.ts
@@ -130,6 +130,30 @@ describe("ownMessageSecret", () => {
     ).toEqual(secret);
   });
 
+  // A wrapper keeps its context outside itself, so normalizing walks straight
+  // past the secret and every edit to a disappearing message stops decrypting.
+  it("reads the outer context of a wrapped message", () => {
+    const secret = new Uint8Array(32).fill(9);
+
+    expect(
+      ownMessageSecret(
+        upsert({
+          messageContextInfo: { messageSecret: secret },
+          ephemeralMessage: { message: { conversation: "oi" } },
+        }),
+      ),
+    ).toEqual(secret);
+  });
+
+  // A history dump puts it on the WebMessageInfo instead of in the content.
+  it("reads the secret a history dump carries on the message itself", () => {
+    const secret = new Uint8Array(32).fill(9);
+    const message = upsert({ conversation: "oi" });
+    message.messageSecret = secret;
+
+    expect(ownMessageSecret(message)).toEqual(secret);
+  });
+
   it("returns null when there is none", () => {
     expect(ownMessageSecret(upsert({ conversation: "oi" }))).toBeNull();
   });

--- a/src/baileys/helpers/secretEncryptedMessageEdit.ts
+++ b/src/baileys/helpers/secretEncryptedMessageEdit.ts
@@ -17,7 +17,9 @@ const MESSAGE_EDIT_ENC_TYPES: ReadonlySet<number | string> = new Set([
  * number or as a `{ low, high }` Long depending on how it came off the wire,
  * and a dump mixes both.
  */
-export function messageTimestampSeconds(message: WAMessage): number {
+export function messageTimestampSeconds(
+  message: Pick<WAMessage, "messageTimestamp">,
+): number {
   const timestamp = message.messageTimestamp;
   if (typeof timestamp === "number") {
     return timestamp;

--- a/src/baileys/helpers/secretEncryptedMessageEdit.ts
+++ b/src/baileys/helpers/secretEncryptedMessageEdit.ts
@@ -12,6 +12,23 @@ const MESSAGE_EDIT_ENC_TYPES: ReadonlySet<number | string> = new Set([
   "MESSAGE_EDIT",
 ]);
 
+/**
+ * The unix seconds on a message. A protobuf 64-bit field decodes either as a
+ * number or as a `{ low, high }` Long depending on how it came off the wire,
+ * and a dump mixes both.
+ */
+export function messageTimestampSeconds(message: WAMessage): number {
+  const timestamp = message.messageTimestamp;
+  if (typeof timestamp === "number") {
+    return timestamp;
+  }
+  if (timestamp && typeof timestamp === "object") {
+    const { low = 0, high = 0 } = timestamp as { low?: number; high?: number };
+    return high * 2 ** 32 + (low >>> 0);
+  }
+  return 0;
+}
+
 export interface SecretMessageEdit {
   targetKey: WAMessageKey;
   encPayload: Uint8Array;

--- a/src/baileys/helpers/secretEncryptedMessageEdit.ts
+++ b/src/baileys/helpers/secretEncryptedMessageEdit.ts
@@ -58,10 +58,24 @@ export function secretMessageEdit(
  * The message secret a message publishes for its own future modifications
  * (edits, reactions, poll votes). Only present on messages that can be
  * modified, which is why the caller stores it opportunistically.
+ *
+ * Three homes, one per route a message can arrive by:
+ *
+ *  - the normalized content, for an ordinary live message;
+ *  - the outer `Message`, because a wrapper keeps its context outside itself —
+ *    an ephemeral message's `messageContextInfo` sits next to the wrapper, not
+ *    inside it, and normalizing walks straight past it;
+ *  - the `WebMessageInfo` itself, which is where a history dump puts it.
+ *
+ * A secret read from any of them decrypts the same edits; missing one just
+ * means the edits to those messages arrive undecryptable.
  */
 export function ownMessageSecret(message: WAMessage): Uint8Array | null {
-  const secret = normalizeMessageContent(message.message)?.messageContextInfo
-    ?.messageSecret;
+  const secret =
+    normalizeMessageContent(message.message)?.messageContextInfo
+      ?.messageSecret ||
+    message.message?.messageContextInfo?.messageSecret ||
+    message.messageSecret;
   return secret?.length ? secret : null;
 }
 

--- a/src/baileys/helpers/secretEncryptedMessageEdit.ts
+++ b/src/baileys/helpers/secretEncryptedMessageEdit.ts
@@ -1,0 +1,82 @@
+import {
+  normalizeMessageContent,
+  proto,
+  type WAMessage,
+  type WAMessageKey,
+} from "@whiskeysockets/baileys";
+
+// Enum values reach us as the number or, depending on how the payload was
+// decoded, as the symbolic name. Accept both rather than betting on one.
+const MESSAGE_EDIT_ENC_TYPES: ReadonlySet<number | string> = new Set([
+  proto.Message.SecretEncryptedMessage.SecretEncType.MESSAGE_EDIT,
+  "MESSAGE_EDIT",
+]);
+
+export interface SecretMessageEdit {
+  targetKey: WAMessageKey;
+  encPayload: Uint8Array;
+  encIv: Uint8Array;
+}
+
+/**
+ * The encrypted edit carried by a message, if that is what it is.
+ *
+ * WhatsApp used to deliver an edit as a plaintext `protocolMessage` of type
+ * MESSAGE_EDIT, which Baileys turns into a `messages.update`. Newer clients
+ * send `secretEncryptedMessage` instead — encrypted under the ORIGINAL
+ * message's secret — and Baileys has no handler for it, so the raw blob
+ * surfaces as an ordinary incoming message and every consumer renders it as
+ * unsupported content.
+ */
+export function secretMessageEdit(
+  message: WAMessage,
+): SecretMessageEdit | null {
+  const content = normalizeMessageContent(message.message);
+  const encrypted = content?.secretEncryptedMessage;
+  if (!encrypted?.encPayload || !encrypted.encIv) {
+    return null;
+  }
+
+  const encType = encrypted.secretEncType;
+  if (encType == null || !MESSAGE_EDIT_ENC_TYPES.has(encType)) {
+    return null;
+  }
+
+  const targetKey = encrypted.targetMessageKey;
+  if (!targetKey?.id) {
+    return null;
+  }
+
+  return {
+    targetKey: targetKey as WAMessageKey,
+    encPayload: encrypted.encPayload,
+    encIv: encrypted.encIv,
+  };
+}
+
+/**
+ * The message secret a message publishes for its own future modifications
+ * (edits, reactions, poll votes). Only present on messages that can be
+ * modified, which is why the caller stores it opportunistically.
+ */
+export function ownMessageSecret(message: WAMessage): Uint8Array | null {
+  const secret = normalizeMessageContent(message.message)?.messageContextInfo
+    ?.messageSecret;
+  return secret?.length ? secret : null;
+}
+
+/**
+ * The replacement content, as an `IMessage`, from a decrypted edit payload.
+ *
+ * The plaintext is a serialized `Message`. It has been observed both bare and
+ * wrapped the way the plaintext edit path wraps it, so unwrap to the content
+ * itself and let the caller re-wrap once, in one shape.
+ */
+export function decodeEditedMessage(plaintext: Uint8Array): proto.IMessage {
+  const decoded = proto.Message.decode(plaintext);
+  return (
+    decoded.editedMessage?.message ??
+    decoded.protocolMessage?.editedMessage ??
+    decoded
+  );
+}

--- a/src/baileys/helpers/secretEncryptedMessageEdit.ts
+++ b/src/baileys/helpers/secretEncryptedMessageEdit.ts
@@ -111,3 +111,94 @@ export function decodeEditedMessage(plaintext: Uint8Array): proto.IMessage {
     decoded
   );
 }
+
+// The same chain `normalizeMessageContent` walks, in the same order. Kept as a
+// local list rather than reused from Baileys because Baileys only exposes the
+// walk, not the path it took, and the path is what has to be rebuilt.
+const WRAPPER_KEYS = [
+  "ephemeralMessage",
+  "viewOnceMessage",
+  "documentWithCaptionMessage",
+  "viewOnceMessageV2",
+  "viewOnceMessageV2Extension",
+  "editedMessage",
+  "associatedChildMessage",
+  "groupStatusMessage",
+  "groupStatusMessageV2",
+] as const;
+
+/**
+ * Puts `replacement` where the message's real content sits, keeping whatever
+ * wrapped it.
+ *
+ * A disappearing message arrives as `ephemeralMessage: { message: ... }`, and
+ * its `messageContextInfo` sits on the OUTER object, next to the wrapper.
+ * Assigning the decoded edit over the whole `message` would drop both: the
+ * consumer would receive what looks like an ordinary, non-disappearing message,
+ * and the secret the next edit needs would go with it.
+ *
+ * An unwrapped message has no outer anything, so there the replacement simply
+ * is the new content.
+ */
+export function replaceInnerContent(
+  outer: proto.IMessage | null | undefined,
+  replacement: proto.IMessage,
+): proto.IMessage {
+  if (!outer) {
+    return replacement;
+  }
+
+  let deepest: { message?: proto.IMessage | null } | null = null;
+  let content: proto.IMessage = outer;
+
+  // Bounded like Baileys' own walk, so a payload that wraps itself cannot spin.
+  for (let depth = 0; depth < 5; depth += 1) {
+    const key = WRAPPER_KEYS.find(
+      (candidate) => (content as Record<string, unknown>)[candidate],
+    );
+    if (!key) {
+      break;
+    }
+    deepest = content[key] as { message?: proto.IMessage | null };
+    content = deepest.message ?? {};
+  }
+
+  if (!deepest) {
+    return replacement;
+  }
+
+  deepest.message = replacement;
+  return outer;
+}
+
+/**
+ * The edits in the order they were made, oldest first.
+ *
+ * Two edits of one message are last-one-wins, so applying them in the wrong
+ * order leaves the older text standing. A history dump makes that the DEFAULT
+ * rather than an edge case: Baileys builds each chat's array newest-first (it
+ * keeps `msgs[0]` as "the most recent message in the chat"), so walking it
+ * straight applies the newest replacement and then overwrites it with an older
+ * one. The same reversal then rides into the unresolved queue, which emits in
+ * the order it was given.
+ *
+ * `newestFirst` is the tie-break, not the sort: messages stamped in the same
+ * second carry no ordering of their own, so the only thing left to go on is
+ * which way the array they came in was built.
+ */
+export function orderEditsOldestFirst<T extends { message: WAMessage }>(
+  edits: T[],
+  { newestFirst = false }: { newestFirst?: boolean } = {},
+): T[] {
+  const indexed = edits.map((entry, index) => ({ entry, index }));
+  indexed.sort((a, b) => {
+    const byTime =
+      messageTimestampSeconds(a.entry.message) -
+      messageTimestampSeconds(b.entry.message);
+    if (byTime !== 0) {
+      return byTime;
+    }
+    return newestFirst ? b.index - a.index : a.index - b.index;
+  });
+  return indexed.map(({ entry }) => entry);
+}

--- a/src/baileys/helpers/secretEncryptedMessageEdit.ts
+++ b/src/baileys/helpers/secretEncryptedMessageEdit.ts
@@ -90,12 +90,17 @@ export function secretMessageEdit(
  * means the edits to those messages arrive undecryptable.
  */
 export function ownMessageSecret(message: WAMessage): Uint8Array | null {
-  const secret =
-    normalizeMessageContent(message.message)?.messageContextInfo
-      ?.messageSecret ||
-    message.message?.messageContextInfo?.messageSecret ||
-    message.messageSecret;
-  return secret?.length ? secret : null;
+  // Picked by length rather than by truthiness: an empty Uint8Array is truthy,
+  // and protobuf hands one back for a bytes field that was never on the wire.
+  // A `||` chain therefore stops at a messageContextInfo that exists for some
+  // other reason — an expiration, a device list — and never reaches the secret
+  // sitting one level out, which is the shape a wrapped message has.
+  const candidates = [
+    normalizeMessageContent(message.message)?.messageContextInfo?.messageSecret,
+    message.message?.messageContextInfo?.messageSecret,
+    message.messageSecret,
+  ];
+  return candidates.find((secret) => secret?.length) ?? null;
 }
 
 /**

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,6 +9,7 @@ const {
   BAILEYS_HTTP_TIMEOUT_MS,
   BAILEYS_TX_ACQUIRE_TIMEOUT_MS,
   BAILEYS_TX_HOLD_WARN_MS,
+  BAILEYS_MESSAGE_SECRET_STORE_TIMEOUT_MS,
   BAILEYS_SEND_TIMEOUT_MS,
   BAILEYS_SEND_STALL_RESTART_ENABLED,
   BAILEYS_CLIENT_VERSION,
@@ -159,6 +160,18 @@ const config = {
       "BAILEYS_SEND_TIMEOUT_MS",
       BAILEYS_SEND_TIMEOUT_MS,
       45_000,
+    ),
+    // How long a message delivery may wait on the message-secret store. Filing
+    // a secret is a side effect of delivering a message, never a reason not to
+    // deliver it: with node-redis's offline queue a disconnect leaves the
+    // command pending until reconnection, and unbounded that would withhold the
+    // message itself and every edit queued behind its delivery slot. Recalling
+    // one is bounded from the other side, so a parked read cannot wedge the
+    // edit chain for good.
+    messageSecretStoreTimeoutMs: intFromEnv(
+      "BAILEYS_MESSAGE_SECRET_STORE_TIMEOUT_MS",
+      BAILEYS_MESSAGE_SECRET_STORE_TIMEOUT_MS,
+      5_000,
     ),
     // Whether a connection whose sends keep timing out may recreate its own
     // socket. Off by default: this kills a live socket on a heuristic, so it

--- a/src/test/preload.ts
+++ b/src/test/preload.ts
@@ -33,9 +33,34 @@ const mockRedis = {
   __multiCommands: multiCommands,
   __expirations: expirations,
 
-  hSet: mock(async (key: string, field: string, value: string) => {
-    if (!hashData.has(key)) hashData.set(key, new Map());
-    hashData.get(key)?.set(field, value);
+  // node-redis takes either one field/value pair or an object of them; both
+  // reach the same hash.
+  hSet: mock(
+    async (
+      key: string,
+      fieldOrFields: string | Record<string, string>,
+      value?: string,
+    ) => {
+      if (!hashData.has(key)) hashData.set(key, new Map());
+      const hash = hashData.get(key) as Map<string, string>;
+      if (typeof fieldOrFields === "string") {
+        hash.set(fieldOrFields, value as string);
+        return 1;
+      }
+      for (const [field, fieldValue] of Object.entries(fieldOrFields)) {
+        hash.set(field, fieldValue);
+      }
+      return Object.keys(fieldOrFields).length;
+    },
+  ),
+  hGetAll: mock(async (key: string) => {
+    return Object.fromEntries(hashData.get(key) ?? new Map());
+  }),
+  // Time is NOT simulated: this records the lifetime so a spec can assert it,
+  // and keys never actually expire.
+  expire: mock(async (key: string, seconds: number) => {
+    if (!hashData.has(key) && !stringData.has(key)) return 0;
+    expirations.set(key, { type: "EX", value: seconds });
     return 1;
   }),
   hGet: mock(async (key: string, field: string) => {

--- a/src/test/preload.ts
+++ b/src/test/preload.ts
@@ -328,36 +328,72 @@ const mockRedis = {
       commands.push(cmd);
       multiCommands.push(cmd);
     };
-    return {
-      hSet: (key: string, field: string, value: string) => {
-        queue({ op: "hSet", args: [key, field, value] });
+    const chain = {
+      hSet: (
+        key: string,
+        fieldOrFields: string | Record<string, string>,
+        value?: string,
+      ) => {
+        queue({ op: "hSet", args: [key, fieldOrFields, value] });
+        return chain;
+      },
+      expire: (key: string, seconds: number) => {
+        queue({ op: "expire", args: [key, seconds] });
+        return chain;
       },
       hDel: (key: string, field: string) => {
         queue({ op: "hDel", args: [key, field] });
+        return chain;
       },
       hGet: (key: string, field: string) => {
         queue({ op: "hGet", args: [key, field] });
+        return chain;
       },
-      execAsPipeline: mock(async () => {
-        const results: any[] = [];
-        for (const cmd of commands) {
-          if (cmd.op === "hSet") {
-            const [key, field, value] = cmd.args;
-            if (!hashData.has(key)) hashData.set(key, new Map());
-            hashData.get(key)?.set(field, value);
-            results.push(1);
-          } else if (cmd.op === "hDel") {
-            const [key, field] = cmd.args;
-            hashData.get(key)?.delete(field);
-            results.push(1);
-          } else if (cmd.op === "hGet") {
-            const [key, field] = cmd.args;
-            results.push(hashData.get(key)?.get(field) ?? null);
-          }
-        }
-        return results;
-      }),
+      // MULTI/EXEC and a plain pipeline run the same commands here; only the
+      // real server tells them apart, and no spec asserts on that difference.
+      exec: mock(async () => runQueued()),
+      execAsPipeline: mock(async () => runQueued()),
     };
+
+    function runQueued() {
+      const results: any[] = [];
+      for (const cmd of commands) {
+        if (cmd.op === "hSet") {
+          const [key, fieldOrFields, value] = cmd.args;
+          if (!hashData.has(key)) hashData.set(key, new Map());
+          const hash = hashData.get(key) as Map<string, string>;
+          if (typeof fieldOrFields === "string") {
+            hash.set(fieldOrFields, value);
+            results.push(1);
+          } else {
+            for (const [field, fieldValue] of Object.entries(
+              fieldOrFields as Record<string, string>,
+            )) {
+              hash.set(field, fieldValue);
+            }
+            results.push(Object.keys(fieldOrFields).length);
+          }
+        } else if (cmd.op === "expire") {
+          const [key, seconds] = cmd.args;
+          if (hashData.has(key) || stringData.has(key)) {
+            expirations.set(key, { type: "EX", value: seconds });
+            results.push(1);
+          } else {
+            results.push(0);
+          }
+        } else if (cmd.op === "hDel") {
+          const [key, field] = cmd.args;
+          hashData.get(key)?.delete(field);
+          results.push(1);
+        } else if (cmd.op === "hGet") {
+          const [key, field] = cmd.args;
+          results.push(hashData.get(key)?.get(field) ?? null);
+        }
+      }
+      return results;
+    }
+
+    return chain;
   }),
 };
 

--- a/src/test/preload.ts
+++ b/src/test/preload.ts
@@ -415,6 +415,7 @@ mock.module("@/config", () => ({
       txHoldWarnMs: 30_000,
       audioPreprocessTimeoutMs: 20_000,
       sendTimeoutMs: 45_000,
+      messageSecretStoreTimeoutMs: 5_000,
       sendStallRestartEnabled: false,
       clientVersion: "default",
       overrideClientVersion: false,

--- a/src/test/preload.ts
+++ b/src/test/preload.ts
@@ -25,6 +25,9 @@ const mockRedis = {
   // The real client flips this false while the connection is down; callers use
   // it to skip a write instead of parking it on the offline queue.
   isReady: true,
+  // The real client returns a view of itself that carries the signal; every
+  // command below is the same mock either way.
+  withAbortSignal: (_signal: AbortSignal) => mockRedis,
   __hashData: hashData,
   __stringData: stringData,
   __multiCommands: multiCommands,
@@ -80,10 +83,13 @@ const mockRedis = {
         EX?: number;
         condition?: "NX" | "XX";
         expiration?: { type: string; value: number };
+        GET?: boolean;
       },
     ) => {
       const nx = options?.NX || options?.condition === "NX";
       if (nx && stringData.has(key)) return null;
+      // SET ... GET answers with the value it replaced, null if there was none.
+      const previous = options?.GET ? (stringData.get(key) ?? null) : null;
       stringData.set(key, value);
       if (options?.expiration) {
         expirations.set(key, options.expiration);
@@ -94,7 +100,7 @@ const mockRedis = {
       } else {
         expirations.delete(key);
       }
-      return "OK";
+      return options?.GET ? previous : "OK";
     },
   ),
   incr: mock(async (key: string) => {

--- a/src/test/preload.ts
+++ b/src/test/preload.ts
@@ -1,5 +1,6 @@
 import { afterEach, mock } from "bun:test";
 import { proto as realProto } from "@whiskeysockets/baileys/WAProto/index.js";
+import { MESSAGE_SECRET_WRITE_SCRIPT } from "@/baileys/helpers/messageSecretStore";
 
 /**
  * Shared test preload — runs before every test file.
@@ -163,6 +164,22 @@ const mockRedis = {
     ) => {
       const keys = options?.keys ?? [];
       const args = options?.arguments ?? [];
+
+      // Message-secret write: KEYS=[key], ARGV=[ttl, field, value, ...].
+      // Matched on the script's own source rather than a marker, so the day it
+      // changes shape this stops claiming it and the specs say so instead of
+      // quietly testing the old behaviour.
+      if (script.trim() === MESSAGE_SECRET_WRITE_SCRIPT) {
+        const [key] = keys;
+        const [ttl, ...fields] = args;
+        if (!hashData.has(key)) hashData.set(key, new Map());
+        const hash = hashData.get(key) as Map<string, string>;
+        for (let i = 0; i + 1 < fields.length; i += 2) {
+          hash.set(fields[i], fields[i + 1]);
+        }
+        expirations.set(key, { type: "EX", value: Number(ttl) });
+        return 1;
+      }
 
       // steal-if-stale idempotency lock (compare-and-set): KEYS=[key],
       // ARGV=[expected, new, ttl]. Reclaims an orphaned "processing" marker

--- a/src/test/preload.ts
+++ b/src/test/preload.ts
@@ -22,6 +22,9 @@ const multiCommands: Array<{ op: string; args: any[] }> = [];
 const expirations = new Map<string, { type: string; value: number }>();
 
 const mockRedis = {
+  // The real client flips this false while the connection is down; callers use
+  // it to skip a write instead of parking it on the offline queue.
+  isReady: true,
   __hashData: hashData,
   __stringData: stringData,
   __multiCommands: multiCommands,

--- a/src/test/preload.ts
+++ b/src/test/preload.ts
@@ -1,4 +1,5 @@
 import { afterEach, mock } from "bun:test";
+import { proto as realProto } from "@whiskeysockets/baileys/WAProto/index.js";
 
 /**
  * Shared test preload — runs before every test file.
@@ -596,6 +597,13 @@ mock.module("@whiskeysockets/baileys", () => ({
   isJidNewsletter: (jid: string) => jid?.endsWith("@newsletter") ?? false,
   isJidBot: (jid: string) => jid?.endsWith("@bot") ?? false,
   isJidMetaAI: (jid: string) => jid?.endsWith("@lid") ?? false,
+  // Faithful enough for the callers that matter: strips the device suffix and
+  // the legacy c.us server, like 7.0.0-rc14's jidNormalizedUser.
+  jidNormalizedUser: (jid: string) => {
+    if (!jid) return "";
+    const [user, server] = jid.split("@");
+    return `${user?.split(":")[0]}@${server === "c.us" ? "s.whatsapp.net" : server}`;
+  },
   downloadContentFromMessage: mock(async () => {
     async function* generate() {
       yield Buffer.from("chunk1");
@@ -658,6 +666,14 @@ mock.module("@whiskeysockets/baileys", () => ({
     Message: {
       AppStateSyncKeyData: {
         fromObject: (obj: any) => ({ ...obj, __appStateSyncKey: true }),
+      },
+      // The real decoder, from the generated protobuf: an encrypted message
+      // edit is only proven decrypted by the plaintext parsing as a Message,
+      // and a stub would prove nothing. WAProto is a separate entry point, so
+      // reaching for it here does not recurse into this mock.
+      decode: (buffer: Uint8Array) => realProto.Message.decode(buffer),
+      SecretEncryptedMessage: {
+        SecretEncType: realProto.Message.SecretEncryptedMessage.SecretEncType,
       },
     },
   },


### PR DESCRIPTION
When a customer edits a message on WhatsApp, the correction now reaches the inbox: the message is updated in place and marked as edited, instead of the original staying stale next to an orange "this message is not supported" bubble.

## Closes

- Reported in the community: https://www.lucasmoreira.ai/c/perguntas-e-respostas/mensagem-editada-nao-suportada

## How to reproduce

1. From another phone, send a message to a paired number.
2. Edit that message on WhatsApp.
3. Before: the original keeps the old text and a second, unsupported message appears. After: the original shows the new text, flagged as edited.

## What changed

WhatsApp stopped sending an incoming edit as a plaintext `protocolMessage` of type `MESSAGE_EDIT`. It now arrives as `secretEncryptedMessage` (`secretEncType: MESSAGE_EDIT`), encrypted under the **original** message's `messageSecret`. Baileys 7.0.0-rc14 has no handler for that node, so the encrypted blob fell through to the webhook as an ordinary message and the edit was never applied. Our own edits still work because they sync back as the plaintext form.

- `messageSecretStore` files every `messageContextInfo.messageSecret` as it arrives, per connection and keyed by message id, for one hour. The edit window is fifteen minutes, so nothing older can decrypt anything; a per-message key with no expiry would grow the keyspace by every message the fleet ever receives.
- `decryptMessageEdit` derives the key the way WhatsApp does (HKDF-SHA256 over the original's secret, bound to the message id and to both parties, use case `"Message Edit"`) and opens the AES-256-GCM payload. Same construction as whatsmeow's `msgsecret.go` and as Baileys' own `reporting-utils.js`.
- The result is re-emitted as the **same** `messages.update` with `editedMessage` that Baileys emits for a plaintext edit, so consumers need no change. The encrypted node is dropped from the upsert instead of being forwarded: it is not a message, and forwarding it is what produced the bubble.
- An edit whose original this instance never saw (restart, or older than the TTL) is dropped with a warning. There is no content to show either way, and a blob is worse than nothing.

The derivation is over the JID **string** of both parties, and a chat mid-LID-migration reports the same person as both `<lid>@lid` and `<phone>@s.whatsapp.net`. The payload does not say which form went into the key, so `messageEditSenders` builds candidates and they are tried in order. The GCM tag makes a wrong guess a clean miss rather than a wrong plaintext. Validated against a real edit from a real phone: the first candidate (LID on both sides) is the one that verifies.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/baileys-api/392)
<!-- Reviewable:end -->
