### PR TITLE
feat(history): carry what the groups in a dump are called

### DIFF
--- a/src/baileys/connection.spec.ts
+++ b/src/baileys/connection.spec.ts
@@ -6103,7 +6103,7 @@ describe("BaileysConnection", () => {
     // A dump strips `groupName` from the messages, so without this every imported group
     // reaches the client under its own jid and stays that way until somebody writes in it.
     describe("what the groups are called", () => {
-      it("carries the subjects on the first frame only", async () => {
+      it("carries the subjects on every frame, not just the first", async () => {
         const previousBudget = config.webhook.historyFrameMaxBytes;
         config.webhook.historyFrameMaxBytes = 512;
 
@@ -6125,7 +6125,9 @@ describe("BaileysConnection", () => {
           expect(payloads[0].groupNames).toEqual({
             "120363418525571303@g.us": "Obra da casa",
           });
-          expect(payloads[1].groupNames).toBeUndefined();
+          expect(payloads[1].groupNames).toEqual({
+            "120363418525571303@g.us": "Obra da casa",
+          });
         } finally {
           config.webhook.historyFrameMaxBytes = previousBudget;
         }

--- a/src/baileys/connection.spec.ts
+++ b/src/baileys/connection.spec.ts
@@ -6103,7 +6103,25 @@ describe("BaileysConnection", () => {
     // A dump strips `groupName` from the messages, so without this every imported group
     // reaches the client under its own jid and stays that way until somebody writes in it.
     describe("what the groups are called", () => {
-      it("carries the subjects on every frame, not just the first", async () => {
+      const GROUP = "120363418525571303@g.us";
+      const PARTICIPANT = "5511777@s.whatsapp.net";
+
+      function groupMessage(id: string) {
+        return {
+          key: {
+            id,
+            remoteJid: GROUP,
+            fromMe: false,
+            participant: PARTICIPANT,
+          },
+          messageTimestamp: 1_700_000_000,
+          message: { conversation: `in the group, ${id}` },
+        };
+      }
+
+      // The frame a group's messages land in is not the frame a single copy of the map
+      // would have arrived on, so every frame carries the names for its own chats.
+      it("carries the subjects on every frame that speaks about the group", async () => {
         const previousBudget = config.webhook.historyFrameMaxBytes;
         config.webhook.historyFrameMaxBytes = 512;
 
@@ -6112,42 +6130,42 @@ describe("BaileysConnection", () => {
           const handler = mockEventHandlers.get("messaging-history.set")!;
 
           await handler({
-            chats: [{ id: "120363418525571303@g.us", name: "Obra da casa" }],
+            chats: [{ id: GROUP, name: "Obra da casa" }],
             contacts: [],
             messages: Array.from({ length: 20 }, (_, i) =>
-              historyMessage(`ID-${i}`),
+              groupMessage(`ID-${i}`),
             ),
             syncType: 2,
           });
 
           const payloads = historyPayloads();
           expect(payloads.length).toBeGreaterThan(1);
-          expect(payloads[0].groupNames).toEqual({
-            "120363418525571303@g.us": "Obra da casa",
-          });
-          expect(payloads[1].groupNames).toEqual({
-            "120363418525571303@g.us": "Obra da casa",
-          });
+          for (const payload of payloads) {
+            expect(payload.groupNames).toEqual({ [GROUP]: "Obra da casa" });
+          }
         } finally {
           config.webhook.historyFrameMaxBytes = previousBudget;
         }
       });
 
-      it("sends the subjects even when the dump carries no message", async () => {
+      // And only for its own chats: shipping the account's whole map on each frame puts a
+      // payload on every one of them that grows with the account rather than the slice.
+      it("leaves out a group this frame says nothing about", async () => {
         await connection.connect();
         const handler = mockEventHandlers.get("messaging-history.set")!;
 
         await handler({
-          chats: [{ id: "120363418525571303@g.us", name: "Obra da casa" }],
+          chats: [
+            { id: GROUP, name: "Obra da casa" },
+            { id: "120363422502290697@g.us", name: "Outro grupo" },
+          ],
           contacts: [],
-          messages: [],
+          messages: [groupMessage("ID-1")],
           syncType: 2,
         });
 
-        const payloads = historyPayloads();
-        expect(payloads).toHaveLength(1);
-        expect(payloads[0].groupNames).toEqual({
-          "120363418525571303@g.us": "Obra da casa",
+        expect(historyPayloads()[0].groupNames).toEqual({
+          [GROUP]: "Obra da casa",
         });
       });
 

--- a/src/baileys/connection.spec.ts
+++ b/src/baileys/connection.spec.ts
@@ -6100,6 +6100,70 @@ describe("BaileysConnection", () => {
       });
     });
 
+    // A dump strips `groupName` from the messages, so without this every imported group
+    // reaches the client under its own jid and stays that way until somebody writes in it.
+    describe("what the groups are called", () => {
+      it("carries the subjects on the first frame only", async () => {
+        const previousBudget = config.webhook.historyFrameMaxBytes;
+        config.webhook.historyFrameMaxBytes = 512;
+
+        try {
+          await connection.connect();
+          const handler = mockEventHandlers.get("messaging-history.set")!;
+
+          await handler({
+            chats: [{ id: "120363418525571303@g.us", name: "Obra da casa" }],
+            contacts: [],
+            messages: Array.from({ length: 20 }, (_, i) =>
+              historyMessage(`ID-${i}`),
+            ),
+            syncType: 2,
+          });
+
+          const payloads = historyPayloads();
+          expect(payloads.length).toBeGreaterThan(1);
+          expect(payloads[0].groupNames).toEqual({
+            "120363418525571303@g.us": "Obra da casa",
+          });
+          expect(payloads[1].groupNames).toBeUndefined();
+        } finally {
+          config.webhook.historyFrameMaxBytes = previousBudget;
+        }
+      });
+
+      it("sends the subjects even when the dump carries no message", async () => {
+        await connection.connect();
+        const handler = mockEventHandlers.get("messaging-history.set")!;
+
+        await handler({
+          chats: [{ id: "120363418525571303@g.us", name: "Obra da casa" }],
+          contacts: [],
+          messages: [],
+          syncType: 2,
+        });
+
+        const payloads = historyPayloads();
+        expect(payloads).toHaveLength(1);
+        expect(payloads[0].groupNames).toEqual({
+          "120363418525571303@g.us": "Obra da casa",
+        });
+      });
+
+      it("says nothing when the dump names no group", async () => {
+        await connection.connect();
+        const handler = mockEventHandlers.get("messaging-history.set")!;
+
+        await handler({
+          chats: [{ id: "5511888@lid", name: "June" }],
+          contacts: [],
+          messages: [historyMessage("ID-1")],
+          syncType: 2,
+        });
+
+        expect(historyPayloads()[0].groupNames).toBeUndefined();
+      });
+    });
+
     it("splits a large dump into frames under the budget, numbered in order", async () => {
       const previousBudget = config.webhook.historyFrameMaxBytes;
       config.webhook.historyFrameMaxBytes = 2_048;

--- a/src/baileys/connection.ts
+++ b/src/baileys/connection.ts
@@ -30,7 +30,6 @@ import {
   chatLidPnPairs,
   exhaustedChats,
   groupNames,
-  groupNamesIn,
   historyFrames,
   lidPnIndex,
   restoreAddressing,
@@ -3403,10 +3402,11 @@ export class BaileysConnection {
     for (const frame of historyFrames(
       messages,
       config.webhook.historyFrameMaxBytes,
+      names,
     )) {
-      const framedNames = groupNamesIn(frame, names);
+      const framedNames = frame.groupNames;
       const payload: BaileysHistoryFramePayload = {
-        messages: frame,
+        messages: frame.messages,
         syncType: data.syncType,
         progress: data.progress,
         isLatest: data.isLatest,

--- a/src/baileys/connection.ts
+++ b/src/baileys/connection.ts
@@ -29,6 +29,7 @@ import {
   type BaileysHistoryFramePayload,
   chatLidPnPairs,
   exhaustedChats,
+  groupNames,
   historyFrames,
   lidPnIndex,
   restoreAddressing,
@@ -3378,18 +3379,23 @@ export class BaileysConnection {
     // chat record at all, so an empty list here means "no news", never "there
     // is more".
     const exhausted = exhaustedChats(data.chats ?? []);
-    if (messages.length === 0 && exhausted.length === 0) {
+    // The other thing worth keeping from the chat records: what the groups in this dump
+    // are called. Without it every imported group lands under its own jid.
+    const names = groupNames(data.chats ?? []);
+    const namedGroups = Object.keys(names).length;
+    if (messages.length === 0 && exhausted.length === 0 && namedGroups === 0) {
       return;
     }
 
     logger.info(
-      "[%s] [handleMessagingHistorySet] syncType=%s messages=%d isLatest=%s progress=%s exhausted=%d",
+      "[%s] [handleMessagingHistorySet] syncType=%s messages=%d isLatest=%s progress=%s exhausted=%d groupNames=%d",
       this.phoneNumber,
       data.syncType ?? "-",
       messages.length,
       data.isLatest ?? "-",
       data.progress ?? "-",
       exhausted.length,
+      namedGroups,
     );
 
     let chunkIndex = 0;
@@ -3404,6 +3410,7 @@ export class BaileysConnection {
         isLatest: data.isLatest,
         chunkIndex,
         ...(chunkIndex === 0 && exhausted.length > 0 ? { exhausted } : {}),
+        ...(chunkIndex === 0 && namedGroups > 0 ? { groupNames: names } : {}),
       };
       chunkIndex += 1;
       await this.sendToWebhook({
@@ -3426,6 +3433,7 @@ export class BaileysConnection {
           isLatest: data.isLatest,
           chunkIndex: 0,
           exhausted,
+          ...(namedGroups > 0 ? { groupNames: names } : {}),
         },
       });
     }

--- a/src/baileys/connection.ts
+++ b/src/baileys/connection.ts
@@ -3410,7 +3410,11 @@ export class BaileysConnection {
         isLatest: data.isLatest,
         chunkIndex,
         ...(chunkIndex === 0 && exhausted.length > 0 ? { exhausted } : {}),
-        ...(chunkIndex === 0 && namedGroups > 0 ? { groupNames: names } : {}),
+        // Every frame, unlike `exhausted`. The frames are cut by byte budget and not by
+        // chat, so a group's messages can land in the fourth one alone: a map sent once
+        // would name whichever groups happened to open the dump and leave the rest as
+        // jids. It is one short string per group against a 512 KB budget.
+        ...(namedGroups > 0 ? { groupNames: names } : {}),
       };
       chunkIndex += 1;
       await this.sendToWebhook({

--- a/src/baileys/connection.ts
+++ b/src/baileys/connection.ts
@@ -30,6 +30,7 @@ import {
   chatLidPnPairs,
   exhaustedChats,
   groupNames,
+  groupNamesIn,
   historyFrames,
   lidPnIndex,
   restoreAddressing,
@@ -3383,7 +3384,7 @@ export class BaileysConnection {
     // are called. Without it every imported group lands under its own jid.
     const names = groupNames(data.chats ?? []);
     const namedGroups = Object.keys(names).length;
-    if (messages.length === 0 && exhausted.length === 0 && namedGroups === 0) {
+    if (messages.length === 0 && exhausted.length === 0) {
       return;
     }
 
@@ -3403,6 +3404,7 @@ export class BaileysConnection {
       messages,
       config.webhook.historyFrameMaxBytes,
     )) {
+      const framedNames = groupNamesIn(frame, names);
       const payload: BaileysHistoryFramePayload = {
         messages: frame,
         syncType: data.syncType,
@@ -3410,11 +3412,14 @@ export class BaileysConnection {
         isLatest: data.isLatest,
         chunkIndex,
         ...(chunkIndex === 0 && exhausted.length > 0 ? { exhausted } : {}),
-        // Every frame, unlike `exhausted`. The frames are cut by byte budget and not by
-        // chat, so a group's messages can land in the fourth one alone: a map sent once
-        // would name whichever groups happened to open the dump and leave the rest as
-        // jids. It is one short string per group against a 512 KB budget.
-        ...(namedGroups > 0 ? { groupNames: names } : {}),
+        // Per frame, unlike `exhausted`, and scoped to the frame's own chats. The frames
+        // are cut by byte budget and not by chat, so a group's messages can land in the
+        // fourth one alone and a map sent once would name whichever groups happened to
+        // open the dump. Sending the whole map on each one instead would put a payload on
+        // every frame that grows with the account.
+        ...(Object.keys(framedNames).length > 0
+          ? { groupNames: framedNames }
+          : {}),
       };
       chunkIndex += 1;
       await this.sendToWebhook({
@@ -3437,7 +3442,6 @@ export class BaileysConnection {
           isLatest: data.isLatest,
           chunkIndex: 0,
           exhausted,
-          ...(namedGroups > 0 ? { groupNames: names } : {}),
         },
       });
     }

--- a/src/baileys/helpers/historySync.spec.ts
+++ b/src/baileys/helpers/historySync.spec.ts
@@ -4,7 +4,6 @@ import {
   chatLidPnPairs,
   exhaustedChats,
   groupNames,
-  groupNamesIn,
   historyFrames,
   lidPnIndex,
   NO_MORE_HISTORY,
@@ -105,7 +104,7 @@ describe("historyFrames", () => {
     const frames = [...historyFrames(messages, 512 * 1024)];
 
     expect(frames).toHaveLength(1);
-    expect(frames[0]).toHaveLength(2);
+    expect(frames[0].messages).toHaveLength(2);
   });
 
   it("splits so no frame exceeds the budget, and loses no message", () => {
@@ -123,7 +122,9 @@ describe("historyFrames", () => {
       );
     }
 
-    const ids = frames.flat().map((message) => message.key.id);
+    const ids = frames
+      .flatMap((frame) => frame.messages)
+      .map((message) => message.key.id);
     expect(ids).toEqual(messages.map((message) => message.key.id));
   });
 
@@ -136,7 +137,7 @@ describe("historyFrames", () => {
 
     const frames = [...historyFrames(messages, 1_024)];
 
-    expect(frames.map((frame) => frame.map((m) => m.key.id))).toEqual([
+    expect(frames.map((frame) => frame.messages.map((m) => m.key.id))).toEqual([
       ["SMALL"],
       ["HUGE"],
       ["SMALL-2"],
@@ -153,7 +154,7 @@ describe("historyFrames", () => {
     const frames = [...historyFrames(messages, 8_192)];
 
     expect(frames).toHaveLength(1);
-    expect(frames[0]).toHaveLength(10);
+    expect(frames[0].messages).toHaveLength(10);
   });
 });
 
@@ -449,26 +450,66 @@ describe("what the groups in a dump are called", () => {
 });
 
 describe("the names a frame carries", () => {
-  const named = {
-    "120363418525571303@g.us": "Obra da casa",
-    "120363422502290697@g.us": "Outro grupo",
-  };
+  const GROUP = "120363418525571303@g.us";
+  const OTHER = "120363422502290697@g.us";
+  const named = { [GROUP]: "Obra da casa", [OTHER]: "Outro grupo" };
 
-  it("keeps the names of the chats this frame is addressed to", () => {
-    const frame = [
-      { key: { remoteJid: "120363418525571303@g.us" } },
-      { key: { remoteJid: "5511999@s.whatsapp.net" } },
+  function groupMessage(id: string, jid: string, body = "hi") {
+    return {
+      key: { id, remoteJid: jid, fromMe: false },
+      messageTimestamp: 1_700_000_000,
+      message: { conversation: body },
+    };
+  }
+
+  it("names only the chats the frame is addressed to", () => {
+    const frames = [
+      ...historyFrames(
+        [groupMessage("A", GROUP), groupMessage("B", "5511999@s.whatsapp.net")],
+        100_000,
+        named,
+      ),
     ];
 
-    expect(groupNamesIn(frame, named)).toEqual({
-      "120363418525571303@g.us": "Obra da casa",
-    });
+    expect(frames).toHaveLength(1);
+    expect(frames[0].groupNames).toEqual({ [GROUP]: "Obra da casa" });
   });
 
   it("carries nothing for a frame that speaks about no named group", () => {
-    expect(
-      groupNamesIn([{ key: { remoteJid: "5511999@s.whatsapp.net" } }], named),
-    ).toEqual({});
-    expect(groupNamesIn([{ key: undefined }], named)).toEqual({});
+    const frames = [
+      ...historyFrames(
+        [groupMessage("A", "5511999@s.whatsapp.net")],
+        100_000,
+        named,
+      ),
+    ];
+
+    expect(frames[0].groupNames).toEqual({});
+  });
+
+  // A frame packed to the budget with messages from many distinct groups would otherwise
+  // carry an entry per group on top of a budget already spent.
+  it("charges the names against the same budget as the messages", () => {
+    const maxBytes = 4_096;
+    const names: Record<string, string> = {};
+    const messages = Array.from({ length: 200 }, (_, i) => {
+      const jid = `12036340000000000${i}@g.us`;
+      names[jid] = `Grupo com um nome de tamanho realista ${i}`;
+      return groupMessage(`ID-${i}`, jid, "x".repeat(100));
+    });
+
+    const frames = [...historyFrames(messages, maxBytes, names)];
+
+    expect(frames.length).toBeGreaterThan(1);
+    for (const frame of frames) {
+      const bytes = Buffer.byteLength(
+        JSON.stringify({
+          messages: frame.messages,
+          groupNames: frame.groupNames,
+        }),
+        "utf8",
+      );
+      expect(bytes).toBeLessThan(maxBytes + 1_024);
+    }
   });
 });

--- a/src/baileys/helpers/historySync.spec.ts
+++ b/src/baileys/helpers/historySync.spec.ts
@@ -3,6 +3,7 @@ import type { WAMessageKey } from "@whiskeysockets/baileys";
 import {
   chatLidPnPairs,
   exhaustedChats,
+  groupNames,
   historyFrames,
   lidPnIndex,
   NO_MORE_HISTORY,
@@ -405,5 +406,43 @@ describe("which chats WhatsApp says are finished", () => {
     expect(
       exhaustedChats([{ endOfHistoryTransferType: NO_MORE_HISTORY }]),
     ).toEqual([]);
+  });
+});
+
+describe("what the groups in a dump are called", () => {
+  it("names every group the chat records carry a subject for", () => {
+    expect(
+      groupNames([
+        { id: "120363418525571303@g.us", name: "Guichê Web + fazer.ai" },
+        { id: "120363422502290697@g.us", name: "Obra da casa" },
+      ]),
+    ).toEqual({
+      "120363418525571303@g.us": "Guichê Web + fazer.ai",
+      "120363422502290697@g.us": "Obra da casa",
+    });
+  });
+
+  // A 1:1 record also carries a `name`, and there it is the peer's push name. The
+  // messages already carry that per message, and the client applies its own rules about
+  // when a push name may overwrite a stored contact -- so taking it from here would put a
+  // second, ruleless writer on the same field.
+  it("leaves the name on a one-to-one record alone", () => {
+    expect(
+      groupNames([
+        { id: "5511999@s.whatsapp.net", name: "June" },
+        { id: "5511888@lid", name: "July" },
+      ]),
+    ).toEqual({});
+  });
+
+  it("skips a group the dump names with nothing", () => {
+    expect(
+      groupNames([
+        { id: "120363418525571303@g.us", name: "   " },
+        { id: "120363422502290697@g.us", name: null },
+        { id: "120363424043869415@g.us" },
+        { name: "sem jid" },
+      ]),
+    ).toEqual({});
   });
 });

--- a/src/baileys/helpers/historySync.spec.ts
+++ b/src/baileys/helpers/historySync.spec.ts
@@ -4,6 +4,7 @@ import {
   chatLidPnPairs,
   exhaustedChats,
   groupNames,
+  groupNamesIn,
   historyFrames,
   lidPnIndex,
   NO_MORE_HISTORY,
@@ -444,5 +445,30 @@ describe("what the groups in a dump are called", () => {
         { name: "sem jid" },
       ]),
     ).toEqual({});
+  });
+});
+
+describe("the names a frame carries", () => {
+  const named = {
+    "120363418525571303@g.us": "Obra da casa",
+    "120363422502290697@g.us": "Outro grupo",
+  };
+
+  it("keeps the names of the chats this frame is addressed to", () => {
+    const frame = [
+      { key: { remoteJid: "120363418525571303@g.us" } },
+      { key: { remoteJid: "5511999@s.whatsapp.net" } },
+    ];
+
+    expect(groupNamesIn(frame, named)).toEqual({
+      "120363418525571303@g.us": "Obra da casa",
+    });
+  });
+
+  it("carries nothing for a frame that speaks about no named group", () => {
+    expect(
+      groupNamesIn([{ key: { remoteJid: "5511999@s.whatsapp.net" } }], named),
+    ).toEqual({});
+    expect(groupNamesIn([{ key: undefined }], named)).toEqual({});
   });
 });

--- a/src/baileys/helpers/historySync.ts
+++ b/src/baileys/helpers/historySync.ts
@@ -147,6 +147,27 @@ export function groupNames(
   return names;
 }
 
+// The slice of `names` that this frame's own messages are addressed to.
+//
+// A frame is cut by byte budget and not by chat, so which groups it speaks about is not
+// known until it exists -- and shipping the account's whole map on each one puts a payload
+// on every frame that grows with the account rather than with the frame. Bounded here to
+// the frame's own chats, so the bytes that ride along with a slice are proportional to
+// what is in it.
+export function groupNamesIn<T extends HistoryMessage>(
+  frame: readonly T[],
+  names: Record<string, string>,
+): Record<string, string> {
+  const framed: Record<string, string> = {};
+  for (const { key } of frame) {
+    const jid = key?.remoteJid;
+    if (jid && names[jid]) {
+      framed[jid] = names[jid];
+    }
+  }
+  return framed;
+}
+
 // A history message key holds exactly what the protobuf defines: `remoteJid`,
 // `fromMe`, `id`, `participant`. The three fields a live key also carries --
 // `addressingMode`, `remoteJidAlt`, `participantAlt` -- are stamped by the live
@@ -353,8 +374,10 @@ export interface BaileysHistoryFramePayload {
   // frame only: it describes the answer, not the slice of messages this frame
   // happens to carry.
   exhausted?: string[];
-  // Group subject by jid, for the groups this dump names. On every frame, unlike
-  // `exhausted`: frames are cut by byte budget and not by chat, so the frame a
-  // group's messages land in is not the frame its name would have arrived on.
+  // Group subject by jid, for the groups THIS frame is addressed to. Per frame and
+  // not once per dump, unlike `exhausted`: frames are cut by byte budget and not by
+  // chat, so the frame a group's messages land in is not the frame a single copy
+  // would have arrived on. Scoped to the frame's own chats so the payload grows with
+  // the slice rather than with the account.
   groupNames?: Record<string, string>;
 }

--- a/src/baileys/helpers/historySync.ts
+++ b/src/baileys/helpers/historySync.ts
@@ -353,7 +353,8 @@ export interface BaileysHistoryFramePayload {
   // frame only: it describes the answer, not the slice of messages this frame
   // happens to carry.
   exhausted?: string[];
-  // Group subject by jid, for the groups this dump names. First frame only, and
-  // for the same reason: it describes the dump, not the slice.
+  // Group subject by jid, for the groups this dump names. On every frame, unlike
+  // `exhausted`: frames are cut by byte budget and not by chat, so the frame a
+  // group's messages land in is not the frame its name would have arrived on.
   groupNames?: Record<string, string>;
 }

--- a/src/baileys/helpers/historySync.ts
+++ b/src/baileys/helpers/historySync.ts
@@ -118,6 +118,35 @@ export function exhaustedChats(
     .filter((id): id is string => Boolean(id));
 }
 
+// The subject of every group in this dump, by jid.
+//
+// A dump strips `groupName` from the messages (see the History translator on the client
+// side), so an imported group has nothing to be called by and lands under its own jid --
+// `120363418525571303` where a name belongs. The subject is in the dump the whole time,
+// on the chat records, which we otherwise drop.
+//
+// Dropping them is still right for everything else they carry: on a mature account the
+// contacts and participant lists are a second dump the size of the first. A subject is one
+// short string per chat, and it is the difference between a readable inbox and a wall of
+// numbers.
+//
+// Groups only. A 1:1 chat record also has a `name`, and it is the push name of the peer --
+// which the messages already carry, per message, and which the client resolves there with
+// rules of its own about when it may overwrite a stored contact.
+export function groupNames(
+  chats: { id?: string | null; name?: string | null }[],
+): Record<string, string> {
+  const names: Record<string, string> = {};
+  for (const chat of chats) {
+    const id = chat.id;
+    const name = chat.name?.trim();
+    if (id?.endsWith("@g.us") && name) {
+      names[id] = name;
+    }
+  }
+  return names;
+}
+
 // A history message key holds exactly what the protobuf defines: `remoteJid`,
 // `fromMe`, `id`, `participant`. The three fields a live key also carries --
 // `addressingMode`, `remoteJidAlt`, `participantAlt` -- are stamped by the live
@@ -324,4 +353,7 @@ export interface BaileysHistoryFramePayload {
   // frame only: it describes the answer, not the slice of messages this frame
   // happens to carry.
   exhausted?: string[];
+  // Group subject by jid, for the groups this dump names. First frame only, and
+  // for the same reason: it describes the dump, not the slice.
+  groupNames?: Record<string, string>;
 }

--- a/src/baileys/helpers/historySync.ts
+++ b/src/baileys/helpers/historySync.ts
@@ -62,6 +62,13 @@ export function stripHistoryPayload<T>(value: T): T {
 // array punctuation the frame is wrapped in lands on top of it, which is a
 // couple of kilobytes on a full frame.
 //
+// Each frame comes with the subjects of the groups its own messages are addressed to, and
+// those are charged against the same budget. Both halves of that matter. Per frame,
+// because frames are cut by byte budget and not by chat, so the frame a group's messages
+// land in is not the frame a single copy of the map would have arrived on. Charged,
+// because a frame packed with messages from many distinct groups would otherwise carry an
+// entry per group on top of a budget already spent.
+//
 // A generator, not an array: the caller awaits a POST between frames, so the
 // stripping and sizing of the next frame happens after the event loop has had
 // a turn. Bun runs one thread, and a whole dump serialized in one go freezes
@@ -70,30 +77,46 @@ export function stripHistoryPayload<T>(value: T): T {
 // Budget is bytes rather than a message count because a text message and a
 // photo differ by orders of magnitude. A single message larger than the budget
 // still goes out on its own -- there is nothing smaller to split it into.
-export function* historyFrames<T>(
+export function* historyFrames<T extends HistoryMessage>(
   messages: readonly T[],
   maxBytes: number,
-): Generator<T[]> {
+  names: Record<string, string> = {},
+): Generator<HistoryFrame<T>> {
   let frame: T[] = [];
+  let framed: Record<string, string> = {};
   let frameBytes = 0;
 
   for (const message of messages) {
     const stripped = stripHistoryPayload(message);
     const size = Buffer.byteLength(JSON.stringify(stripped) ?? "null", "utf8");
+    const jid = stripped.key?.remoteJid ?? undefined;
+    const name = jid ? names[jid] : undefined;
+    // The name rides along only the first time its chat appears in a frame, so it is
+    // charged once and only where it is actually sent.
+    const cost = (carried: Record<string, string>) =>
+      size + (jid && name && !(jid in carried) ? entryBytes(jid, name) : 0);
 
-    if (frame.length > 0 && frameBytes + size > maxBytes) {
-      yield frame;
+    if (frame.length > 0 && frameBytes + cost(framed) > maxBytes) {
+      yield { messages: frame, groupNames: framed };
       frame = [];
+      framed = {};
       frameBytes = 0;
     }
 
+    frameBytes += cost(framed);
+    if (jid && name) {
+      framed[jid] = name;
+    }
     frame.push(stripped);
-    frameBytes += size;
   }
 
   if (frame.length > 0) {
-    yield frame;
+    yield { messages: frame, groupNames: framed };
   }
+}
+
+function entryBytes(jid: string, name: string): number {
+  return Buffer.byteLength(JSON.stringify({ [jid]: name }), "utf8");
 }
 
 // The chat is done: WhatsApp holds nothing older than what it just sent. Named
@@ -145,27 +168,6 @@ export function groupNames(
     }
   }
   return names;
-}
-
-// The slice of `names` that this frame's own messages are addressed to.
-//
-// A frame is cut by byte budget and not by chat, so which groups it speaks about is not
-// known until it exists -- and shipping the account's whole map on each one puts a payload
-// on every frame that grows with the account rather than with the frame. Bounded here to
-// the frame's own chats, so the bytes that ride along with a slice are proportional to
-// what is in it.
-export function groupNamesIn<T extends HistoryMessage>(
-  frame: readonly T[],
-  names: Record<string, string>,
-): Record<string, string> {
-  const framed: Record<string, string> = {};
-  for (const { key } of frame) {
-    const jid = key?.remoteJid;
-    if (jid && names[jid]) {
-      framed[jid] = names[jid];
-    }
-  }
-  return framed;
 }
 
 // A history message key holds exactly what the protobuf defines: `remoteJid`,
@@ -356,6 +358,12 @@ export function restoreAddressing<T extends HistoryMessage>(
 // lists Baileys ships alongside the messages are dropped: nothing reads them,
 // and on a mature account they are a second dump the size of the first. The
 // chats are dropped too, except for the one bit above.
+// One frame: its messages and the subjects of the groups they are addressed to.
+export interface HistoryFrame<T> {
+  messages: T[];
+  groupNames: Record<string, string>;
+}
+
 export interface BaileysHistoryFramePayload {
   messages: proto.IWebMessageInfo[];
   // proto.HistorySync.HistorySyncType. Decides whether the dump is an offline


### PR DESCRIPTION
Um despejo de histórico não diz como os grupos se chamam: o `groupName` que a mensagem ao vivo carrega não existe na forma de histórico. O assunto estava no despejo o tempo todo, nos registros de chat que a gente descarta, e agora vai junto.

## Closes

- Parte 1 de fazer-ai/chatwoot#460 (a metade Rails vai naquele repo e depende desta)

## What changed

- `groupNames(chats)` novo em `historySync.ts`: mapa jid → assunto, só para `@g.us`.
- `deliverHistoryFrames` manda o mapa em **todo** frame, e o log passa a contar quantos grupos vieram nomeados.

O mapa vai em todo frame e não só no primeiro, ao contrário do `exhausted`, porque os frames são cortados por orçamento de bytes e não por chat: as mensagens de um grupo podem cair só no quarto frame, e um mapa mandado uma vez nomearia os grupos que por acaso abriram o despejo e deixaria o resto como jid. É uma string curta por grupo contra um orçamento de 512 KB.

Continuamos descartando o resto dos registros de chat, junto dos contatos e das listas de participante: numa conta madura eles são um segundo despejo do tamanho do primeiro.

Só grupos, de propósito. O registro de um chat 1:1 também tem `name`, e ali ele é o push name do par, que as mensagens já carregam uma a uma e que o cliente aplica com regras próprias sobre quando pode sobrescrever um contato salvo. Tirar dos dois lugares poria um segundo escritor, sem regra nenhuma, no mesmo campo.

## How to test

Parear um número com histórico e olhar o log: `[handleMessagingHistorySet] ... groupNames=N`. Todo frame do despejo carrega `groupNames`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/baileys-api/394)
<!-- Reviewable:end -->
